### PR TITLE
ytnobody-MADFLOW-104: startAllTeams中のCtrl+C/SIGTERM受信による誤エラー出力を修正

### DIFF
--- a/cmd/madflow/main.go
+++ b/cmd/madflow/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/signal"
@@ -178,7 +179,13 @@ func cmdStart() error {
 	go displayChatLog(ctx, orc.ChatLogPath())
 
 	fmt.Printf("Starting MADFLOW for project '%s'...\n", proj.ID)
-	return orc.Run(ctx)
+	err = orc.Run(ctx)
+	// context.Canceled is the expected outcome when the user stops the process
+	// (Ctrl+C / SIGTERM). Treat it as a clean exit rather than an error.
+	if errors.Is(err, context.Canceled) {
+		return nil
+	}
+	return err
 }
 
 // loadProjectConfig detects the project and loads its config.


### PR DESCRIPTION
Issue: ytnobody-MADFLOW-104

## 問題

`madflow start` 起動中にCtrl+C/SIGTERMを受け取ると、以下のエラーが表示されてクラッシュしたように見える問題がありました:

```
Error: wait for agents ready: context canceled
```

## 根本原因

`Run()` の起動シーケンスは以下の順序で実行されます:

1. `startResidentAgents()` — superintendent を起動
2. `startAllTeams()` — 全チームを並行起動（各チームのClaude Codeエージェント初期化に時間がかかる）
3. `waitForAgentsReady()` — superintendentの初期起動完了を待機

`startAllTeams()` の実行中にCtrl+C/SIGTERMが届くと:
- context がキャンセルされる
- `startAllTeams()` は最大30秒タイムアウトを待って完了する
- `startAllTeams()` 完了後、`waitForAgentsReady()` が既にキャンセル済みのcontextで呼ばれる
- 即座に `context.Canceled` を返し、`"wait for agents ready: context canceled"` エラーが出力される

## 修正内容

### `internal/orchestrator/orchestrator.go`
`startAllTeams()` 後に `ctx.Err()` を確認し、contextがキャンセル済みの場合はグレースフルシャットダウンを実行:
- `wg.Wait()` でgoroutineの完了を待つ
- `nil` を返す（エラーではなく正常終了）

### `cmd/madflow/main.go`
`orc.Run(ctx)` が `context.Canceled` を返した場合（Ctrl+C等による正常終了）をエラーとして扱わず `nil` を返す。

### テスト追加
`TestRunGracefulShutdownDuringStartup`: 事前キャンセル済みcontextで `Run()` を呼んだ場合に `nil` が返ることを確認するテストを追加。