### PR TITLE
ytnobody-MADFLOW-055: CI/CDにパフォーマンス回帰チェックを追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,3 +44,57 @@ jobs:
 
       - name: go test
         run: go test -race -timeout 120s ./...
+
+      - name: Benchmark regression check
+        if: github.event_name == 'pull_request'
+        run: |
+          set -e
+          export PATH="$(go env GOPATH)/bin:$PATH"
+
+          # Install benchstat for statistical benchmark comparison
+          go install golang.org/x/perf/cmd/benchstat@latest
+
+          # Run benchmarks on current (PR) branch
+          echo "=== Running benchmarks on PR branch ==="
+          go test -bench=. -benchmem -count=5 -timeout 300s ./... > /tmp/bench_new.txt 2>&1 || true
+          cat /tmp/bench_new.txt
+
+          # Fetch base branch tip and create an isolated worktree for comparison
+          echo "=== Fetching base branch: ${{ github.base_ref }} ==="
+          git fetch origin "${{ github.base_ref }}" --depth=1
+          git worktree add /tmp/bench-base FETCH_HEAD
+
+          # Run benchmarks on base branch
+          echo "=== Running benchmarks on base branch ==="
+          (cd /tmp/bench-base && go test -bench=. -benchmem -count=5 -timeout 300s ./...) > /tmp/bench_old.txt 2>&1 || true
+          cat /tmp/bench_old.txt
+
+          # Remove temporary worktree
+          git worktree remove /tmp/bench-base --force
+
+          # Compare benchmarks
+          echo "=== Benchmark comparison (old=base, new=PR) ==="
+          BENCHSTAT_OUT=$(benchstat /tmp/bench_old.txt /tmp/bench_new.txt 2>&1)
+          echo "$BENCHSTAT_OUT"
+
+          # Fail if any benchmark regressed by 10% or more
+          if echo "$BENCHSTAT_OUT" | awk '
+            /\+[0-9]/ {
+              for (i = 1; i <= NF; i++) {
+                if ($i ~ /^\+[0-9]+(\.[0-9]+)?%$/) {
+                  val = $i
+                  gsub(/[+%]/, "", val)
+                  if (val + 0 >= 10.0) {
+                    print "REGRESSION: " $0
+                    found = 1
+                  }
+                }
+              }
+            }
+            END { exit (found ? 1 : 0) }
+          '; then
+            echo "Benchmark check passed: No regression >= 10% detected."
+          else
+            echo "ERROR: Performance regression of 10% or more detected!"
+            exit 1
+          fi

--- a/internal/chatlog/bench_test.go
+++ b/internal/chatlog/bench_test.go
@@ -1,0 +1,48 @@
+package chatlog
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func BenchmarkParseMessage(b *testing.B) {
+	line := "[2026-01-01T00:00:00] [@recipient] sender: hello world benchmark message"
+	for b.Loop() {
+		_, _ = ParseMessage(line)
+	}
+}
+
+func BenchmarkParseMessageInvalid(b *testing.B) {
+	line := "this is not a valid chatlog line"
+	for b.Loop() {
+		_, _ = ParseMessage(line)
+	}
+}
+
+func BenchmarkChatLogPoll(b *testing.B) {
+	dir := b.TempDir()
+	path := filepath.Join(dir, "chatlog.txt")
+
+	// Pre-fill with 100 messages
+	f, err := os.Create(path)
+	if err != nil {
+		b.Fatalf("setup failed: %v", err)
+	}
+	for i := range 100 {
+		fmt.Fprintf(f, "[2026-01-01T00:00:00] [@engineer-1] superintendent: message %d\n", i)
+	}
+	f.Close()
+
+	cl := New(path)
+	for b.Loop() {
+		_, _ = cl.Poll("engineer-1")
+	}
+}
+
+func BenchmarkFormatMessage(b *testing.B) {
+	for b.Loop() {
+		_ = FormatMessage("recipient", "sender", "hello world benchmark message")
+	}
+}

--- a/internal/issue/bench_test.go
+++ b/internal/issue/bench_test.go
@@ -1,0 +1,62 @@
+package issue
+
+import (
+	"fmt"
+	"testing"
+)
+
+func BenchmarkStoreCreate(b *testing.B) {
+	dir := b.TempDir()
+	s := NewStore(dir)
+	for b.Loop() {
+		_, _ = s.Create("benchmark title", "benchmark body")
+	}
+}
+
+func BenchmarkStoreGet(b *testing.B) {
+	dir := b.TempDir()
+	s := NewStore(dir)
+	iss, err := s.Create("benchmark title", "benchmark body")
+	if err != nil {
+		b.Fatalf("setup failed: %v", err)
+	}
+	for b.Loop() {
+		_, _ = s.Get(iss.ID)
+	}
+}
+
+func BenchmarkStoreList10(b *testing.B) {
+	dir := b.TempDir()
+	s := NewStore(dir)
+	for i := range 10 {
+		_, _ = s.Create(fmt.Sprintf("title %d", i), "body")
+	}
+	for b.Loop() {
+		_, _ = s.List(StatusFilter{})
+	}
+}
+
+func BenchmarkStoreUpdate(b *testing.B) {
+	dir := b.TempDir()
+	s := NewStore(dir)
+	iss, err := s.Create("benchmark title", "benchmark body")
+	if err != nil {
+		b.Fatalf("setup failed: %v", err)
+	}
+	n := 0
+	for b.Loop() {
+		iss.Title = fmt.Sprintf("title %d", n)
+		n++
+		_ = s.Update(iss)
+	}
+}
+
+func BenchmarkHasComment(b *testing.B) {
+	iss := &Issue{}
+	for i := range 100 {
+		iss.Comments = append(iss.Comments, Comment{ID: int64(i)})
+	}
+	for b.Loop() {
+		_ = iss.HasComment(99)
+	}
+}


### PR DESCRIPTION
Issue: ytnobody-MADFLOW-055

## 概要

PR時にベンチマーク比較を行い、10%以上のパフォーマンス低下があればCIをリジェクトするステップを追加します。

## 変更内容

### ベンチマークテスト追加
- `internal/issue/bench_test.go`: Store操作のベンチマーク（Create/Get/List/Update/HasComment）
- `internal/chatlog/bench_test.go`: chatlog操作のベンチマーク（ParseMessage/Poll/FormatMessage）

### CI/CDワークフロー更新 (`.github/workflows/ci.yml`)
- `Benchmark regression check` ステップを追加（`pull_request` イベント時のみ実行）
- `golang.org/x/perf/cmd/benchstat` をインストールしてベンチマーク結果を統計的に比較
- `git worktree` でベースブランチを隔離チェックアウトして並行比較
- `benchstat` 出力をAWKで解析し、10%以上の正の差異があればCIを失敗させる