### PR TITLE
feat: worktree cleanup on disband & issue title in chatlog

### DIFF
--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -263,6 +263,19 @@ func (o *Orchestrator) cleanStaleWorktrees() {
 	}
 }
 
+// cleanTeamWorktrees removes worktrees for a specific team number.
+// This is called when a team is disbanded to free up disk space and
+// prevent stale worktrees from accumulating.
+func (o *Orchestrator) cleanTeamWorktrees(teamNum int) {
+	prefix := fmt.Sprintf("team-%d", teamNum)
+	for name, repo := range o.repos {
+		removed := repo.CleanWorktrees(prefix)
+		if len(removed) > 0 {
+			log.Printf("[orchestrator] cleaned %d worktree(s) for team %d in %s: %v", len(removed), teamNum, name, removed)
+		}
+	}
+}
+
 // ensureDevelopBranch ensures the main repo is on the develop branch at startup.
 // This prevents issues where a previous engineer left the repo on a feature branch.
 func (o *Orchestrator) ensureDevelopBranch() {
@@ -409,13 +422,14 @@ func (o *Orchestrator) startAllTeams(ctx context.Context) {
 	// blocked waiting for the first LLM response from each engineer).
 	for i := 0; i < maxTeams; i++ {
 		idx := i
-		var issueID string
+		var issueID, issueTitle string
 		if idx < len(assignable) {
 			issueID = assignable[idx].ID
+			issueTitle = assignable[idx].Title
 		}
 
 		go func() {
-			t, err := o.teams.Create(ctx, issueID)
+			t, err := o.teams.Create(ctx, issueID, issueTitle)
 			if err != nil {
 				if ctx.Err() == nil {
 					log.Printf("[orchestrator] start teams: team %d: %v", idx+1, err)
@@ -562,10 +576,12 @@ func (o *Orchestrator) handleTeamCreate(ctx context.Context, body string) {
 
 	log.Printf("[orchestrator] TEAM_CREATE %s: starting async team creation", issueID)
 
+	issueTitle := existingIss.Title
+
 	// Run the expensive Create call in a goroutine to avoid blocking
 	// the watchCommands loop (Create can take 10+ minutes waiting for LLM).
 	go func() {
-		t, err := o.teams.Create(ctx, issueID)
+		t, err := o.teams.Create(ctx, issueID, issueTitle)
 		if err != nil {
 			log.Printf("[orchestrator] TEAM_CREATE failed for %s: %v", issueID, err)
 			o.chatLog.Append("superintendent", "orchestrator",
@@ -587,7 +603,7 @@ func (o *Orchestrator) handleTeamCreate(ctx context.Context, body string) {
 	}()
 }
 
-// handleTeamDisband disbands the team for an issue.
+// handleTeamDisband disbands the team for an issue and cleans up its worktrees.
 // Expected format: TEAM_DISBAND issue-id
 func (o *Orchestrator) handleTeamDisband(body string) {
 	parts := strings.Fields(body)
@@ -597,12 +613,14 @@ func (o *Orchestrator) handleTeamDisband(body string) {
 	}
 	issueID := parts[1]
 
-	if err := o.teams.DisbandByIssue(issueID); err != nil {
+	teamNum, err := o.teams.DisbandByIssue(issueID)
+	if err != nil {
 		log.Printf("[orchestrator] TEAM_DISBAND failed for %s: %v", issueID, err)
 		return
 	}
 
-	log.Printf("[orchestrator] team disbanded for issue %s", issueID)
+	o.cleanTeamWorktrees(teamNum)
+	log.Printf("[orchestrator] team %d disbanded for issue %s (worktrees cleaned)", teamNum, issueID)
 }
 
 // handleRelease triggers a develop -> main merge.
@@ -729,10 +747,12 @@ func (o *Orchestrator) handlePRMerged(issueID string) {
 		log.Printf("[orchestrator] PR merged: update issue %s failed: %v", issueID, err)
 	}
 
-	// Disband the assigned team
+	// Disband the assigned team and clean up its worktrees
 	if iss.AssignedTeam > 0 {
-		if err := o.teams.DisbandByIssue(issueID); err != nil {
+		if teamNum, err := o.teams.DisbandByIssue(issueID); err != nil {
 			log.Printf("[orchestrator] PR merged: disband team for %s failed: %v", issueID, err)
+		} else {
+			o.cleanTeamWorktrees(teamNum)
 		}
 	}
 

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -555,7 +555,7 @@ func TestHandleTeamCreateRejectsActiveTeam(t *testing.T) {
 	defer cancel()
 
 	// Create a team for this issue via the manager directly (simulates race window).
-	_, err := orc.Teams().Create(ctx, iss.ID)
+	_, err := orc.Teams().Create(ctx, iss.ID, iss.Title)
 	if err != nil {
 		t.Fatalf("create team: %v", err)
 	}
@@ -801,7 +801,7 @@ func TestHandlePRMerged(t *testing.T) {
 	// Create a team for this issue
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	tm, err := orc.Teams().Create(ctx, "owner-repo-001")
+	tm, err := orc.Teams().Create(ctx, "owner-repo-001", iss.Title)
 	if err != nil {
 		t.Fatalf("create team: %v", err)
 	}

--- a/internal/team/team.go
+++ b/internal/team/team.go
@@ -15,13 +15,19 @@ import (
 // announceStart は各エージェントの作業開始をチャットログに報告する。
 // イシューが割り当てられている場合は、正しいエンジニアIDに直接割り当てメッセージも送信する。
 // これにより、監督が誤ったエンジニアIDに送信してもエンジニアが確実に作業を受け取れる。
+// チャットログにはイシューのタイトルを含め、どの作業を行うか明確にする。
 func announceStart(team *Team) {
 	// 監督にチーム開始を通知（監督が正しいエンジニアIDを知るために必要）
-	line := chatlog.FormatMessage(
-		"superintendent",
-		team.Engineer.ID.String(),
-		fmt.Sprintf("チーム %d の %s として作業を開始します。イシュー: %s", team.ID, team.Engineer.ID.Role, team.IssueID),
-	)
+	// イシュータイトルがある場合は作業内容を明記する
+	var msg string
+	if team.IssueTitle != "" {
+		msg = fmt.Sprintf("チーム %d の %s として以下の作業を開始します。\nイシュー: %s\nタイトル: %s",
+			team.ID, team.Engineer.ID.Role, team.IssueID, team.IssueTitle)
+	} else {
+		msg = fmt.Sprintf("チーム %d の %s として作業を開始します。イシュー: %s",
+			team.ID, team.Engineer.ID.Role, team.IssueID)
+	}
+	line := chatlog.FormatMessage("superintendent", team.Engineer.ID.String(), msg)
 	appendLine(team.Engineer.ChatLog.Path(), line)
 
 	// イシューが割り当てられている場合、正しいエンジニアIDに直接割り当てメッセージを送信する。
@@ -50,10 +56,11 @@ func appendLine(path, line string) {
 
 // Team represents a task force team (engineer).
 type Team struct {
-	ID       int
-	IssueID  string
-	Engineer *agent.Agent
-	cancel   context.CancelFunc
+	ID         int
+	IssueID    string
+	IssueTitle string
+	Engineer   *agent.Agent
+	cancel     context.CancelFunc
 }
 
 // DefaultMaxTeams is the default maximum number of concurrent teams.
@@ -89,7 +96,8 @@ func NewManager(factory TeamFactory, maxTeams int) *Manager {
 }
 
 // Create creates and starts a new team for the given issue.
-func (m *Manager) Create(ctx context.Context, issueID string) (*Team, error) {
+// issueTitle is included in the chatlog announcement so it's clear what work will be done.
+func (m *Manager) Create(ctx context.Context, issueID, issueTitle string) (*Team, error) {
 	m.mu.Lock()
 	// Count both active teams and teams being created to prevent maxTeams bypass.
 	totalSlots := len(m.teams) + m.pendingCount
@@ -124,10 +132,11 @@ func (m *Manager) Create(ctx context.Context, issueID string) (*Team, error) {
 	teamCtx, cancel := context.WithCancel(ctx)
 
 	team := &Team{
-		ID:       teamNum,
-		IssueID:  issueID,
-		Engineer: engineer,
-		cancel:   cancel,
+		ID:         teamNum,
+		IssueID:    issueID,
+		IssueTitle: issueTitle,
+		Engineer:   engineer,
+		cancel:     cancel,
 	}
 
 	// Move from pending to active.
@@ -192,7 +201,8 @@ func (m *Manager) Disband(teamNum int) error {
 }
 
 // DisbandByIssue finds and disbands the team assigned to the given issue.
-func (m *Manager) DisbandByIssue(issueID string) error {
+// Returns the disbanded team number and any error.
+func (m *Manager) DisbandByIssue(issueID string) (int, error) {
 	m.mu.Lock()
 	var targetNum int
 	var found bool
@@ -206,9 +216,9 @@ func (m *Manager) DisbandByIssue(issueID string) error {
 	m.mu.Unlock()
 
 	if !found {
-		return fmt.Errorf("no team found for issue %s", issueID)
+		return 0, fmt.Errorf("no team found for issue %s", issueID)
 	}
-	return m.Disband(targetNum)
+	return targetNum, m.Disband(targetNum)
 }
 
 // List returns a snapshot of all active teams.

--- a/internal/team/team_test.go
+++ b/internal/team/team_test.go
@@ -64,7 +64,7 @@ func createAndCancel(t *testing.T, mgr *Manager, issueID string) *Team {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // cancel before Create
 
-	team, err := mgr.Create(ctx, issueID)
+	team, err := mgr.Create(ctx, issueID, "")
 	if err != nil {
 		t.Fatalf("Create failed: %v", err)
 	}
@@ -123,7 +123,7 @@ func TestCreateFactoryError(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	_, err := m.Create(ctx, "issue-001")
+	_, err := m.Create(ctx, "issue-001", "")
 	if err == nil {
 		t.Fatal("expected error from factory, got nil")
 	}
@@ -221,7 +221,7 @@ func TestHasIssue(t *testing.T) {
 	}
 
 	// After disbanding, HasIssue should return false
-	m.DisbandByIssue("issue-001")
+	_, _ = m.DisbandByIssue("issue-001")
 	if m.HasIssue("issue-001") {
 		t.Error("expected HasIssue to return false after disbanding issue-001")
 	}
@@ -243,7 +243,7 @@ func TestDisbandByIssue(t *testing.T) {
 	createAndCancel(t, m, "issue-001")
 	createAndCancel(t, m, "issue-002")
 
-	if err := m.DisbandByIssue("issue-001"); err != nil {
+	if _, err := m.DisbandByIssue("issue-001"); err != nil {
 		t.Fatalf("DisbandByIssue failed: %v", err)
 	}
 
@@ -261,7 +261,7 @@ func TestDisbandByIssue(t *testing.T) {
 func TestDisbandByIssueNotFound(t *testing.T) {
 	m := NewManager(newMockFactory(t), 0)
 
-	err := m.DisbandByIssue("nonexistent")
+	_, err := m.DisbandByIssue("nonexistent")
 	if err == nil {
 		t.Fatal("expected error for non-existent issue, got nil")
 	}
@@ -277,7 +277,7 @@ func TestCreateRespectsMaxTeams(t *testing.T) {
 	// 3rd team should fail
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
-	_, err := m.Create(ctx, "issue-003")
+	_, err := m.Create(ctx, "issue-003", "")
 	if err == nil {
 		t.Fatal("expected error when exceeding max teams, got nil")
 	}
@@ -328,7 +328,7 @@ func TestDefaultMaxTeams(t *testing.T) {
 	// Next one should fail
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
-	_, err := m.Create(ctx, "issue-over-limit")
+	_, err := m.Create(ctx, "issue-over-limit", "")
 	if err == nil {
 		t.Fatal("expected error when exceeding default max teams")
 	}


### PR DESCRIPTION
## Summary
- **Issue #138**: チーム解散時にworktreeのクリーンアップを実行する `cleanTeamWorktrees` メソッドを追加。`handleTeamDisband` と `handlePRMerged` の両方から呼び出される。
- **Issue #139**: `Team` 構造体に `IssueTitle` フィールドを追加し、チャットログの作業開始アナウンスにイシューのタイトルを含めることで、どの作業を行うか明確にした。
- `DisbandByIssue` の戻り値を `(int, error)` に変更し、解散したチーム番号を返すようにした（targeted cleanup用）。
- テストファイルを新しい関数シグネチャに合わせて更新。

Closes #138
Closes #139

## Test plan
- [x] `go build ./...` がエラーなく通ること
- [x] `go test ./internal/team/` が全件パスすること
- [x] `go test ./internal/orchestrator/` が全件パスすること
- [x] integration test の失敗は既存の問題（develop ブランチでも同様に失敗）であり、本PRの変更に起因しないことを確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)