### PR TITLE
fix(agent): fix Watch/markReady race condition causing TestRunReturnsOnMaxIterationsError to fail

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -92,6 +92,10 @@ func (a *Agent) Run(ctx context.Context) error {
 	log.Printf("[%s] agent started", recipient)
 
 	memo, _ := reset.LoadLatestMemo(a.MemosDir, recipient)
+	// Watch must be started before markReady() to avoid a race condition:
+	// markReady() signals test goroutines to write messages, and if Watch()
+	// is called after markReady(), those messages may be missed.
+	msgCh := a.ChatLog.Watch(ctx, recipient)
 	_, initErr := a.sendWithRetry(ctx, a.buildInitialPrompt(memo))
 	a.markReady()
 	if initErr != nil {
@@ -100,8 +104,6 @@ func (a *Agent) Run(ctx context.Context) error {
 		}
 		log.Printf("[%s] initial send failed: %v", recipient, initErr)
 	}
-
-	msgCh := a.ChatLog.Watch(ctx, recipient)
 	for {
 		select {
 		case <-ctx.Done():


### PR DESCRIPTION
## Summary

- Move `chatlog.Watch()` call before `markReady()` in `agent.Run()` to prevent race condition
- Fix `chatlog.Watch()` and `WatchAll()` to capture file offset synchronously in calling goroutine (not inside the spawned goroutine)

## Root Cause

Two race conditions were causing `TestRunReturnsOnMaxIterationsError` to time out:

1. **agent.go**: `Watch()` was called AFTER `markReady()`. Test goroutines write to chatlog upon `markReady()` signal, but `Watch()` hadn't started yet → messages were missed

2. **chatlog.go**: `Watch()` spawned a goroutine that captured `os.Stat()` offset asynchronously. If the goroutine was delayed in scheduling, it would record the file offset AFTER new messages were written → those messages would be permanently missed

## Fix

1. In `agent.go`: call `msgCh := a.ChatLog.Watch(ctx, recipient)` before `a.markReady()`
2. In `chatlog.go`: move `os.Stat()` to the calling goroutine (synchronous), before the background poller goroutine is spawned

## Test

- `TestRunReturnsOnMaxIterationsError` now passes consistently with `-count=3 -race`
- All agent and chatlog tests pass

Fixes: local-001