### PR TITLE
ytnobody-MADFLOW-057: unauthorized_usersのIssueに承認フローを追加

### DIFF
--- a/internal/issue/issue.go
+++ b/internal/issue/issue.go
@@ -31,16 +31,20 @@ const (
 )
 
 type Issue struct {
-	ID           string    `toml:"id"`
-	Title        string    `toml:"title"`
-	URL          string    `toml:"url,omitempty"`
-	Status       Status    `toml:"status"`
-	AssignedTeam int       `toml:"assigned_team"`
-	Repos        []string  `toml:"repos,omitempty"`
-	Labels       []string  `toml:"labels,omitempty"`
-	Body         string    `toml:"body"`
-	Acceptance   string    `toml:"acceptance,omitempty"`
-	Comments     []Comment `toml:"comments,omitempty"`
+	ID           string `toml:"id"`
+	Title        string `toml:"title"`
+	URL          string `toml:"url,omitempty"`
+	Status       Status `toml:"status"`
+	AssignedTeam int    `toml:"assigned_team"`
+	// PendingApproval is set to true when an issue is created by a user not in
+	// authorized_users. The issue will not be assigned to a team until an
+	// authorized user posts a comment containing "/approve".
+	PendingApproval bool      `toml:"pending_approval,omitempty"`
+	Repos           []string  `toml:"repos,omitempty"`
+	Labels          []string  `toml:"labels,omitempty"`
+	Body            string    `toml:"body"`
+	Acceptance      string    `toml:"acceptance,omitempty"`
+	Comments        []Comment `toml:"comments,omitempty"`
 }
 
 // HasComment checks whether a comment with the given ID already exists.

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -239,7 +239,7 @@ func (o *Orchestrator) startAllTeams(ctx context.Context) {
 		maxTeams = team.DefaultMaxTeams
 	}
 
-	// Collect assignable issues
+	// Collect assignable issues (excluding those pending approval).
 	var assignable []*issue.Issue
 	allIssues, err := o.store.List(issue.StatusFilter{})
 	if err != nil {
@@ -247,6 +247,10 @@ func (o *Orchestrator) startAllTeams(ctx context.Context) {
 	} else {
 		for _, iss := range allIssues {
 			if iss.Status == issue.StatusOpen || iss.Status == issue.StatusInProgress {
+				if iss.PendingApproval {
+					log.Printf("[orchestrator] skipping issue %s (pending approval)", iss.ID)
+					continue
+				}
 				assignable = append(assignable, iss)
 			}
 		}


### PR DESCRIPTION
Issue: ytnobody-MADFLOW-057

## 概要

`authorized_users` に含まれないユーザーが作成したIssueは、承認済みユーザーによる `/approve` コメントがあるまでチームに割り当てない承認フローを実装します。

## 変更内容

### `internal/issue/issue.go`
- `Issue` 構造体に `PendingApproval bool` フィールドを追加
- 未承認ユーザーのIssueは `pending_approval = true` で保存（完全スキップではない）

### `internal/github/github.go` (Syncer)
- `syncRepo`: unauthorized userのIssueを `PendingApproval=true` で取り込む
- `syncComments`: authorized_userの `/approve` コメントを検出し `PendingApproval=false` に更新

### `internal/github/events.go` (EventWatcher)
- `handleIssuesEvent`: unauthorized userのIssueを `PendingApproval=true` で取り込む
- `handleIssueCommentEvent`: authorized_userの `/approve` コメントで `PendingApproval=false` に更新

### `internal/orchestrator/orchestrator.go`
- `startAllTeams`: `PendingApproval=true` のIssueをチーム割り当て対象から除外

### テスト
- `PendingApproval` フィールドの永続化テスト
- チーム割り当てスキップのテスト
- `/approve` 検出・未承認ユーザーの無視テスト（全13件追加）