### PR TITLE
ytnobody-MADFLOW-038: デフォルトモデルを安価なモデルに変更・economy プリセット追加

### DIFF
--- a/cmd/madflow/use.go
+++ b/cmd/madflow/use.go
@@ -11,14 +11,51 @@ import (
 	"github.com/ytnobody/madflow/internal/project"
 )
 
-const useUsage = `Usage: madflow use <claude|gemini|mixed>
+const useUsage = `Usage: madflow use <claude|gemini|mixed|economy>
 
 Switches all agent models in madflow.toml to a specific backend.
-  claude: All roles use Claude models (stable, higher cost)
-  gemini: All roles use Gemini models (cost-effective)
-  mixed:  Strategic roles (superintendent, RM) use Claude,
-          execution roles (engineer, reviewer) use Gemini (recommended for cost optimization)
+  claude:  All roles use Claude models (high capability)
+             superintendent: claude-sonnet-4-6
+             engineer:       claude-sonnet-4-6
+  gemini:  All roles use Gemini Flash (cost-effective)
+             superintendent: gemini-2.0-flash
+             engineer:       gemini-2.0-flash
+  mixed:   Strategic roles use Claude, execution roles use Gemini (recommended)
+             superintendent: claude-sonnet-4-6
+             engineer:       gemini-2.0-flash
+  economy: All roles use the most cost-effective Claude models
+             superintendent: claude-haiku-4-5
+             engineer:       claude-haiku-4-5
 `
+
+// resolvePreset returns the ModelConfig for a given backend preset name.
+// Returns an error for unknown preset names.
+func resolvePreset(backend string) (config.ModelConfig, error) {
+	switch backend {
+	case "claude":
+		return config.ModelConfig{
+			Superintendent: "claude-sonnet-4-6",
+			Engineer:       "claude-sonnet-4-6",
+		}, nil
+	case "gemini":
+		return config.ModelConfig{
+			Superintendent: "gemini-2.0-flash",
+			Engineer:       "gemini-2.0-flash",
+		}, nil
+	case "mixed":
+		return config.ModelConfig{
+			Superintendent: "claude-sonnet-4-6",
+			Engineer:       "gemini-2.0-flash",
+		}, nil
+	case "economy":
+		return config.ModelConfig{
+			Superintendent: "claude-haiku-4-5",
+			Engineer:       "claude-haiku-4-5",
+		}, nil
+	default:
+		return config.ModelConfig{}, fmt.Errorf("unknown backend: %s", backend)
+	}
+}
 
 func cmdUse() error {
 	if len(os.Args) < 3 {
@@ -27,25 +64,9 @@ func cmdUse() error {
 	}
 	backend := os.Args[2]
 
-	var newModels config.ModelConfig
-	switch backend {
-	case "claude":
-		newModels = config.ModelConfig{
-			Superintendent: "claude-opus-4-6",
-			Engineer:       "claude-sonnet-4-6",
-		}
-	case "gemini":
-		newModels = config.ModelConfig{
-			Superintendent: "gemini-2.5-pro",
-			Engineer:       "gemini-2.5-flash",
-		}
-	case "mixed":
-		newModels = config.ModelConfig{
-			Superintendent: "claude-sonnet-4-6",
-			Engineer:       "gemini-2.5-flash",
-		}
-	default:
-		fmt.Fprintf(os.Stderr, "unknown backend: %s\n", backend)
+	newModels, err := resolvePreset(backend)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
 		fmt.Fprint(os.Stderr, useUsage)
 		return nil
 	}

--- a/cmd/madflow/use_test.go
+++ b/cmd/madflow/use_test.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/ytnobody/madflow/internal/config"
+)
+
+func TestResolvePreset_Claude(t *testing.T) {
+	models, err := resolvePreset("claude")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if models.Superintendent != "claude-sonnet-4-6" {
+		t.Errorf("claude preset: expected superintendent claude-sonnet-4-6, got %s", models.Superintendent)
+	}
+	if models.Engineer != "claude-sonnet-4-6" {
+		t.Errorf("claude preset: expected engineer claude-sonnet-4-6, got %s", models.Engineer)
+	}
+}
+
+func TestResolvePreset_Gemini(t *testing.T) {
+	models, err := resolvePreset("gemini")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if models.Superintendent != "gemini-2.0-flash" {
+		t.Errorf("gemini preset: expected superintendent gemini-2.0-flash, got %s", models.Superintendent)
+	}
+	if models.Engineer != "gemini-2.0-flash" {
+		t.Errorf("gemini preset: expected engineer gemini-2.0-flash, got %s", models.Engineer)
+	}
+}
+
+func TestResolvePreset_Mixed(t *testing.T) {
+	models, err := resolvePreset("mixed")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if models.Superintendent != "claude-sonnet-4-6" {
+		t.Errorf("mixed preset: expected superintendent claude-sonnet-4-6, got %s", models.Superintendent)
+	}
+	if models.Engineer != "gemini-2.0-flash" {
+		t.Errorf("mixed preset: expected engineer gemini-2.0-flash, got %s", models.Engineer)
+	}
+}
+
+func TestResolvePreset_Economy(t *testing.T) {
+	models, err := resolvePreset("economy")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if models.Superintendent != "claude-haiku-4-5" {
+		t.Errorf("economy preset: expected superintendent claude-haiku-4-5, got %s", models.Superintendent)
+	}
+	if models.Engineer != "claude-haiku-4-5" {
+		t.Errorf("economy preset: expected engineer claude-haiku-4-5, got %s", models.Engineer)
+	}
+}
+
+func TestResolvePreset_Unknown(t *testing.T) {
+	_, err := resolvePreset("unknown-backend")
+	if err == nil {
+		t.Fatal("expected error for unknown backend, got nil")
+	}
+}
+
+func TestResolvePreset_ReturnsModelConfig(t *testing.T) {
+	// Verify all presets return a non-empty ModelConfig
+	presets := []string{"claude", "gemini", "mixed", "economy"}
+	for _, preset := range presets {
+		models, err := resolvePreset(preset)
+		if err != nil {
+			t.Errorf("%s: unexpected error: %v", preset, err)
+			continue
+		}
+		if models == (config.ModelConfig{}) {
+			t.Errorf("%s: expected non-empty ModelConfig", preset)
+		}
+		if models.Superintendent == "" {
+			t.Errorf("%s: Superintendent model is empty", preset)
+		}
+		if models.Engineer == "" {
+			t.Errorf("%s: Engineer model is empty", preset)
+		}
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -97,10 +97,10 @@ func setDefaults(cfg *Config) {
 		cfg.Agent.ContextResetMinutes = 8
 	}
 	if cfg.Agent.Models.Superintendent == "" {
-		cfg.Agent.Models.Superintendent = "claude-opus-4-6"
+		cfg.Agent.Models.Superintendent = "claude-sonnet-4-6"
 	}
 	if cfg.Agent.Models.Engineer == "" {
-		cfg.Agent.Models.Engineer = "claude-sonnet-4-6"
+		cfg.Agent.Models.Engineer = "claude-haiku-4-5"
 	}
 	if cfg.Agent.MaxTeams == 0 {
 		cfg.Agent.MaxTeams = 4

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -73,8 +73,11 @@ path = "."
 	if cfg.Agent.ContextResetMinutes != 8 {
 		t.Errorf("expected default 8, got %d", cfg.Agent.ContextResetMinutes)
 	}
-	if cfg.Agent.Models.Superintendent != "claude-opus-4-6" {
-		t.Errorf("expected default superintendent model, got %s", cfg.Agent.Models.Superintendent)
+	if cfg.Agent.Models.Superintendent != "claude-sonnet-4-6" {
+		t.Errorf("expected default superintendent model claude-sonnet-4-6, got %s", cfg.Agent.Models.Superintendent)
+	}
+	if cfg.Agent.Models.Engineer != "claude-haiku-4-5" {
+		t.Errorf("expected default engineer model claude-haiku-4-5, got %s", cfg.Agent.Models.Engineer)
 	}
 }
 


### PR DESCRIPTION
## Issue

ytnobody-MADFLOW-038: エージェント間対話のモデルを設定できるようにする。

## 変更内容

### `internal/config/config.go`
- デフォルトモデルを安価なモデルに変更:
  - `superintendent`: `claude-opus-4-6` → `claude-sonnet-4-6`
  - `engineer`: `claude-sonnet-4-6` → `claude-haiku-4-5`

### `cmd/madflow/use.go`
- `resolvePreset(backend string) (config.ModelConfig, error)` 関数を抽出（テスタブル化）
- `economy` プリセットを追加: `superintendent=claude-haiku-4-5, engineer=claude-haiku-4-5`
- `claude` プリセット更新: `superintendent: opus → sonnet`
- `gemini` プリセット更新: `gemini-2.5-pro/flash → gemini-2.0-flash`
- `useUsage` を各プリセットの詳細説明付きに更新

### `cmd/madflow/use_test.go`（新規）
- `TestResolvePreset_Claude` / `Gemini` / `Mixed` / `Economy`: 各プリセットの期待値テスト
- `TestResolvePreset_Unknown`: 不明バックエンド名でエラーが返ることを確認
- `TestResolvePreset_ReturnsModelConfig`: 全プリセットで非空 ModelConfig が返ることを確認

### `internal/config/config_test.go`
- `TestLoadDefaults` を新しいデフォルト値（sonnet/haiku）に合わせて更新

## テスト

`go test ./...` 全 PASS 確認済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)