### PR TITLE
ytnobody-MADFLOW-086: README.mdにMADFLOWロゴを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+<p align="center">
+  <img src="https://github.com/user-attachments/assets/77200c22-452b-459e-84b5-88ab0dc80703" alt="MADFLOW Logo" width="400">
+</p>
+
 # MADFLOW
 
 MADFLOW（Multi-Agent Development Flow）は、複数の AI エージェントがチームとして協調し、ソフトウェア開発を自律的に進める開発フレームワークです。


### PR DESCRIPTION
## Summary

README.mdの冒頭にMADFLOWのロゴ画像を追加しました。

エンジニア・オーケストレーター無応答のため、監督が直接実装しました。

### 変更内容
- README.mdの冒頭にロゴ画像をセンタリングで追加
- 画像幅: 400px

Issue: ytnobody-MADFLOW-086