### PR TITLE
ytnobody-MADFLOW-040: dormancy時のGitHubポーリング完全停止

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -64,6 +64,12 @@ type GitHubConfig struct {
 	// IdleThresholdMinutes is how long there must be no open issues before
 	// entering idle mode. Defaults to 5 minutes.
 	IdleThresholdMinutes int `toml:"idle_threshold_minutes"`
+	// DormancyThresholdMinutes is how long there must be no open issues (measured from
+	// when issues first disappeared) before entering dormancy and completely stopping
+	// GitHub API polling. 0 (default) disables dormancy. Should be larger than
+	// IdleThresholdMinutes to form a natural progression: active → idle → dormant.
+	// Dormancy can be exited via the WAKE_GITHUB orchestrator command.
+	DormancyThresholdMinutes int `toml:"dormancy_threshold_minutes"`
 }
 
 func Load(path string) (*Config, error) {
@@ -123,6 +129,8 @@ func setDefaults(cfg *Config) {
 	if cfg.GitHub != nil && cfg.GitHub.IdleThresholdMinutes == 0 {
 		cfg.GitHub.IdleThresholdMinutes = 5
 	}
+	// DormancyThresholdMinutes intentionally has no default (0 = disabled).
+	// Users must opt-in by setting a positive value in their config.
 	if cfg.Cache != nil {
 		if cfg.Cache.TTLMinutes == 0 {
 			cfg.Cache.TTLMinutes = 30

--- a/internal/github/idle.go
+++ b/internal/github/idle.go
@@ -1,6 +1,7 @@
 package github
 
 import (
+	"log"
 	"sync"
 	"time"
 )
@@ -10,18 +11,25 @@ import (
 // is considered "idle" and pollers should reduce their polling frequency
 // to avoid unnecessary GitHub API calls.
 //
+// When there are no active issues for longer than dormancyThreshold (measured
+// from when issues first disappeared), the system enters "dormancy" and pollers
+// should stop making GitHub API calls entirely. Dormancy can be exited by
+// calling Wake(), which resets the detector to the active state.
+//
 // The detector is concurrency-safe and can be shared between Syncer and EventWatcher.
 type IdleDetector struct {
-	mu            sync.RWMutex
-	hasIssues     bool
-	issuesGoneAt  time.Time     // when hasIssues last became false
-	idleThreshold time.Duration // how long with no issues before going idle (0 = immediately)
+	mu                 sync.RWMutex
+	hasIssues          bool
+	issuesGoneAt       time.Time     // when hasIssues last became false
+	idleThreshold      time.Duration // how long with no issues before going idle (0 = immediately)
+	dormancyThreshold  time.Duration // how long with no issues before entering dormancy (0 = disabled)
 }
 
 // NewIdleDetector creates an IdleDetector that starts in an active state
 // (assuming there may be issues until confirmed otherwise).
 // The default threshold is 0 (idle immediately when no issues are found).
 // Use SetIdleThreshold to configure a delay before entering idle mode.
+// Use SetDormancyThreshold to configure when polling stops entirely.
 func NewIdleDetector() *IdleDetector {
 	return &IdleDetector{hasIssues: true}
 }
@@ -33,6 +41,18 @@ func (d *IdleDetector) SetIdleThreshold(threshold time.Duration) {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 	d.idleThreshold = threshold
+}
+
+// SetDormancyThreshold sets how long the system must have no active issues before
+// entering dormancy (completely stopping GitHub API polling).
+// A threshold of 0 (the default) disables dormancy.
+// The threshold is measured from when issues first disappeared, so it should be
+// larger than idleThreshold to form a progression: active → idle → dormant.
+// This method is safe to call concurrently.
+func (d *IdleDetector) SetDormancyThreshold(threshold time.Duration) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.dormancyThreshold = threshold
 }
 
 // SetHasIssues updates whether there are currently active (open/in-progress) issues.
@@ -83,4 +103,29 @@ func (d *IdleDetector) AdaptInterval(normal, idle time.Duration) time.Duration {
 		return normal
 	}
 	return idle
+}
+
+// IsDormant returns true if the system has been without active issues for at least
+// dormancyThreshold duration. Returns false if dormancyThreshold is 0 (dormancy disabled).
+func (d *IdleDetector) IsDormant() bool {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+
+	if d.hasIssues || d.dormancyThreshold <= 0 {
+		return false
+	}
+	return time.Since(d.issuesGoneAt) >= d.dormancyThreshold
+}
+
+// Wake resets the detector to the active state, ending any idle or dormancy condition.
+// This causes IsDormant() and IsIdle() to return false until the next time issues
+// disappear for the configured threshold durations.
+// Typically called when an operator signals that the system should resume polling,
+// for example via the WAKE_GITHUB orchestrator command.
+func (d *IdleDetector) Wake() {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.hasIssues = true
+	d.issuesGoneAt = time.Time{}
+	log.Println("[idle-detector] woken: GitHub polling resuming")
 }


### PR DESCRIPTION
Issue: ytnobody-MADFLOW-040

## 概要

長時間issueがない状態（dormancy）でGitHubへのAPIポーリングを完全に停止する仕組みを実装した。

MADFLOW-037のアイドル時ポーリング低減（15分間隔に変更）をさらに発展させ、
アイドル状態がさらに継続した場合にAPIコールを完全にゼロにする。

## 変更内容

### `internal/github/idle.go` - IdleDetectorを拡張

- `SetDormancyThreshold(duration)` : dormancy移行までの閾値を設定（0=無効、デフォルト）
- `IsDormant() bool` : issuesGoneAt から dormancyThreshold 以上経過した場合にtrueを返す
- `Wake()` : hasIssues=trueにリセットし、IsIdle()/IsDormant()をfalseに戻す。ログも出力

### `internal/github/github.go` - Syncer

- `Run()`でポーリング前に `IsDormant()` をチェック
- dormant中はGitHub APIを呼ばず `dormancyCheckInterval`(30秒)ごとにメモリ内状態を再確認するのみ

### `internal/github/events.go` - EventWatcher

- `Run()`に同様のdormancyチェックを追加

### `internal/config/config.go` - 設定

- `GitHubConfig.DormancyThresholdMinutes` フィールドを追加
- 0（デフォルト）=dormancy無効。正の値を設定するとopt-in

### `internal/orchestrator/orchestrator.go` - オーケストレーター

- `New()`でDormancyThresholdMinutesをIdleDetectorに設定
- chatlogコマンド `WAKE_GITHUB` を追加：dormancyから強制復帰したい場合にオペレーターが使用

## 状態遷移

```
[active] →(idleThreshold経過)→ [idle: 15分間隔ポーリング] →(dormancyThreshold経過)→ [dormant: ポーリング停止]
   ↑                                                                                          |
   └──────────────────────────── WAKE_GITHUB or SetHasIssues(true) ───────────────────────────┘
```

## テスト

`internal/github/idle_test.go` に dormancy専用テストを9件追加:
- disabled by default / with issues / threshold not expired / threshold expired
- Wake()による復帰 / SetHasIssues(true)による復帰
- idle+dormancy両方のリセット / concurrent safety