### PR TITLE
local-025: リリースワークフロー (GitHub Actions) の安定化

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,13 +36,28 @@ jobs:
           GOOS=darwin  GOARCH=arm64 go build -ldflags "${LDFLAGS}" -o dist/madflow-darwin-arm64  ./cmd/madflow
           GOOS=windows GOARCH=amd64 go build -ldflags "${LDFLAGS}" -o dist/madflow-windows-amd64.exe ./cmd/madflow
 
-      - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
-        with:
-          generate_release_notes: true
-          files: |
-            dist/madflow-linux-amd64
-            dist/madflow-linux-arm64
-            dist/madflow-darwin-amd64
-            dist/madflow-darwin-arm64
-            dist/madflow-windows-amd64.exe
+      - name: Create or Update GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          VERSION="${GITHUB_REF_NAME}"
+          # リリースが既に存在する場合は assets のみアップロード（上書き）
+          if gh release view "$VERSION" -R ${{ github.repository }} > /dev/null 2>&1; then
+            echo "Release $VERSION already exists. Uploading/overwriting assets..."
+            gh release upload "$VERSION" -R ${{ github.repository }} \
+              dist/madflow-linux-amd64 \
+              dist/madflow-linux-arm64 \
+              dist/madflow-darwin-amd64 \
+              dist/madflow-darwin-arm64 \
+              dist/madflow-windows-amd64.exe \
+              --clobber
+          else
+            echo "Creating new release $VERSION..."
+            gh release create "$VERSION" -R ${{ github.repository }} \
+              --generate-notes \
+              dist/madflow-linux-amd64 \
+              dist/madflow-linux-arm64 \
+              dist/madflow-darwin-amd64 \
+              dist/madflow-darwin-arm64 \
+              dist/madflow-windows-amd64.exe
+          fi


### PR DESCRIPTION
Issue: local-025

## 変更概要

`softprops/action-gh-release@v2` の既知バグ（タグに対応するリリースが既に存在する場合に `Validation Failed: already_exists` エラーが発生）を回避するため、`gh` CLI を使った堅牢な実装に置き換えました。

## 実装内容

`.github/workflows/release.yml` の「Create GitHub Release」ステップを以下のロジックに書き換え:

1. `gh release view` でリリース存在チェック
2. 既存リリースがある場合: `gh release upload --clobber` でアセットを上書きアップロード
3. 新規の場合: `gh release create --generate-notes` で新規リリース作成

## 修正ファイル

- `.github/workflows/release.yml`: `softprops/action-gh-release@v2` を `gh` CLI スクリプトに置き換え