### PR TITLE
ytnobody-MADFLOW-015: Gemini CLI バックエンドサポート拡張・バグ修正

### DIFF
--- a/cmd/madflow/use.go
+++ b/cmd/madflow/use.go
@@ -11,9 +11,13 @@ import (
 	"github.com/ytnobody/madflow/internal/project"
 )
 
-const useUsage = `Usage: madflow use <claude|gemini>
+const useUsage = `Usage: madflow use <claude|gemini|mixed>
 
 Switches all agent models in madflow.toml to a specific backend.
+  claude: All roles use Claude models (stable, higher cost)
+  gemini: All roles use Gemini models (cost-effective)
+  mixed:  Strategic roles (superintendent, PM, architect, RM) use Claude,
+          execution roles (engineer, reviewer) use Gemini (recommended for cost optimization)
 `
 
 func cmdUse() error {
@@ -27,21 +31,30 @@ func cmdUse() error {
 	switch backend {
 	case "claude":
 		newModels = config.ModelConfig{
-			Superintendent: "claude-3-opus-20240229",
-			PM:             "claude-3-sonnet-20240229",
-			Architect:      "claude-3-opus-20240229",
-			Engineer:       "claude-3-haiku-20240307",
-			Reviewer:       "claude-3-sonnet-20240229",
-			ReleaseManager: "claude-3-haiku-20240307",
+			Superintendent: "claude-opus-4-6",
+			PM:             "claude-sonnet-4-6",
+			Architect:      "claude-opus-4-6",
+			Engineer:       "claude-sonnet-4-6",
+			Reviewer:       "claude-sonnet-4-6",
+			ReleaseManager: "claude-haiku-4-5",
 		}
 	case "gemini":
 		newModels = config.ModelConfig{
-			Superintendent: "gemini-1.5-pro-latest",
-			PM:             "gemini-1.5-pro-latest",
-			Architect:      "gemini-1.5-pro-latest",
-			Engineer:       "gemini-1.5-flash-latest",
-			Reviewer:       "gemini-1.5-pro-latest",
-			ReleaseManager: "gemini-1.5-flash-latest",
+			Superintendent: "gemini-2.5-pro",
+			PM:             "gemini-2.5-flash",
+			Architect:      "gemini-2.5-pro",
+			Engineer:       "gemini-2.5-flash",
+			Reviewer:       "gemini-2.5-flash",
+			ReleaseManager: "gemini-2.5-flash",
+		}
+	case "mixed":
+		newModels = config.ModelConfig{
+			Superintendent: "claude-sonnet-4-6",
+			PM:             "claude-haiku-4-5",
+			Architect:      "claude-sonnet-4-6",
+			Engineer:       "gemini-2.5-flash",
+			Reviewer:       "gemini-2.5-flash",
+			ReleaseManager: "claude-haiku-4-5",
 		}
 	default:
 		fmt.Fprintf(os.Stderr, "unknown backend: %s\n", backend)

--- a/internal/agent/claude.go
+++ b/internal/agent/claude.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -92,18 +93,60 @@ func (c *ClaudeProcess) buildArgs(prompt string) []string {
 	return args
 }
 
+// RateLimitError はレート制限に抵触したことを示す専用エラー型。
+type RateLimitError struct {
+	Wrapped error
+}
+
+func (e *RateLimitError) Error() string {
+	return e.Wrapped.Error()
+}
+
+func (e *RateLimitError) Unwrap() error {
+	return e.Wrapped
+}
+
+// containsRateLimitKeyword は文字列がレート制限関連のキーワードを含むか検査する。
+// Gemini CLI の stderr 出力から直接レート制限を検出するために使用する。
+func containsRateLimitKeyword(s string) bool {
+	lower := strings.ToLower(s)
+	keywords := []string{
+		"resource_exhausted",
+		"quota exceeded",
+		"rate limit",
+		"429",
+		"too many requests",
+		"resourceexhausted",
+	}
+	for _, kw := range keywords {
+		if strings.Contains(lower, kw) {
+			return true
+		}
+	}
+	return false
+}
+
 // IsRateLimitError checks whether the error indicates a token/rate limit.
 func IsRateLimitError(err error) bool {
 	if err == nil {
 		return false
 	}
+	// 型ベースのチェック（RateLimitError 型でラップされている場合）
+	var rlErr *RateLimitError
+	if errors.As(err, &rlErr) {
+		return true
+	}
+	// 既存の文字列チェック（後方互換性）
 	msg := strings.ToLower(err.Error())
 	return strings.Contains(msg, "rate limit") ||
 		strings.Contains(msg, "token limit") ||
 		strings.Contains(msg, "usage limit") ||
 		strings.Contains(msg, "too many requests") ||
 		strings.Contains(msg, "429") ||
-		strings.Contains(msg, "overloaded")
+		strings.Contains(msg, "overloaded") ||
+		strings.Contains(msg, "resource_exhausted") ||
+		strings.Contains(msg, "quota exceeded") ||
+		strings.Contains(msg, "resourceexhausted")
 }
 
 // filterEnv returns a copy of env with the given key removed.

--- a/internal/agent/gemini.go
+++ b/internal/agent/gemini.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"os/exec"
 	"strings"
-	"time"
 )
 
 // GeminiOptions configures a Gemini CLI subprocess.
@@ -28,95 +27,78 @@ func NewGeminiProcess(opts GeminiOptions) *GeminiProcess {
 
 // Send invokes `gemini -p` with the given prompt and returns the response.
 func (g *GeminiProcess) Send(ctx context.Context, prompt string) (string, error) {
-	var response string
-	var err error
+	args := g.buildArgs(prompt)
 
-	// Implement exponential backoff for rate limiting
-	backoff := 1 * time.Second
-	maxRetries := 5
-
-	for i := 0; i < maxRetries; i++ {
-		args := g.buildArgs(prompt)
-
-		cmd := exec.CommandContext(ctx, "gemini", args...)
-		if g.opts.WorkDir != "" {
-			cmd.Dir = g.opts.WorkDir
-		}
-
-		var stdout, stderr bytes.Buffer
-		cmd.Stdout = &stdout
-		cmd.Stderr = &stderr
-
-		err = cmd.Run()
-		if err == nil {
-			response = strings.TrimSpace(stdout.String())
-			return response, nil
-		}
-
-		// If context was cancelled, return context error
-		if ctx.Err() != nil {
-			return "", ctx.Err()
-		}
-
-		// Check if the error is a rate limit error
-		if IsRateLimitError(err) {
-			// Exponential backoff
-			time.Sleep(backoff)
-			backoff *= 2
-			continue
-		}
-
-		// For other errors, return immediately
-		return "", fmt.Errorf("gemini process failed: %w\nstderr: %s", err, stderr.String())
+	cmd := exec.CommandContext(ctx, "gemini", args...)
+	if g.opts.WorkDir != "" {
+		cmd.Dir = g.opts.WorkDir
 	}
 
-	return "", fmt.Errorf("gemini process failed after %d retries: %w", maxRetries, err)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
+	if err == nil {
+		response := strings.TrimSpace(stdout.String())
+		response = sanitizeGeminiResponse(response)
+		return response, nil
+	}
+
+	// コンテキストキャンセルの場合
+	if ctx.Err() != nil {
+		return "", ctx.Err()
+	}
+
+	// stderr の内容もエラーに含める（rate limit 検出用）
+	stderrStr := stderr.String()
+	wrappedErr := fmt.Errorf("gemini process failed: %w\nstderr: %s", err, stderrStr)
+
+	// stderr にレート制限関連の文字列がある場合、専用エラー型で返す
+	if containsRateLimitKeyword(stderrStr) || IsRateLimitError(err) {
+		return "", &RateLimitError{Wrapped: wrappedErr}
+	}
+
+	return "", wrappedErr
 }
 
 func (g *GeminiProcess) buildArgs(prompt string) []string {
-	args := []string{
-		"-p", prompt,
-		"-o", "text",
-		"--approval-mode", "yolo", // Corresponds to claude's --dangerously-skip-permissions
+	// システムプロンプトがある場合、プロンプトの先頭に付加する
+	// （Gemini CLI には --system-prompt フラグがないため）
+	combinedPrompt := prompt
+	if g.opts.SystemPrompt != "" {
+		combinedPrompt = g.opts.SystemPrompt + "\n\n" + prompt
 	}
 
+	args := []string{
+		"-p", combinedPrompt,
+		"-o", "text",
+		"--approval-mode", "yolo",
+	}
+
+	// モデル名はそのまま渡す（gemini- prefix を strip しない）
 	if g.opts.Model != "" {
-		// The gemini CLI might not have a --model flag in the same way claude does.
-		// Model selection is often handled via configuration or environment variables.
-		// For now, we assume the model can be passed.
-		// The model name for gemini should be just the model name, e.g. "gemini-pro"
-		modelName := strings.TrimPrefix(g.opts.Model, "gemini-")
-		if modelName != "" {
-			args = append(args, "-m", modelName)
-		}
+		args = append(args, "-m", g.opts.Model)
 	}
 
 	if len(g.opts.AllowedTools) > 0 {
 		args = append(args, "--allowed-tools", strings.Join(g.opts.AllowedTools, ","))
 	}
-	
-	// Prepend system prompt to the main prompt if it exists
-    if g.opts.SystemPrompt != "" {
-        prompt = g.opts.SystemPrompt + "\n\n" + prompt
-        args[1] = prompt // Update the prompt in args
-    }
 
 	return args
 }
 
-// NOTE: IsRateLimitError is defined in claude.go. Since both files are in the
-// same 'agent' package, GeminiProcess can use it. We'll need to make sure
-// the error messages from the gemini CLI are covered.
-// A more robust solution might be to have a shared error handling utility.
-// For now, we assume the existing function is sufficient.
+// sanitizeGeminiResponse はGeminiのレスポンスからマークダウンのコードフェンスを除去する。
+func sanitizeGeminiResponse(response string) string {
+	lines := strings.Split(response, "\n")
 
-func filterEnvGemini(env []string, key string) []string {
-	prefix := key + "="
-	result := make([]string, 0, len(env))
-	for _, e := range env {
-		if !strings.HasPrefix(e, prefix) {
-			result = append(result, e)
-		}
+	// 全体が単一のコードブロックで包まれている場合のみ除去
+	if len(lines) >= 2 &&
+		strings.HasPrefix(strings.TrimSpace(lines[0]), "```") &&
+		strings.TrimSpace(lines[len(lines)-1]) == "```" {
+		// 先頭と末尾のフェンスを除去
+		inner := lines[1 : len(lines)-1]
+		return strings.TrimSpace(strings.Join(inner, "\n"))
 	}
-	return result
+	return response
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -88,7 +88,7 @@ func setDefaults(cfg *Config) {
 		cfg.Agent.Models.Architect = "claude-opus-4-6"
 	}
 	if cfg.Agent.Models.Engineer == "" {
-		cfg.Agent.Models.Engineer = "gemini-pro"
+		cfg.Agent.Models.Engineer = "claude-sonnet-4-6"
 	}
 	if cfg.Agent.Models.Reviewer == "" {
 		cfg.Agent.Models.Reviewer = "claude-sonnet-4-6"


### PR DESCRIPTION
## Issue

ytnobody-MADFLOW-015: [Feature] Support for Gemini CLI as an Alternative Backend

## 変更概要

### バグ修正（Critical）
- `gemini.go` `buildArgs()`: モデル名から `gemini-` prefix を不正に strip していたバグを修正（例: `gemini-2.5-flash` → `2.5-flash` になっていた問題）
- `gemini.go` `buildArgs()`: SystemPrompt 処理のバグを修正（ローカル変数 `prompt` を変更後 `args[1]` を直接書き換えていた問題）

### 機能改善
- `gemini.go` `Send()`: 内部 Exponential Backoff ループを除去し、Agent レベルの Dormancy 機構に一本化
- `gemini.go` `Send()`: stderr からのレート制限検出を追加（`RateLimitError` 型で返す）
- `gemini.go`: `sanitizeGeminiResponse()` を追加（Gemini レスポンスのマークダウンコードフェンス除去）
- `gemini.go`: 未使用の `filterEnvGemini()` 関数と `time` import を削除
- `claude.go`: `RateLimitError` 型を追加（`errors.As` による型チェック対応）
- `claude.go`: `containsRateLimitKeyword()` ユーティリティ関数を追加
- `claude.go`: `IsRateLimitError()` に Gemini 固有キーワード（`resource_exhausted`, `quota exceeded`, `resourceexhausted`）を追加

### 設定・コマンド更新
- `use.go`: claude/gemini のモデル名を現行バージョンに更新
- `use.go`: `mixed` バックエンドを追加（戦略レイヤー: Claude、実行レイヤー: Gemini のハイブリッド構成）
- `config.go`: Engineer のデフォルトモデルを `gemini-pro`（廃止済み）から `claude-sonnet-4-6` に修正

## テスト

- `go build ./...` ✅
- `go test ./internal/agent/... ./cmd/madflow/...` ✅ 全テスト PASS
- 新規テスト追加: `TestSanitizeGeminiResponse`, `TestContainsRateLimitKeyword`, `TestRateLimitError`, `TestIsRateLimitError_GeminiKeywords`

🤖 Generated with [Claude Code](https://claude.com/claude-code)