### PR TITLE
fix: announceStart のchatlog宛先をsuperintendentに修正

### DIFF
--- a/internal/team/team.go
+++ b/internal/team/team.go
@@ -15,7 +15,7 @@ import (
 // announceStart は各エージェントの作業開始をチャットログに報告する。
 func announceStart(team *Team) {
 	line := chatlog.FormatMessage(
-		"",
+		"superintendent",
 		team.Engineer.ID.String(),
 		fmt.Sprintf("チーム %d の %s として作業を開始します。イシュー: %s", team.ID, team.Engineer.ID.Role, team.IssueID),
 	)


### PR DESCRIPTION
## 概要

`internal/team/team.go` の `announceStart` 関数のバグを修正します。

## 問題

`announceStart` 関数が recipient="" (空) で chatlog に書き込んでいたため、
`TestCreateAnnouncesStart` が `ag.ChatLog.Poll("superintendent")` で 0件を取得し失敗していた。

## 修正内容

```go
// Before
line := chatlog.FormatMessage("", ...)

// After  
line := chatlog.FormatMessage("superintendent", ...)
```

## テスト確認

- `go test ./internal/team/... -count=1` → PASS

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>