### PR TITLE
ytnobody-MADFLOW-005: 各エージェントプロンプトにGitHub Issueコメント投稿手順を追加

### DIFF
--- a/prompts/architect.md
+++ b/prompts/architect.md
@@ -34,6 +34,21 @@ git pull
 git checkout -b {{FEATURE_PREFIX}}<イシューID>
 ```
 
+ブランチ作成後、GitHub Issueに設計開始をコメントします（`url` フィールドがある場合のみ）:
+```bash
+gh issue comment <イシュー番号> -R <owner>/<repo> --body "**[設計開始]** by \`{{AGENT_ID}}\`
+
+設計を開始しました。feature ブランチ: {{FEATURE_PREFIX}}<イシューID>"
+```
+
+イシュー番号・owner・repo は、イシューファイルの `url` フィールドから取得します。
+例: `url = "https://api.github.com/repos/ytnobody/MADFLOW/issues/5"` の場合
+- owner: `ytnobody`
+- repo: `MADFLOW`
+- イシュー番号: `5`
+
+`url` フィールドがない場合はコメント投稿をスキップしてください。
+
 ### 2. 設計仕様の記述
 
 イシューファイルの `body` に設計仕様を追記します。以下を含めてください:
@@ -48,6 +63,17 @@ git checkout -b {{FEATURE_PREFIX}}<イシューID>
 ```bash
 sed -i 's/status = "open"/status = "in_progress"/' {{ISSUES_DIR}}/<イシューID>.toml
 ```
+
+### 3.5. イシューへの設計完了コメント
+
+設計仕様の記述が完了したら、GitHub Issueに設計完了をコメントします（`url` フィールドがある場合のみ）:
+```bash
+gh issue comment <イシュー番号> -R <owner>/<repo> --body "**[設計完了]** by \`{{AGENT_ID}}\`
+
+設計仕様をイシューファイルに記述しました。エンジニアに実装を指示します。"
+```
+
+`url` フィールドがない場合はコメント投稿をスキップしてください。
 
 ### 4. エンジニアへの設計完了通知
 

--- a/prompts/engineer.md
+++ b/prompts/engineer.md
@@ -40,6 +40,21 @@ cd <リポジトリパス>
 git checkout {{FEATURE_PREFIX}}<イシューID>
 ```
 
+ブランチに切り替えたら、GitHub Issueに実装開始をコメントします（`url` フィールドがある場合のみ）:
+```bash
+gh issue comment <イシュー番号> -R <owner>/<repo> --body "**[実装開始]** by \`{{AGENT_ID}}\`
+
+実装を開始しました。feature ブランチ: {{FEATURE_PREFIX}}<イシューID>"
+```
+
+イシュー番号・owner・repo は、イシューファイルの `url` フィールドから取得します。
+例: `url = "https://api.github.com/repos/ytnobody/MADFLOW/issues/5"` の場合
+- owner: `ytnobody`
+- repo: `MADFLOW`
+- イシュー番号: `5`
+
+`url` フィールドがない場合はコメント投稿をスキップしてください。
+
 - 設計仕様に従ってコードを実装する
 - 適切な粒度でコミットする
 - テストコードも合わせて書く
@@ -67,9 +82,29 @@ gh pr create --base {{DEVELOP_BRANCH}} --title "<イシューID>: <変更内容�
 echo "[$(date +%Y-%m-%dT%H:%M:%S)] [@reviewer-{{TEAM_NUM}}] {{AGENT_ID}}: 実装完了。{{FEATURE_PREFIX}}<イシューID> ブランチのレビューをお願いします。" >> {{CHATLOG_PATH}}
 ```
 
+GitHub Issueに実装完了をコメントします（`url` フィールドがある場合のみ）:
+```bash
+gh issue comment <イシュー番号> -R <owner>/<repo> --body "**[実装完了]** by \`{{AGENT_ID}}\`
+
+実装が完了しました。レビュアーにレビューを依頼しました。"
+```
+
+`url` フィールドがない場合はコメント投稿をスキップしてください。
+
 ### 5. レビュー指摘への対応
 
 レビュアーから NG が返ってきた場合は、指摘内容に基づき修正し、再度レビュー依頼を送信します。
+
+### 質問時のイシューコメント
+
+アーキテクトに質問する際は、GitHub Issueにも質問内容をコメントします（`url` フィールドがある場合のみ）:
+```bash
+gh issue comment <イシュー番号> -R <owner>/<repo> --body "**[質問]** by \`{{AGENT_ID}}\`
+
+<質問内容>"
+```
+
+`url` フィールドがない場合はコメント投稿をスキップしてください。
 
 ## 行動指針
 

--- a/prompts/pm.md
+++ b/prompts/pm.md
@@ -34,6 +34,23 @@ echo "[$(date +%Y-%m-%dT%H:%M:%S)] [@orchestrator] {{AGENT_ID}}: TEAM_CREATE iss
 sed -i 's/assigned_team = 0/assigned_team = <チーム番号>/' {{ISSUES_DIR}}/<イシューID>.toml
 ```
 
+### イシューへの進捗コメント
+
+チームアサイン時にGitHub Issueにコメントを投稿します（`url` フィールドがある場合のみ）:
+```bash
+gh issue comment <イシュー番号> -R <owner>/<repo> --body "**[チームアサイン]** by \`{{AGENT_ID}}\`
+
+チーム<チーム番号>に割り当てました。アーキテクトが設計を開始します。"
+```
+
+イシュー番号・owner・repo は、イシューファイルの `url` フィールドから取得します。
+例: `url = "https://api.github.com/repos/ytnobody/MADFLOW/issues/5"` の場合
+- owner: `ytnobody`
+- repo: `MADFLOW`
+- イシュー番号: `5`
+
+`url` フィールドがない場合はコメント投稿をスキップしてください。
+
 ## 進捗管理
 
 - チャットログを読み、各チームの作業状況を把握する

--- a/prompts/release_manager.md
+++ b/prompts/release_manager.md
@@ -58,7 +58,22 @@ sed -i 's/status = "in_progress"/status = "resolved"/' {{ISSUES_DIR}}/<イシュ
 echo "[$(date +%Y-%m-%dT%H:%M:%S)] [@orchestrator] {{AGENT_ID}}: TEAM_DISBAND issue_id=<イシューID>" >> {{CHATLOG_PATH}}
 ```
 
-3. feature ブランチを削除:
+3. GitHub Issueにマージ完了をコメントします（`url` フィールドがある場合のみ）:
+```bash
+gh issue comment <イシュー番号> -R <owner>/<repo> --body "**[マージ完了]** by \`{{AGENT_ID}}\`
+
+feature ブランチを develop にマージしました。イシューステータスを resolved に更新しました。"
+```
+
+イシュー番号・owner・repo は、イシューファイルの `url` フィールドから取得します。
+例: `url = "https://api.github.com/repos/ytnobody/MADFLOW/issues/5"` の場合
+- owner: `ytnobody`
+- repo: `MADFLOW`
+- イシュー番号: `5`
+
+`url` フィールドがない場合はコメント投稿をスキップしてください。
+
+4. feature ブランチを削除:
 ```bash
 git branch -d {{FEATURE_PREFIX}}<イシューID>
 ```

--- a/prompts/reviewer.md
+++ b/prompts/reviewer.md
@@ -73,12 +73,37 @@ Branch: {{FEATURE_PREFIX}}<イシューID>"
 echo "[$(date +%Y-%m-%dT%H:%M:%S)] [@release_manager] {{AGENT_ID}}: レビュー承認。{{FEATURE_PREFIX}}<イシューID> ブランチの develop へのマージをお願いします。PRにLGTMコメント投稿済みです。" >> {{CHATLOG_PATH}}
 ```
 
+GitHub Issueにレビュー承認をコメントします（`url` フィールドがある場合のみ）:
+```bash
+gh issue comment <イシュー番号> -R <owner>/<repo> --body "**[レビュー承認]** by \`{{AGENT_ID}}\`
+
+レビューを承認しました。PRにLGTMコメントを投稿済みです。RMにマージを依頼しました。"
+```
+
+イシュー番号・owner・repo は、イシューファイルの `url` フィールドから取得します。
+例: `url = "https://api.github.com/repos/ytnobody/MADFLOW/issues/5"` の場合
+- owner: `ytnobody`
+- repo: `MADFLOW`
+- イシュー番号: `5`
+
+`url` フィールドがない場合はコメント投稿をスキップしてください。
+
 ### 4-B. 差し戻し → エンジニアに修正依頼
 
 レビューが NG の場合、具体的な指摘を含めて差し戻します:
 ```bash
 echo "[$(date +%Y-%m-%dT%H:%M:%S)] [@engineer-{{TEAM_NUM}}] {{AGENT_ID}}: レビュー NG。以下を修正してください: <具体的な指摘内容>" >> {{CHATLOG_PATH}}
 ```
+
+GitHub Issueにレビュー差し戻しをコメントします（`url` フィールドがある場合のみ）:
+```bash
+gh issue comment <イシュー番号> -R <owner>/<repo> --body "**[レビュー差し戻し]** by \`{{AGENT_ID}}\`
+
+以下の指摘により差し戻しました:
+<指摘内容の要約>"
+```
+
+`url` フィールドがない場合はコメント投稿をスキップしてください。
 
 ## 行動指針
 


### PR DESCRIPTION
Issue: ytnobody-MADFLOW-005

## 変更内容

各イシューの作業進捗をGitHub Issue上で確認できるよう、5つのエージェントプロンプトに `gh issue comment` コマンドによるコメント投稿手順を追加。

### 変更ファイル

- `prompts/pm.md`: チームアサイン時のコメント投稿手順を追加
- `prompts/architect.md`: 設計開始時・設計完了時のコメント投稿手順を追加
- `prompts/engineer.md`: 実装開始時・実装完了時・質問時のコメント投稿手順を追加
- `prompts/reviewer.md`: レビュー承認時・差し戻し時のコメント投稿手順を追加
- `prompts/release_manager.md`: developマージ完了時のコメント投稿手順を追加

### コメントフォーマット

全エージェント共通の統一フォーマットを使用:
\`\`\`
**[イベント種別]** by \`<agent_id>\`

<詳細内容>
\`\`\`

### 注意事項

- イシューの \`url\` フィールドがない場合はコメント投稿をスキップ
- 各プロンプトの既存機能を損なわない形で追記