### PR TITLE
Update gmn link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ MADFLOW（Multi-Agent Development Flow）は、複数の AI エージェント�
 - Git
 - 以下のいずれか:
   - [Claude Code](https://claude.com/claude-code)（`claude` コマンド）
-  - [gmn](https://github.com/yourusername/gmn)（`gmn` コマンド）- Gemini モデル使用時
+  - [gmn](https://github.com/tomohiro-owada/gmn)（`gmn` コマンド）- Gemini モデル使用時
 - GitHub CLI（`gh`）（GitHub Issue 同期を使用する場合）
 
 ## インストール


### PR DESCRIPTION
This pull request updates a dependency reference in the `README.md` file to point to the correct repository for the `gmn` command, which is used when working with the Gemini model.

Documentation update:

* Changed the `gmn` command reference link to point to the correct GitHub repository (`https://github.com/tomohiro-owada/gmn`) in the prerequisites section of `README.md`.