### PR TITLE
MADFLOW-061: ドキュメント整合性定期チェック機能を追加

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -38,6 +38,11 @@ type AgentConfig struct {
 	// check the main branch for bugs and improvement opportunities.
 	// 0 disables the periodic check. Defaults to 6 hours.
 	MainCheckIntervalHours int `toml:"main_check_interval_hours"`
+	// DocCheckIntervalHours specifies how often the superintendent is prompted to
+	// check that documentation is consistent with the current codebase and create
+	// fix PRs when discrepancies are found.
+	// 0 triggers the default of 24 hours.
+	DocCheckIntervalHours int `toml:"doc_check_interval_hours"`
 	// ExtraPrompt is appended to the system prompt of every agent.
 	// Use this to inject project-specific instructions that apply to all agents.
 	ExtraPrompt string `toml:"extra_prompt"`
@@ -114,6 +119,9 @@ func setDefaults(cfg *Config) {
 	}
 	if cfg.Agent.MainCheckIntervalHours == 0 {
 		cfg.Agent.MainCheckIntervalHours = 6
+	}
+	if cfg.Agent.DocCheckIntervalHours == 0 {
+		cfg.Agent.DocCheckIntervalHours = 24
 	}
 	if cfg.Branches.Main == "" {
 		cfg.Branches.Main = "main"

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -451,3 +451,56 @@ path = "."
 		t.Errorf("expected [alice bob], got %v", cfg.AuthorizedUsers)
 	}
 }
+
+func TestDocCheckIntervalHoursDefault(t *testing.T) {
+	content := `
+[project]
+name = "test-app"
+
+[[project.repos]]
+name = "main"
+path = "."
+`
+	dir := t.TempDir()
+	path := filepath.Join(dir, "madflow.toml")
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if cfg.Agent.DocCheckIntervalHours != 24 {
+		t.Errorf("expected default doc_check_interval_hours 24, got %d", cfg.Agent.DocCheckIntervalHours)
+	}
+}
+
+func TestDocCheckIntervalHoursCustom(t *testing.T) {
+	content := `
+[project]
+name = "test-app"
+
+[[project.repos]]
+name = "main"
+path = "."
+
+[agent]
+doc_check_interval_hours = 48
+`
+	dir := t.TempDir()
+	path := filepath.Join(dir, "madflow.toml")
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if cfg.Agent.DocCheckIntervalHours != 48 {
+		t.Errorf("expected doc_check_interval_hours 48, got %d", cfg.Agent.DocCheckIntervalHours)
+	}
+}


### PR DESCRIPTION
## 概要

毎日ドキュメントが現状のコードに沿っているかを確認し、差異があれば修正PRを作成する機能を実装しました。

## 変更内容

### `internal/config/config.go`
- `AgentConfig` に `DocCheckIntervalHours int` フィールドを追加
- `setDefaults()` でデフォルト値 24（時間）を設定

### `internal/orchestrator/orchestrator.go`
- `docCheckPrompt` 定数を追加（ドキュメント整合性チェック指示）
- `runDocCheck()` goroutine メソッドを追加
- `Run()` 内で `DocCheckIntervalHours > 0` の場合に docCheck goroutine を起動

### `internal/config/config_test.go`
- `TestDocCheckIntervalHoursDefault`: デフォルト値（24）のテスト
- `TestDocCheckIntervalHoursCustom`: カスタム値（48）のテスト

Issue: ytnobody-MADFLOW-061