### PR TITLE
ytnobody-MADFLOW-090: revive madflow use <preset> subcommand

### DIFF
--- a/cmd/madflow/main.go
+++ b/cmd/madflow/main.go
@@ -23,6 +23,8 @@ const usage = `Usage: madflow <command> [options]
 Commands:
   init                      Initialize a new project
   start                     Start all agents
+  use <preset>              Switch the active model preset in madflow.toml
+                            Presets: claude, gemini, claude-cheap, gemini-cheap, hybrid, hybrid-cheap
   version                   Show current version
   upgrade                   Upgrade madflow to the latest version
 `
@@ -53,6 +55,12 @@ func main() {
 	case "version", "--version", "-v":
 		fmt.Printf("madflow %s\n", version)
 		return
+	case "use":
+		preset := ""
+		if len(os.Args) >= 3 {
+			preset = os.Args[2]
+		}
+		err = cmdUse(preset)
 	case "upgrade":
 		err = cmdUpgrade(version)
 	case "help", "--help", "-h":

--- a/cmd/madflow/use.go
+++ b/cmd/madflow/use.go
@@ -4,9 +4,112 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
+	"strings"
 
 	"github.com/ytnobody/madflow/internal/project"
 )
+
+// presetModels defines the model configuration for each preset name.
+type presetModels struct {
+	Superintendent string
+	Engineer       string
+}
+
+// presets maps preset name → model configuration.
+var presets = map[string]presetModels{
+	"claude": {
+		Superintendent: "claude-sonnet-4-6",
+		Engineer:       "claude-sonnet-4-6",
+	},
+	"gemini": {
+		Superintendent: "gemini-pro-2-5",
+		Engineer:       "gemini-pro-2-5",
+	},
+	"claude-cheap": {
+		Superintendent: "claude-sonnet-4-6",
+		Engineer:       "claude-haiku-4-5",
+	},
+	"gemini-cheap": {
+		Superintendent: "gemini-flash-2-5",
+		Engineer:       "gemini-flash-2-5",
+	},
+	"hybrid": {
+		Superintendent: "claude-sonnet-4-6",
+		Engineer:       "gemini-pro-2-5",
+	},
+	"hybrid-cheap": {
+		Superintendent: "claude-sonnet-4-6",
+		Engineer:       "gemini-flash-2-5",
+	},
+}
+
+// cmdUse switches the active model preset in madflow.toml.
+func cmdUse(preset string) error {
+	if preset == "" {
+		return fmt.Errorf("usage: madflow use <preset>\n\nAvailable presets:\n%s", formatPresets())
+	}
+
+	models, ok := presets[preset]
+	if !ok {
+		return fmt.Errorf("unknown preset %q\n\nAvailable presets:\n%s", preset, formatPresets())
+	}
+
+	configPath, err := findConfigPath()
+	if err != nil {
+		return err
+	}
+
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		return fmt.Errorf("read config: %w", err)
+	}
+
+	updated, err := updateModelsSection(string(data), models.Superintendent, models.Engineer)
+	if err != nil {
+		return fmt.Errorf("update config: %w", err)
+	}
+
+	if err := os.WriteFile(configPath, []byte(updated), 0644); err != nil {
+		return fmt.Errorf("write config: %w", err)
+	}
+
+	fmt.Printf("Switched to preset %q:\n  superintendent = %q\n  engineer       = %q\n", preset, models.Superintendent, models.Engineer)
+	fmt.Printf("Config updated: %s\n", configPath)
+	return nil
+}
+
+// updateModelsSection replaces the superintendent and engineer model values
+// in the [agent.models] section of a TOML config string.
+// It preserves all other content (comments, ordering, unrelated keys).
+func updateModelsSection(content, superintendent, engineer string) (string, error) {
+	reSuper := regexp.MustCompile(`(?m)^(\s*superintendent\s*=\s*)".+"`)
+	reEng := regexp.MustCompile(`(?m)^(\s*engineer\s*=\s*)".+"`)
+
+	result := reSuper.ReplaceAllString(content, `${1}"`+superintendent+`"`)
+	result = reEng.ReplaceAllString(result, `${1}"`+engineer+`"`)
+
+	// Verify both keys exist after replacement (they should be present in a valid config).
+	if !reSuper.MatchString(content) {
+		return "", fmt.Errorf("superintendent key not found in [agent.models]")
+	}
+	if !reEng.MatchString(content) {
+		return "", fmt.Errorf("engineer key not found in [agent.models]")
+	}
+
+	return result, nil
+}
+
+// formatPresets returns a human-readable list of available presets.
+func formatPresets() string {
+	names := []string{"claude", "gemini", "claude-cheap", "gemini-cheap", "hybrid", "hybrid-cheap"}
+	var sb strings.Builder
+	for _, name := range names {
+		m := presets[name]
+		fmt.Fprintf(&sb, "  %-14s  superintendent=%s, engineer=%s\n", name, m.Superintendent, m.Engineer)
+	}
+	return sb.String()
+}
 
 // findConfigPath locates the madflow.toml configuration file.
 func findConfigPath() (string, error) {

--- a/cmd/madflow/use_test.go
+++ b/cmd/madflow/use_test.go
@@ -1,0 +1,137 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestPresets_AllDefined(t *testing.T) {
+	expectedPresets := []string{"claude", "gemini", "claude-cheap", "gemini-cheap", "hybrid", "hybrid-cheap"}
+	for _, name := range expectedPresets {
+		if _, ok := presets[name]; !ok {
+			t.Errorf("preset %q is not defined", name)
+		}
+	}
+}
+
+func TestPresets_Models(t *testing.T) {
+	tests := []struct {
+		preset         string
+		superintendent string
+		engineer       string
+	}{
+		{"claude", "claude-sonnet-4-6", "claude-sonnet-4-6"},
+		{"gemini", "gemini-pro-2-5", "gemini-pro-2-5"},
+		{"claude-cheap", "claude-sonnet-4-6", "claude-haiku-4-5"},
+		{"gemini-cheap", "gemini-flash-2-5", "gemini-flash-2-5"},
+		{"hybrid", "claude-sonnet-4-6", "gemini-pro-2-5"},
+		{"hybrid-cheap", "claude-sonnet-4-6", "gemini-flash-2-5"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.preset, func(t *testing.T) {
+			m, ok := presets[tt.preset]
+			if !ok {
+				t.Fatalf("preset %q not found", tt.preset)
+			}
+			if m.Superintendent != tt.superintendent {
+				t.Errorf("superintendent: got %q, want %q", m.Superintendent, tt.superintendent)
+			}
+			if m.Engineer != tt.engineer {
+				t.Errorf("engineer: got %q, want %q", m.Engineer, tt.engineer)
+			}
+		})
+	}
+}
+
+func TestUpdateModelsSection(t *testing.T) {
+	input := `[project]
+name = "test"
+
+[agent]
+context_reset_minutes = 8
+
+[agent.models]
+superintendent = "claude-opus-4-6"
+engineer = "claude-sonnet-4-6"
+
+[branches]
+main = "main"
+`
+
+	t.Run("switch to gemini preset", func(t *testing.T) {
+		result, err := updateModelsSection(input, "gemini-pro-2-5", "gemini-pro-2-5")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !strings.Contains(result, `superintendent = "gemini-pro-2-5"`) {
+			t.Errorf("superintendent not updated: %s", result)
+		}
+		if !strings.Contains(result, `engineer = "gemini-pro-2-5"`) {
+			t.Errorf("engineer not updated: %s", result)
+		}
+		// Other sections must be preserved.
+		if !strings.Contains(result, `[project]`) {
+			t.Error("project section lost")
+		}
+		if !strings.Contains(result, `[branches]`) {
+			t.Error("branches section lost")
+		}
+	})
+
+	t.Run("switch to hybrid preset", func(t *testing.T) {
+		result, err := updateModelsSection(input, "claude-sonnet-4-6", "gemini-pro-2-5")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !strings.Contains(result, `superintendent = "claude-sonnet-4-6"`) {
+			t.Errorf("superintendent not updated: %s", result)
+		}
+		if !strings.Contains(result, `engineer = "gemini-pro-2-5"`) {
+			t.Errorf("engineer not updated: %s", result)
+		}
+	})
+
+	t.Run("switch to claude-cheap preset", func(t *testing.T) {
+		result, err := updateModelsSection(input, "claude-sonnet-4-6", "claude-haiku-4-5")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !strings.Contains(result, `superintendent = "claude-sonnet-4-6"`) {
+			t.Errorf("superintendent not updated: %s", result)
+		}
+		if !strings.Contains(result, `engineer = "claude-haiku-4-5"`) {
+			t.Errorf("engineer not updated: %s", result)
+		}
+	})
+}
+
+func TestUpdateModelsSection_MissingKeys(t *testing.T) {
+	// Config with no superintendent key.
+	inputMissingSuper := `[agent.models]
+engineer = "claude-sonnet-4-6"
+`
+	_, err := updateModelsSection(inputMissingSuper, "gemini-pro-2-5", "gemini-pro-2-5")
+	if err == nil {
+		t.Error("expected error for missing superintendent key, got nil")
+	}
+
+	// Config with no engineer key.
+	inputMissingEng := `[agent.models]
+superintendent = "claude-sonnet-4-6"
+`
+	_, err = updateModelsSection(inputMissingEng, "gemini-pro-2-5", "gemini-pro-2-5")
+	if err == nil {
+		t.Error("expected error for missing engineer key, got nil")
+	}
+}
+
+func TestFormatPresets(t *testing.T) {
+	out := formatPresets()
+	expectedPresets := []string{"claude", "gemini", "claude-cheap", "gemini-cheap", "hybrid", "hybrid-cheap"}
+	for _, name := range expectedPresets {
+		if !strings.Contains(out, name) {
+			t.Errorf("formatPresets output missing preset %q", name)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- `madflow use <preset>` サブコマンドを復活し、`[agent.models]` の `superintendent` / `engineer` を一括切り替えできるようにした
- `cmd/madflow/use.go` にプリセットマップ (`presets`) と `cmdUse()` 関数を実装
- `cmd/madflow/main.go` の `switch` 文に `case "use":` を追加し、`usage` 定数を更新
- `updateModelsSection()` ヘルパーは正規表現で TOML のモデル値のみを置換し、他の設定・コメントを保持する

## 対応プリセット

| Preset       | superintendent         | engineer               |
|--------------|------------------------|------------------------|
| claude       | claude-sonnet-4-6      | claude-sonnet-4-6      |
| gemini       | gemini-pro-2-5         | gemini-pro-2-5         |
| claude-cheap | claude-sonnet-4-6      | claude-haiku-4-5       |
| gemini-cheap | gemini-flash-2-5       | gemini-flash-2-5       |
| hybrid       | claude-sonnet-4-6      | gemini-pro-2-5         |
| hybrid-cheap | claude-sonnet-4-6      | gemini-flash-2-5       |

## Test plan

- [x] `TestPresets_AllDefined` – 全プリセット名が定義されていることを確認
- [x] `TestPresets_Models` – 各プリセットのモデル値が正しいことを確認
- [x] `TestUpdateModelsSection` – TOML 文字列内のモデル値置換が正しく動作することを確認
- [x] `TestUpdateModelsSection_MissingKeys` – キーが存在しない場合にエラーを返すことを確認
- [x] `TestFormatPresets` – ヘルプ文字列に全プリセット名が含まれることを確認
- [x] `go test ./...` 全パッケージ PASS

Issue: ytnobody-MADFLOW-090

🤖 Generated with [Claude Code](https://claude.com/claude-code)