### PR TITLE
v0.1.1リリース: develop → main

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+<p align="center">
+  <img src="https://github.com/user-attachments/assets/77200c22-452b-459e-84b5-88ab0dc80703" alt="MADFLOW Logo" width="400">
+</p>
+
 # MADFLOW
 
 MADFLOW（Multi-Agent Development Flow）は、複数の AI エージェントがチームとして協調し、ソフトウェア開発を自律的に進める開発フレームワークです。


### PR DESCRIPTION
## v0.1.1 リリース

Issue: ytnobody-MADFLOW-088

### 変更内容（v0.1.0からの差分）

- docs: v0.1.0に合わせてREADME.mdを更新 (#85)
- feat: README.mdにMADFLOWロゴを追加 (#87)

### CI/CD状態

developブランチの全CIチェック: ✅ success

### リリース後の作業

このPRマージ後、v0.1.1タグおよびGitHub Releaseを作成します。