### PR TITLE
feat: MADFLOW-058 ブランチ保護設定スクリプトを追加

### DIFF
--- a/scripts/setup-branch-protection.sh
+++ b/scripts/setup-branch-protection.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# Setup branch protection rules for develop and main branches.
+# Requires: gh CLI with appropriate permissions (admin or push access).
+#
+# Usage:
+#   ./scripts/setup-branch-protection.sh
+#
+# This script requires the CI workflow status check context "ci" to pass
+# before merging into develop or main branches.
+
+set -euo pipefail
+
+REPO="${REPO:-ytnobody/MADFLOW}"
+
+echo "Setting up branch protection for ${REPO}..."
+
+for BRANCH in develop main; do
+  echo "  Configuring branch: ${BRANCH}"
+  gh api -X PUT "repos/${REPO}/branches/${BRANCH}/protection" \
+    --input - << 'EOF'
+{
+  "required_status_checks": {
+    "strict": true,
+    "contexts": ["ci"]
+  },
+  "enforce_admins": false,
+  "required_pull_request_reviews": null,
+  "restrictions": null
+}
+EOF
+  echo "  Done: ${BRANCH}"
+done
+
+echo "Branch protection setup complete."


### PR DESCRIPTION
Issue: ytnobody-MADFLOW-058

develop および main ブランチへのマージに CI/CD の全通過を必須にするためのブランチ保護設定スクリプトを追加しました。

## 変更内容

- scripts/setup-branch-protection.sh 追加
  - gh api を使用して develop/main ブランチの保護ルールを設定
  - required_status_checks.contexts: ["ci"] で CI ワークフロー必須化
  - strict: true で最新のベースブランチとの同期を要求
  - enforce_admins: false で superintendent の --admin マージを許可
  - REPO 環境変数でリポジトリを上書き可能