### PR TITLE
ytnobody-MADFLOW-077: エンジニア応答問題の根本原因修正

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -168,7 +168,14 @@ func (a *Agent) buildInitialPrompt(memo string) string {
 	sb.WriteString("チャットログへの書き込みには以下のコマンドを使用してください:\n")
 	sb.WriteString(fmt.Sprintf(`echo "[$(date +%%Y-%%m-%%dT%%H:%%M:%%S)] [@宛先] %s: メッセージ内容" >> %s`, a.ID.String(), a.ChatLog.Path()))
 	sb.WriteString("\n\n")
-	sb.WriteString("自分宛のメンションがチャットログに投稿されるのを待ち、適切に対応してください。")
+	if a.OriginalTask != "" {
+		// イシューが割り当て済みの場合は即座に実装開始を指示する。
+		// これにより、チャットログ経由の割り当てメッセージが届かなかった場合でも
+		// エンジニアが作業を開始できる。
+		sb.WriteString("上記の依頼内容に従い、すぐに実装を開始してください。実装完了後は監督に報告してください。その後もチャットログへのメンションを監視し、追加の指示に対応してください。")
+	} else {
+		sb.WriteString("自分宛のメンションがチャットログに投稿されるのを待ち、適切に対応してください。")
+	}
 	return sb.String()
 }
 


### PR DESCRIPTION
Issue: ytnobody-MADFLOW-077

## 根本原因の特定

エンジニアが応答しない問題の根本原因は、**競合状態によるエンジニアIDの不一致**でした。

### 問題の詳細

1. 監督が `TEAM_CREATE` を送信すると、同じ `claude --print` セッション内でエンジニアへの割り当てメッセージも送信する
2. この時点でオーケストレーターはまだチームを作成しておらず（チーム作成には `claude --print` の初回プロンプト処理が必要で数秒〜数十秒かかる）、正しいエンジニアIDが不明
3. 監督は過去のコンテキストから推測した誤ったエンジニアID（例: `engineer-1`）にメッセージを送信
4. オーケストレーターが実際に作成したチームは別のID（例: `engineer-6`）を持つ新しいエンジニア
5. 正しいエンジニアがメッセージを受け取れず、誤ったエンジニア（すでに解散済み）にメッセージが届く

## 修正内容

### 1. `internal/team/team.go` - `announceStart` の改善

チームが作成された際、監督への通知に加え、**正しいエンジニアIDに直接割り当てメッセージを送信**するよう変更。

これにより、監督が誤ったエンジニアIDにメッセージを送っても、正しいエンジニアが確実に作業を受け取れる。

### 2. `internal/agent/agent.go` - `buildInitialPrompt` の改善

`OriginalTask`（イシュー情報）がある場合、チャットログのメッセージを待たずに**即座に実装開始を指示**するよう変更。

チャットログ経由のメッセージが届かない場合でも、初回プロンプトで作業を開始できる2重の安全策。

## テスト

- `TestAnnounceStartSendsDirectAssignmentToEngineer`: 直接割り当てが正しいエンジニアに届くことを確認
- `TestAnnounceStartStandbyNoDirectAssignment`: スタンバイ時は直接割り当てが送信されないことを確認
- `TestBuildInitialPromptWithOriginalTaskStartsImmediately`: OriginalTask がある場合に即時開始指示
- `TestBuildInitialPromptWithoutOriginalTaskWaits`: OriginalTask がない場合は待機指示

全テスト通過を確認済み。