### PR TITLE
local-030: madflow init 時に prompts/ ディレクトリとデフォルトテンプレートを自動生成する

### DIFF
--- a/cmd/madflow/main.go
+++ b/cmd/madflow/main.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ytnobody/madflow/internal/config"
 	"github.com/ytnobody/madflow/internal/orchestrator"
 	"github.com/ytnobody/madflow/internal/project"
+	"github.com/ytnobody/madflow/prompts"
 )
 
 // version is set via ldflags at build time (e.g., -ldflags "-X main.version=v1.2.3").
@@ -146,8 +147,16 @@ feature_prefix = "feature/issue-"
 		}
 	}
 
+	// Create prompts/ directory with default templates so that `madflow start`
+	// works immediately after `madflow init` on a new project.
+	promptsDir := filepath.Join(cwd, "prompts")
+	if err := prompts.WriteDefaults(promptsDir); err != nil {
+		return fmt.Errorf("create default prompts: %w", err)
+	}
+
 	fmt.Printf("Project '%s' initialized.\n", name)
 	fmt.Printf("Config: %s\n", configPath)
+	fmt.Printf("Prompts: %s\n", promptsDir)
 	return nil
 }
 

--- a/cmd/madflow/main_test.go
+++ b/cmd/madflow/main_test.go
@@ -56,6 +56,97 @@ func TestCmdInit_GeneratedConfigDoesNotContainDeprecatedRoles(t *testing.T) {
 	}
 }
 
+func TestCmdInit_CreatesDefaultPrompts(t *testing.T) {
+	// Create a temporary directory to act as the project root.
+	tmpDir := t.TempDir()
+
+	// Change working directory to tmp so cmdInit writes files there.
+	origDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get cwd: %v", err)
+	}
+	defer os.Chdir(origDir) //nolint:errcheck
+
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatalf("failed to chdir: %v", err)
+	}
+
+	// Override os.Args to simulate: madflow init --name testproject
+	origArgs := os.Args
+	os.Args = []string{"madflow", "init", "--name", "testproject", "--repo", tmpDir}
+	defer func() { os.Args = origArgs }()
+
+	if err := cmdInit(); err != nil {
+		t.Fatalf("cmdInit() error: %v", err)
+	}
+
+	// Verify that prompts/ directory was created.
+	promptsDir := filepath.Join(tmpDir, "prompts")
+	info, err := os.Stat(promptsDir)
+	if err != nil {
+		t.Fatalf("prompts/ directory was not created: %v", err)
+	}
+	if !info.IsDir() {
+		t.Fatalf("prompts/ is not a directory")
+	}
+
+	// Verify that default prompt files exist and are non-empty.
+	for _, name := range []string{"superintendent.md", "engineer.md"} {
+		path := filepath.Join(promptsDir, name)
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Errorf("default prompt file %s was not created: %v", name, err)
+			continue
+		}
+		if len(data) == 0 {
+			t.Errorf("default prompt file %s is empty", name)
+		}
+	}
+}
+
+func TestCmdInit_PreservesExistingPrompts(t *testing.T) {
+	// Verify that cmdInit does NOT overwrite already-existing prompt files.
+	tmpDir := t.TempDir()
+
+	origDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get cwd: %v", err)
+	}
+	defer os.Chdir(origDir) //nolint:errcheck
+
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatalf("failed to chdir: %v", err)
+	}
+
+	// Pre-create the prompts directory with custom content.
+	promptsDir := filepath.Join(tmpDir, "prompts")
+	if err := os.MkdirAll(promptsDir, 0755); err != nil {
+		t.Fatalf("failed to create prompts dir: %v", err)
+	}
+	customContent := []byte("# custom prompt – do not overwrite")
+	customFile := filepath.Join(promptsDir, "superintendent.md")
+	if err := os.WriteFile(customFile, customContent, 0644); err != nil {
+		t.Fatalf("failed to write custom prompt: %v", err)
+	}
+
+	origArgs := os.Args
+	os.Args = []string{"madflow", "init", "--name", "testproject", "--repo", tmpDir}
+	defer func() { os.Args = origArgs }()
+
+	if err := cmdInit(); err != nil {
+		t.Fatalf("cmdInit() error: %v", err)
+	}
+
+	// The custom file must not have been overwritten.
+	got, err := os.ReadFile(customFile)
+	if err != nil {
+		t.Fatalf("failed to read superintendent.md: %v", err)
+	}
+	if string(got) != string(customContent) {
+		t.Errorf("cmdInit overwrote existing prompt file; got %q, want %q", got, customContent)
+	}
+}
+
 func TestRoleColors_DoesNotContainDeprecatedRoles(t *testing.T) {
 	deprecatedRoles := []string{"reviewer", "release_manager"}
 	for _, role := range deprecatedRoles {


### PR DESCRIPTION
Issue: local-030

## 変更内容

`cmd/madflow/main.go` の `cmdInit()` 関数に `prompts.WriteDefaults(promptsDir)` の呼び出しを追加。

- `madflow init` 実行時に `prompts/` ディレクトリとデフォルトテンプレートを自動生成
- 既存ファイルは上書きしない（ユーザーのカスタマイズを保護）
- `prompts.WriteDefaults` は PR #106 でマージ済みの実装を利用

## 追加テスト

- `TestCmdInit_CreatesDefaultPrompts`: `prompts/` が作成され、`superintendent.md` / `engineer.md` が存在することを検証
- `TestCmdInit_PreservesExistingPrompts`: 既存のカスタムファイルが上書きされないことを検証

## 動作確認

```
$ madflow init
Project 'myproject' initialized.
Config: /path/to/myproject/madflow.toml
Prompts: /path/to/myproject/prompts
```