### PR TITLE
ytnobody-MADFLOW-050: authorized_usersでGitHubユーザーのフィルタリングを追加

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -13,6 +13,10 @@ type Config struct {
 	Branches   BranchConfig   `toml:"branches"`
 	GitHub     *GitHubConfig  `toml:"github,omitempty"`
 	PromptsDir string         `toml:"prompts_dir,omitempty"`
+	// AuthorizedUsers is a list of GitHub user logins that are allowed to create
+	// issues, PRs, and comments that MADFLOW will process. When empty (the default),
+	// all users are trusted. When non-empty, only listed users are trusted.
+	AuthorizedUsers []string `toml:"authorized_users,omitempty"`
 }
 
 type ProjectConfig struct {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -396,3 +396,58 @@ extra_prompt = "このプロジェクトはGoで書かれています。コー�
 		t.Errorf("expected extra_prompt %q, got %q", expected, cfg.Agent.ExtraPrompt)
 	}
 }
+
+func TestAuthorizedUsersDefault(t *testing.T) {
+	content := `
+[project]
+name = "test-app"
+
+[[project.repos]]
+name = "main"
+path = "."
+`
+	dir := t.TempDir()
+	path := filepath.Join(dir, "madflow.toml")
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(cfg.AuthorizedUsers) != 0 {
+		t.Errorf("expected empty authorized_users by default, got %v", cfg.AuthorizedUsers)
+	}
+}
+
+func TestAuthorizedUsersCustom(t *testing.T) {
+	content := `
+authorized_users = ["alice", "bob"]
+
+[project]
+name = "test-app"
+
+[[project.repos]]
+name = "main"
+path = "."
+`
+	dir := t.TempDir()
+	path := filepath.Join(dir, "madflow.toml")
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(cfg.AuthorizedUsers) != 2 {
+		t.Fatalf("expected 2 authorized_users, got %d", len(cfg.AuthorizedUsers))
+	}
+	if cfg.AuthorizedUsers[0] != "alice" || cfg.AuthorizedUsers[1] != "bob" {
+		t.Errorf("expected [alice bob], got %v", cfg.AuthorizedUsers)
+	}
+}

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -449,7 +449,8 @@ func (o *Orchestrator) runEventWatcher(ctx context.Context) {
 
 	idleInterval := time.Duration(gh.IdlePollMinutes) * time.Minute
 	watcher := github.NewEventWatcher(o.store, gh.Owner, gh.Repos, interval, callback).
-		WithIdleDetector(o.idleDetector, idleInterval)
+		WithIdleDetector(o.idleDetector, idleInterval).
+		WithAuthorizedUsers(o.cfg.AuthorizedUsers)
 	if err := watcher.Run(ctx); err != nil && ctx.Err() == nil {
 		log.Printf("[orchestrator] event watcher stopped: %v", err)
 	}
@@ -488,7 +489,8 @@ func (o *Orchestrator) runGitHubSync(ctx context.Context) {
 	interval := time.Duration(gh.SyncIntervalMinutes) * time.Minute
 	idleInterval := time.Duration(gh.IdlePollMinutes) * time.Minute
 	syncer := github.NewSyncer(o.store, gh.Owner, gh.Repos, interval).
-		WithIdleDetector(o.idleDetector, idleInterval)
+		WithIdleDetector(o.idleDetector, idleInterval).
+		WithAuthorizedUsers(o.cfg.AuthorizedUsers)
 	if err := syncer.Run(ctx); err != nil && ctx.Err() == nil {
 		log.Printf("[orchestrator] github sync stopped: %v", err)
 	}


### PR DESCRIPTION
## 概要

Issue: ytnobody-MADFLOW-050

`authorized_users` フィールドをトップレベルに追加し、指定したGitHubユーザーからのIssue・コメントのみを処理できるようにしました。

## 変更内容

- **`internal/config/config.go`**: `Config` に `AuthorizedUsers []string` フィールド追加
- **`internal/github/github.go`**:
  - `ghIssue` 構造体に `User` (Events API用) / `Author` (gh CLI用) フィールドを追加
  - `ghIssue.authorLogin()` メソッド追加（User.Login優先、フォールバックはAuthor.Login）
  - `Syncer` に `WithAuthorizedUsers()` メソッド追加
  - `syncRepo` 内で未承認ユーザーのIssueをスキップ
  - `isAuthorized()` ヘルパー関数追加（空リスト=全許可）
  - `fetchIssues` の `--json` フィールドに `author` を追加
- **`internal/github/events.go`**:
  - `EventWatcher` に `WithAuthorizedUsers()` メソッド追加
  - `handleIssuesEvent` / `handleIssueCommentEvent` で未承認ユーザーをスキップ
- **`internal/orchestrator/orchestrator.go`**: Syncer/EventWatcher に `cfg.AuthorizedUsers` を渡す

## 使用例

```toml
authorized_users = ["alice", "bob"]

[project]
name = "my-project"
...
```

## テスト

全テスト通過済み（`go test ./...`）

テスト追加内容:
- `TestAuthorizedUsersDefault` / `TestAuthorizedUsersCustom` (config)
- `TestIsAuthorized_EmptyList` / `TestIsAuthorized_WithList` (github)
- `TestGhIssueAuthorLogin_*` 3件 (github)
- `TestSyncer_WithAuthorizedUsers` (github)

🤖 Generated with [Claude Code](https://claude.com/claude-code)