### PR TITLE
ytnobody-MADFLOW-142: ハートビートログの省略

### DIFF
--- a/internal/agent/claude_stream.go
+++ b/internal/agent/claude_stream.go
@@ -218,7 +218,6 @@ type readResultOutput struct {
 // scanForResult synchronously scans lines until a result or error event.
 func (c *ClaudeStreamProcess) scanForResult() (string, error) {
 	eventCount := 0
-	lastLog := time.Now()
 	for c.scanner.Scan() {
 		line := c.scanner.Text()
 		if line == "" {
@@ -247,11 +246,6 @@ func (c *ClaudeStreamProcess) scanForResult() (string, error) {
 			return "", classifyStreamError(event)
 		}
 
-		// Periodic heartbeat so the operator knows work is happening.
-		if time.Since(lastLog) >= 30*time.Second {
-			log.Printf("[claude-stream] processing... (%d events received, session=%s)", eventCount, c.sessionID)
-			lastLog = time.Now()
-		}
 	}
 
 	if err := c.scanner.Err(); err != nil {


### PR DESCRIPTION
Issue: ytnobody-MADFLOW-142

## 変更概要

`internal/agent/claude_stream.go` の `scanForResult()` 内にある定期ハートビートログ出力を削除する。

## 削除したログ

```
[claude-stream] processing... (N events received, session=XXXX)
```

このログは30秒ごとに出力されていたが、ログを汚染するノイズとなっていたため削除した。

## テスト

- `go build ./...` 通過
- `go test ./internal/agent/...` 通過
- `internal/integration` のテスト失敗は本変更とは無関係のpre-existingな問題