### PR TITLE
fix: TEAM_CREATE消失を修正 - chatlog truncation時のreadFromバグ修正 (#152)

### DIFF
--- a/internal/chatlog/chatlog.go
+++ b/internal/chatlog/chatlog.go
@@ -109,6 +109,28 @@ func (c *ChatLog) Poll(recipient string) ([]Message, error) {
 	return messages, nil
 }
 
+// lastTimestampInFile reads the file and returns the timestamp of the last
+// successfully parsed message. Returns zero time if the file is empty or
+// cannot be read.
+func (c *ChatLog) lastTimestampInFile() time.Time {
+	f, err := os.Open(c.path)
+	if err != nil {
+		return time.Time{}
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	var lastTS time.Time
+	for scanner.Scan() {
+		if msg, err := ParseMessage(scanner.Text()); err == nil {
+			if msg.Timestamp.After(lastTS) {
+				lastTS = msg.Timestamp
+			}
+		}
+	}
+	return lastTS
+}
+
 // Watch monitors the chatlog file for new messages to the given recipient.
 // It yields messages on the returned channel until ctx is cancelled.
 func (c *ChatLog) Watch(ctx context.Context, recipient string) <-chan Message {
@@ -117,9 +139,12 @@ func (c *ChatLog) Watch(ctx context.Context, recipient string) <-chan Message {
 	// オフセットをゴルーチン外（呼び出し元スレッド）で取得することで、
 	// Watch() 呼び出し後にゴルーチン起動前に書かれたメッセージを
 	// 見落とすレース条件を防ぐ。
+	// lastTimestamp は truncation 検知時の重複排除に使用する。
 	var offset int64
+	var lastTimestamp time.Time
 	if info, err := os.Stat(c.path); err == nil {
 		offset = info.Size()
+		lastTimestamp = c.lastTimestampInFile()
 	}
 
 	go func() {
@@ -133,13 +158,16 @@ func (c *ChatLog) Watch(ctx context.Context, recipient string) <-chan Message {
 			case <-ctx.Done():
 				return
 			case <-ticker.C:
-				newMessages, newOffset, err := c.readFrom(offset, recipient)
+				newMessages, newOffset, err := c.readFrom(offset, lastTimestamp, recipient)
 				if err != nil {
 					log.Printf("[chatlog] Watch(%s): readFrom error: %v", recipient, err)
 					continue
 				}
 				offset = newOffset
 				for _, msg := range newMessages {
+					if msg.Timestamp.After(lastTimestamp) {
+						lastTimestamp = msg.Timestamp
+					}
 					select {
 					case ch <- msg:
 					case <-ctx.Done():
@@ -158,9 +186,12 @@ func (c *ChatLog) WatchAll(ctx context.Context) <-chan Message {
 	ch := make(chan Message, 16)
 
 	// Watch() と同様に、オフセットをゴルーチン外で取得してレース条件を防ぐ。
+	// lastTimestamp は truncation 検知時の重複排除に使用する。
 	var offset int64
+	var lastTimestamp time.Time
 	if info, err := os.Stat(c.path); err == nil {
 		offset = info.Size()
+		lastTimestamp = c.lastTimestampInFile()
 	}
 
 	go func() {
@@ -174,13 +205,16 @@ func (c *ChatLog) WatchAll(ctx context.Context) <-chan Message {
 			case <-ctx.Done():
 				return
 			case <-ticker.C:
-				newMessages, newOffset, err := c.readFrom(offset, "")
+				newMessages, newOffset, err := c.readFrom(offset, lastTimestamp, "")
 				if err != nil {
 					log.Printf("[chatlog] WatchAll: readFrom error: %v", err)
 					continue
 				}
 				offset = newOffset
 				for _, msg := range newMessages {
+					if msg.Timestamp.After(lastTimestamp) {
+						lastTimestamp = msg.Timestamp
+					}
 					select {
 					case ch <- msg:
 					case <-ctx.Done():
@@ -236,7 +270,14 @@ func (c *ChatLog) Truncate(maxLines int) error {
 	return nil
 }
 
-func (c *ChatLog) readFrom(offset int64, recipient string) ([]Message, int64, error) {
+// readFrom reads messages from the chatlog starting at the given byte offset.
+// lastTimestamp is used to filter out already-processed messages when a file
+// truncation is detected (info.Size() < offset): in that case, offset is reset
+// to 0 to re-read the entire (truncated) file, and only messages with a
+// timestamp strictly after lastTimestamp are returned.  This ensures that
+// messages written just before a truncation (e.g. TEAM_CREATE commands) are
+// not silently dropped.
+func (c *ChatLog) readFrom(offset int64, lastTimestamp time.Time, recipient string) ([]Message, int64, error) {
 	f, err := os.Open(c.path)
 	if err != nil {
 		return nil, offset, err
@@ -248,11 +289,13 @@ func (c *ChatLog) readFrom(offset int64, recipient string) ([]Message, int64, er
 		return nil, offset, err
 	}
 
+	truncated := false
 	if info.Size() < offset {
-		// File was truncated (e.g., by Truncate()); skip to current end to
-		// avoid reprocessing old messages (which could re-create orphaned teams
-		// or fire duplicate commands).
-		return nil, info.Size(), nil
+		// File was truncated (e.g., by Truncate()).  Reset to beginning so that
+		// messages written just before the truncation are not lost.
+		// Duplicate-message prevention is handled by lastTimestamp filtering below.
+		offset = 0
+		truncated = true
 	}
 	if info.Size() == offset {
 		return nil, offset, nil
@@ -271,6 +314,12 @@ func (c *ChatLog) readFrom(offset int64, recipient string) ([]Message, int64, er
 		}
 		msg, err := ParseMessage(line)
 		if err != nil {
+			continue
+		}
+		// When re-reading from the beginning after truncation, skip messages
+		// whose timestamps are not newer than the last processed timestamp to
+		// avoid replaying already-handled commands.
+		if truncated && !lastTimestamp.IsZero() && !msg.Timestamp.After(lastTimestamp) {
 			continue
 		}
 		if recipient == "" || msg.Recipient == recipient {

--- a/internal/chatlog/chatlog_test.go
+++ b/internal/chatlog/chatlog_test.go
@@ -278,8 +278,9 @@ func TestTruncate_EmptyFile(t *testing.T) {
 	}
 }
 
-// TestReadFrom_OffsetResetAfterTruncate verifies that readFrom skips to the
-// end of file when truncation is detected, instead of replaying old messages.
+// TestReadFrom_OffsetResetAfterTruncate verifies that readFrom re-reads the
+// truncated file from the beginning when truncation is detected, but uses
+// lastTimestamp to filter out already-processed old messages.
 // This prevents old TEAM_CREATE/TEAM_DISBAND commands from being re-processed
 // every time the chatlog cleanup goroutine truncates the file.
 func TestReadFrom_OffsetResetAfterTruncate(t *testing.T) {
@@ -308,19 +309,23 @@ func TestReadFrom_OffsetResetAfterTruncate(t *testing.T) {
 	}
 	offset := info.Size()
 
+	// lastTimestamp = timestamp of the last processed message (10:00:05)
+	lastTimestamp, _ := time.Parse("2006-01-02T15:04:05", "2026-02-21T10:00:05")
+
 	// Truncate to keep only 2 lines (file shrinks)
 	if err := cl.Truncate(2); err != nil {
 		t.Fatalf("Truncate failed: %v", err)
 	}
 
-	// readFrom should detect truncation and skip to end-of-file instead of
-	// re-reading from the beginning.  No messages should be returned.
-	messages, newOffset, err := cl.readFrom(offset, "superintendent")
+	// readFrom should detect truncation, re-read from beginning, and filter
+	// out already-processed messages (all remaining have T <= 10:00:05).
+	// Net result: 0 new messages returned.
+	messages, newOffset, err := cl.readFrom(offset, lastTimestamp, "superintendent")
 	if err != nil {
 		t.Fatalf("readFrom failed: %v", err)
 	}
 	if len(messages) != 0 {
-		t.Errorf("expected 0 messages after truncation (skip-to-end), got %d: %v", len(messages), messages)
+		t.Errorf("expected 0 messages after truncation (all old), got %d: %v", len(messages), messages)
 	}
 	// Offset must have been updated to the current (smaller) file size.
 	truncatedInfo, err := os.Stat(path)
@@ -341,7 +346,7 @@ func TestReadFrom_OffsetResetAfterTruncate(t *testing.T) {
 	f.WriteString(newMsg)
 	f.Close()
 
-	messages2, _, err := cl.readFrom(newOffset, "superintendent")
+	messages2, _, err := cl.readFrom(newOffset, lastTimestamp, "superintendent")
 	if err != nil {
 		t.Fatalf("second readFrom failed: %v", err)
 	}
@@ -350,5 +355,65 @@ func TestReadFrom_OffsetResetAfterTruncate(t *testing.T) {
 	}
 	if len(messages2) > 0 && messages2[0].Body != "新しいメッセージ" {
 		t.Errorf("expected new message body '新しいメッセージ', got: %s", messages2[0].Body)
+	}
+}
+
+// TestReadFrom_TruncationPreservesNewMessages verifies the core bug fix:
+// a message written to the chatlog just before a Truncate() call must not be
+// silently dropped.  This was the root cause of TEAM_CREATE commands being
+// missed by the orchestrator when the chatlog cleanup goroutine ran at an
+// inopportune time.
+func TestReadFrom_TruncationPreservesNewMessages(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "chatlog.txt")
+
+	// Write old messages that will be partially removed by Truncate.
+	oldLines := []string{
+		"[2026-02-21T10:00:01] [@orchestrator] superintendent: TEAM_CREATE 1",
+		"[2026-02-21T10:00:02] [@orchestrator] superintendent: TEAM_CREATE 2",
+		"[2026-02-21T10:00:03] [@orchestrator] superintendent: TEAM_CREATE 3",
+		"[2026-02-21T10:00:04] [@orchestrator] superintendent: TEAM_CREATE 4",
+		"[2026-02-21T10:00:05] [@orchestrator] superintendent: TEAM_CREATE 5",
+	}
+	content := strings.Join(oldLines, "\n") + "\n"
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cl := New(path)
+
+	// Simulate Watch(): offset = current file size, lastTimestamp = 10:00:05.
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	offset := info.Size()
+	lastTimestamp, _ := time.Parse("2006-01-02T15:04:05", "2026-02-21T10:00:05")
+
+	// A new TEAM_CREATE arrives just before the truncation goroutine runs.
+	newTeamCreate := "[2026-02-21T10:00:06] [@orchestrator] superintendent: TEAM_CREATE 6\n"
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0644)
+	if err != nil {
+		t.Fatal(err)
+	}
+	f.WriteString(newTeamCreate)
+	f.Close()
+
+	// Truncate keeps last 3 lines: TEAM_CREATE 4, 5, 6.
+	// File shrinks so its size is now less than the previous offset.
+	if err := cl.Truncate(3); err != nil {
+		t.Fatalf("Truncate failed: %v", err)
+	}
+
+	// readFrom must return TEAM_CREATE 6 despite the truncation.
+	messages, _, err := cl.readFrom(offset, lastTimestamp, "orchestrator")
+	if err != nil {
+		t.Fatalf("readFrom failed: %v", err)
+	}
+	if len(messages) != 1 {
+		t.Errorf("expected 1 new message preserved after truncation, got %d", len(messages))
+	}
+	if len(messages) > 0 && messages[0].Body != "TEAM_CREATE 6" {
+		t.Errorf("expected body 'TEAM_CREATE 6', got: %s", messages[0].Body)
 	}
 }


### PR DESCRIPTION
## 概要

Issue: ytnobody-MADFLOW-152

`internal/chatlog/chatlog.go` の `readFrom()` 関数にあるレースコンディションを修正する。

## 根本原因

`readFrom()` 関数でファイルの切り詰め（truncation）を検知した場合（`info.Size() < offset`）、従来は `return nil, info.Size(), nil` でEOFにスキップしていた。

これにより、truncation直前に書き込まれたTEAM_CREATEメッセージがオーケストレーターに届かず、監督が3回再試行しても無応答→フォールバックとなる問題が発生していた。

## 修正内容

### `readFrom()` の変更
- truncation検知時、`offset = 0` にリセットしてファイル全体を再読み込みする
- `lastTimestamp time.Time` パラメータを追加し、truncation後の再読み込み時は `Timestamp > lastTimestamp` のメッセージのみ返す（重複排除）

### `Watch()` / `WatchAll()` の変更
- `lastTimestamp` を追跡してメッセージ処理後に更新
- 起動時に `lastTimestampInFile()` で初期値を設定し、起動直後のtruncationでも旧メッセージを返さない

### 新規ヘルパー
- `lastTimestampInFile()`: ファイル内の最後のメッセージのタイムスタンプを返す

## テスト

- `TestReadFrom_OffsetResetAfterTruncate`: 新しい `lastTimestamp` パラメータに対応するよう更新
- `TestReadFrom_TruncationPreservesNewMessages`: truncation直前のメッセージが保持されることを検証する新規テストを追加