### PR TITLE
fix: MaxProbeInterval削減 & イシュー巡回定期トリガー追加

### DIFF
--- a/internal/agent/dormancy.go
+++ b/internal/agent/dormancy.go
@@ -11,7 +11,9 @@ import (
 const DefaultProbeInterval = 15 * time.Minute
 
 // MaxProbeInterval is the upper bound for exponential backoff.
-const MaxProbeInterval = 60 * time.Minute
+// Anthropic API rate limits typically clear within a few minutes,
+// so 5 minutes is sufficient as a cap.
+const MaxProbeInterval = 5 * time.Minute
 
 // ProbeFunc tests whether the rate limit has been lifted.
 // It should return nil if the limit is cleared.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -50,7 +50,7 @@ type AgentConfig struct {
 	GeminiRPM int `toml:"gemini_rpm"`
 	// DormancyProbeMinutes is the initial interval between rate-limit recovery probes
 	// when all agents enter dormancy due to a rate limit error.
-	// The interval doubles after each failed probe (exponential backoff), up to 60 minutes.
+	// The interval doubles after each failed probe (exponential backoff), up to 5 minutes.
 	// Shorter values help recover faster from transient rate limits (useful for Gemini).
 	// Defaults to 3 minutes.
 	DormancyProbeMinutes int `toml:"dormancy_probe_minutes"`
@@ -58,6 +58,12 @@ type AgentConfig struct {
 	// to run before being killed. This prevents agents from hanging indefinitely
 	// on commands that never finish. Defaults to 5 minutes.
 	BashTimeoutMinutes int `toml:"bash_timeout_minutes"`
+	// IssuePatrolIntervalMinutes specifies how often the superintendent is prompted
+	// to check for new issues and take action. Without this periodic trigger, the
+	// superintendent only reacts to chatlog messages and may stop patrolling for
+	// issues during long idle periods.
+	// 0 triggers the default of 5 minutes. Set to -1 to disable.
+	IssuePatrolIntervalMinutes int `toml:"issue_patrol_interval_minutes"`
 	// WorktreeCleanupIntervalMinutes specifies how often to check for and remove
 	// orphaned git worktrees (those not associated with any active team).
 	// 0 (default) disables periodic worktree cleanup.
@@ -163,6 +169,9 @@ func setDefaults(cfg *Config) {
 	}
 	if cfg.Agent.BashTimeoutMinutes == 0 {
 		cfg.Agent.BashTimeoutMinutes = 5
+	}
+	if cfg.Agent.IssuePatrolIntervalMinutes == 0 {
+		cfg.Agent.IssuePatrolIntervalMinutes = 5
 	}
 	if cfg.Branches.Main == "" {
 		cfg.Branches.Main = "main"

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -664,6 +664,87 @@ bash_timeout_minutes = 10
 	}
 }
 
+func TestIssuePatrolIntervalMinutesDefault(t *testing.T) {
+	content := `
+[project]
+name = "test-app"
+
+[[project.repos]]
+name = "main"
+path = "."
+`
+	dir := t.TempDir()
+	path := filepath.Join(dir, "madflow.toml")
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if cfg.Agent.IssuePatrolIntervalMinutes != 5 {
+		t.Errorf("expected default issue_patrol_interval_minutes 5, got %d", cfg.Agent.IssuePatrolIntervalMinutes)
+	}
+}
+
+func TestIssuePatrolIntervalMinutesCustom(t *testing.T) {
+	content := `
+[project]
+name = "test-app"
+
+[[project.repos]]
+name = "main"
+path = "."
+
+[agent]
+issue_patrol_interval_minutes = 10
+`
+	dir := t.TempDir()
+	path := filepath.Join(dir, "madflow.toml")
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if cfg.Agent.IssuePatrolIntervalMinutes != 10 {
+		t.Errorf("expected issue_patrol_interval_minutes 10, got %d", cfg.Agent.IssuePatrolIntervalMinutes)
+	}
+}
+
+func TestIssuePatrolIntervalMinutesDisabled(t *testing.T) {
+	content := `
+[project]
+name = "test-app"
+
+[[project.repos]]
+name = "main"
+path = "."
+
+[agent]
+issue_patrol_interval_minutes = -1
+`
+	dir := t.TempDir()
+	path := filepath.Join(dir, "madflow.toml")
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if cfg.Agent.IssuePatrolIntervalMinutes != -1 {
+		t.Errorf("expected issue_patrol_interval_minutes -1 (disabled), got %d", cfg.Agent.IssuePatrolIntervalMinutes)
+	}
+}
+
 func TestGitHubBotCommentPatterns(t *testing.T) {
 	content := `
 [project]

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -215,6 +215,17 @@ func (o *Orchestrator) Run(ctx context.Context) error {
 		}()
 	}
 
+	// Start issue patrol goroutine to periodically prompt the superintendent
+	// to check for new issues. Without this, the superintendent only reacts
+	// to chatlog messages and may stop patrolling during long idle periods.
+	if o.cfg.Agent.IssuePatrolIntervalMinutes > 0 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			o.runIssuePatrol(ctx)
+		}()
+	}
+
 	// Watch chatlog for orchestrator commands
 	wg.Add(1)
 	go func() {
@@ -1033,6 +1044,40 @@ func (o *Orchestrator) runDocCheck(ctx context.Context) {
 		case <-ticker.C:
 			log.Println("[doc-check] sending doc consistency check request to superintendent")
 			o.appendOrLog("superintendent", "orchestrator", docCheckPrompt)
+		}
+	}
+}
+
+// issuePatrolPrompt is the message sent to the superintendent for periodic issue patrol.
+const issuePatrolPrompt = `定期イシュー巡回の時間です。
+
+以下の手順で新規イシューを確認してください：
+
+1. イシューディレクトリを確認し、status="open" または status="in_progress" かつ assigned_team=0 のイシューがないか確認する
+2. 該当イシューがあれば、チーム編成を要求する（TEAM_CREATE）
+3. 進行中のチーム（assigned_team > 0）の状況をチャットログから確認する
+4. resolved 状態のイシューがあればクローズ手続きを行う
+
+特に未割り当てのイシューがないか注意してください。`
+
+// runIssuePatrol periodically prompts the superintendent to check for new issues.
+// This prevents the superintendent from becoming idle during long periods without
+// chatlog messages, which was reported as GitHub Issue #155.
+func (o *Orchestrator) runIssuePatrol(ctx context.Context) {
+	interval := time.Duration(o.cfg.Agent.IssuePatrolIntervalMinutes) * time.Minute
+	log.Printf("[issue-patrol] started (interval: %v)", interval)
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			log.Println("[issue-patrol] stopped")
+			return
+		case <-ticker.C:
+			log.Println("[issue-patrol] sending issue patrol request to superintendent")
+			o.appendOrLog("superintendent", "orchestrator", issuePatrolPrompt)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Closes #155

長時間稼働時にsuperintendentがイシュー巡回を停止する問題を修正しました。

- **MaxProbeInterval を60分から5分に削減**: APIレートリミット発生時の指数バックオフ上限が60分では過剰。Anthropic APIのレートリミットは通常数分で解除されるため、5分キャップで十分
- **runIssuePatrol() を追加**: オーケストレーターから定期的(デフォルト5分間隔)にsuperintendentへイシュー巡回を促すメッセージを送信。`issue_patrol_interval_minutes` 設定で間隔カスタマイズ可能(-1で無効化)

## 根本原因

1. `dormancy.go`の`MaxProbeInterval = 60 * time.Minute`が大きすぎ、レートリミット時に最大60分間dormancy状態が継続
2. superintendentはメッセージ駆動のため、チャットログに新規メッセージが来ない長時間アイドル期間中にイシュー巡回が停止

## 変更ファイル

| ファイル | 変更内容 |
|---------|---------|
| `internal/agent/dormancy.go` | MaxProbeInterval: 60分 → 5分 |
| `internal/config/config.go` | `issue_patrol_interval_minutes` 設定追加、コメント更新 |
| `internal/config/config_test.go` | IssuePatrol設定のテスト3件追加 |
| `internal/orchestrator/orchestrator.go` | `runIssuePatrol()` 関数追加 |

## Test plan

- [x] `go test ./internal/agent/...` - 全テストパス
- [x] `go test ./internal/config/...` - 全テストパス (新規3件含む)
- [x] `go build ./...` - ビルド成功

**注記**: エンジニア・オーケストレーター無応答のため監督(superintendent)が直接実装しました。