### PR TITLE
feat: MADFLOW-059 バイナリリリース用GitHub Actionsワークフローを追加

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,48 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Build and Release
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Build binaries
+        run: |
+          VERSION="${GITHUB_REF_NAME}"
+          LDFLAGS="-X main.version=${VERSION}"
+
+          GOOS=linux   GOARCH=amd64 go build -ldflags "${LDFLAGS}" -o dist/madflow-linux-amd64   ./cmd/madflow
+          GOOS=linux   GOARCH=arm64 go build -ldflags "${LDFLAGS}" -o dist/madflow-linux-arm64   ./cmd/madflow
+          GOOS=darwin  GOARCH=amd64 go build -ldflags "${LDFLAGS}" -o dist/madflow-darwin-amd64  ./cmd/madflow
+          GOOS=darwin  GOARCH=arm64 go build -ldflags "${LDFLAGS}" -o dist/madflow-darwin-arm64  ./cmd/madflow
+          GOOS=windows GOARCH=amd64 go build -ldflags "${LDFLAGS}" -o dist/madflow-windows-amd64.exe ./cmd/madflow
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          files: |
+            dist/madflow-linux-amd64
+            dist/madflow-linux-arm64
+            dist/madflow-darwin-amd64
+            dist/madflow-darwin-arm64
+            dist/madflow-windows-amd64.exe


### PR DESCRIPTION
## 概要

Issue: ytnobody-MADFLOW-059

`main` ブランチへマージされた際（タグベース）にバイナリを自動リリースする GitHub Actions ワークフローを追加しました。

## 変更内容

- `.github/workflows/release.yml` 追加
  - トリガー: `v*` タグの push
  - ビルド対象プラットフォーム:
    - linux/amd64
    - linux/arm64
    - darwin/amd64
    - darwin/arm64
    - windows/amd64
  - `softprops/action-gh-release` でリリースノート自動生成付き GitHub Release を作成
  - バイナリに `VERSION` ld flags を注入（`-X main.version=${GITHUB_REF_NAME}`）

## 設計判断

タグ push をトリガーに採用しました（直接 main push より推奨される方式）。
リリースするたびに `v1.0.0` のようなバージョンタグを push することで自動リリースが走ります。