### PR TITLE
chore: sync main into develop for v0.3.0 release

### DIFF
--- a/internal/chatlog/bench_test.go
+++ b/internal/chatlog/bench_test.go
@@ -1,0 +1,48 @@
+package chatlog
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func BenchmarkParseMessage(b *testing.B) {
+	line := "[2026-01-01T00:00:00] [@recipient] sender: hello world benchmark message"
+	for b.Loop() {
+		_, _ = ParseMessage(line)
+	}
+}
+
+func BenchmarkParseMessageInvalid(b *testing.B) {
+	line := "this is not a valid chatlog line"
+	for b.Loop() {
+		_, _ = ParseMessage(line)
+	}
+}
+
+func BenchmarkChatLogPoll(b *testing.B) {
+	dir := b.TempDir()
+	path := filepath.Join(dir, "chatlog.txt")
+
+	// Pre-fill with 100 messages
+	f, err := os.Create(path)
+	if err != nil {
+		b.Fatalf("setup failed: %v", err)
+	}
+	for i := range 100 {
+		fmt.Fprintf(f, "[2026-01-01T00:00:00] [@engineer-1] superintendent: message %d\n", i)
+	}
+	f.Close()
+
+	cl := New(path)
+	for b.Loop() {
+		_, _ = cl.Poll("engineer-1")
+	}
+}
+
+func BenchmarkFormatMessage(b *testing.B) {
+	for b.Loop() {
+		_ = FormatMessage("recipient", "sender", "hello world benchmark message")
+	}
+}

--- a/internal/issue/bench_test.go
+++ b/internal/issue/bench_test.go
@@ -1,0 +1,62 @@
+package issue
+
+import (
+	"fmt"
+	"testing"
+)
+
+func BenchmarkStoreCreate(b *testing.B) {
+	dir := b.TempDir()
+	s := NewStore(dir)
+	for b.Loop() {
+		_, _ = s.Create("benchmark title", "benchmark body")
+	}
+}
+
+func BenchmarkStoreGet(b *testing.B) {
+	dir := b.TempDir()
+	s := NewStore(dir)
+	iss, err := s.Create("benchmark title", "benchmark body")
+	if err != nil {
+		b.Fatalf("setup failed: %v", err)
+	}
+	for b.Loop() {
+		_, _ = s.Get(iss.ID)
+	}
+}
+
+func BenchmarkStoreList10(b *testing.B) {
+	dir := b.TempDir()
+	s := NewStore(dir)
+	for i := range 10 {
+		_, _ = s.Create(fmt.Sprintf("title %d", i), "body")
+	}
+	for b.Loop() {
+		_, _ = s.List(StatusFilter{})
+	}
+}
+
+func BenchmarkStoreUpdate(b *testing.B) {
+	dir := b.TempDir()
+	s := NewStore(dir)
+	iss, err := s.Create("benchmark title", "benchmark body")
+	if err != nil {
+		b.Fatalf("setup failed: %v", err)
+	}
+	n := 0
+	for b.Loop() {
+		iss.Title = fmt.Sprintf("title %d", n)
+		n++
+		_ = s.Update(iss)
+	}
+}
+
+func BenchmarkHasComment(b *testing.B) {
+	iss := &Issue{}
+	for i := range 100 {
+		iss.Comments = append(iss.Comments, Comment{ID: int64(i)})
+	}
+	for b.Loop() {
+		_ = iss.HasComment(99)
+	}
+}


### PR DESCRIPTION
## Summary
- main ブランチのホットフィックスコミット (ベンチマークテスト追加) を develop に同期
- PR #161 (develop→main v0.3.0リリース) のマージ準備として必要

## Context
PR #161 がマージできない原因: develop が main の最新コミットを含んでいないため、ブランチ保護ルールにより拒否されている。
このPRをマージすることで develop が main と同期し、PR #161 のマージが可能になる。