### PR TITLE
fix: チャットログトランケーション後の古いコマンド再処理によるオーケストレーター永久ブロックを修正

### DIFF
--- a/internal/chatlog/chatlog.go
+++ b/internal/chatlog/chatlog.go
@@ -244,8 +244,10 @@ func (c *ChatLog) readFrom(offset int64, recipient string) ([]Message, int64, er
 	}
 
 	if info.Size() < offset {
-		// File was truncated (e.g., by Truncate()), reset offset
-		offset = 0
+		// File was truncated (e.g., by Truncate()); skip to current end to
+		// avoid reprocessing old messages (which could re-create orphaned teams
+		// or fire duplicate commands).
+		return nil, info.Size(), nil
 	}
 	if info.Size() == offset {
 		return nil, offset, nil


### PR DESCRIPTION
## 概要

オーケストレーターが永久に TEAM_CREATE を処理できなくなる問題を修正する。

## 根本原因

3つのバグが複合的に作用していた:

1. **chatlog.Watch のトランケーション後の全コマンド再処理**
   - `readFrom()` がトランケーション検出時にオフセットを `0` にリセット
   - 8分ごとのチャットログクリーンアップ後に過去500行の全コマンドが再処理される

2. **TEAM_CREATE リトライ時の不正な issueID**
   - superintendent がリトライ時に「（2回目）」等の余分なテキストを付加
   - orchestrator が `strings.Fields(body)[1]` をそのまま issueID として使うため
     `"ytnobody-MADFLOW-091（2回目）エンジニア-3が無応答のため..."` のような不正IDでチームが作成される

3. **orphanedチームが TEAM_DISBAND で削除不可能**
   - 不正IDのチームは正規の TEAM_DISBAND コマンドでは削除できない
   - `maxTeams=2` が永久に埋まり続け、以降の全 TEAM_CREATE が失敗する
   - 8分ごとにこのサイクルが繰り返される → 永久ブロック

## 修正内容

- **chatlog.go**: トランケーション検出時にオフセットを現在のファイルサイズに設定（スキップ）
  - 古いメッセージの再処理を防ぐ
  - トランケーション後の新しいメッセージは次のポーリングで正常に取得できる

- **orchestrator.go**: `handleTeamCreate` に issueID の存在確認を追加
  - store に存在しない issueID の TEAM_CREATE を拒否
  - 成否（成功/拒否/失敗）を superintendent に chatlog で通知

- **chatlog_test.go**: 新しい期待動作（スキップ）に合わせてテストを更新

## テスト

全テスト PASS (12パッケージ)

## 注意事項

このPRをマージ後、madflow プロセスを再起動することで既存の orphaned チームがクリアされ、
新しい TEAM_CREATE コマンドが正常に処理されるようになる。

エンジニア・オーケストレーター無応答のため superintendent が直接実装（local-027）。