### PR TITLE
fix: watchCommands を startAllTeams 直後に起動して TEAM_CREATE の取りこぼしを防止 (local-001)

### DIFF
--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -140,6 +140,22 @@ func (o *Orchestrator) Run(ctx context.Context) error {
 
 	o.startAllTeams(ctx)
 
+	// Start watching chatlog for orchestrator commands IMMEDIATELY after teams
+	// are launched — before waitForAgentsReady() — so that TEAM_CREATE messages
+	// written by the superintendent during its initial prompt processing (via
+	// Bash tool-calls) are not missed.
+	//
+	// Root-cause of the local-001 regression: watchCommands() used to start
+	// after waitForAgentsReady(). chatlog.Watch() records the file offset at
+	// call time; any TEAM_CREATE written before that point was skipped forever.
+	// Moving watchCommands here ensures offset=0 (empty chatlog) and all
+	// subsequent writes are observed correctly.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		o.watchCommands(ctx)
+	}()
+
 	// If context was cancelled during team startup (e.g. Ctrl+C or SIGTERM
 	// while agents were initialising), skip the ready-wait and go straight
 	// to the graceful shutdown path so we don't surface a confusing
@@ -225,13 +241,6 @@ func (o *Orchestrator) Run(ctx context.Context) error {
 			o.runIssuePatrol(ctx)
 		}()
 	}
-
-	// Watch chatlog for orchestrator commands
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		o.watchCommands(ctx)
-	}()
 
 	// Start config hot-reload watcher if a config path is set
 	if o.configPath != "" {

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -1027,6 +1027,79 @@ func TestHandleTeamCreateCreatesNewTeamWhenNoIdle(t *testing.T) {
 }
 
 // TestRunGracefulShutdownDuringStartup verifies that Run returns nil (not an
+// TestWatchCommandsPicksUpEarlyTeamCreate is a regression test for local-001.
+//
+// Root cause: watchCommands() was previously started AFTER waitForAgentsReady().
+// chatlog.Watch() records the current file offset when called; any TEAM_CREATE
+// messages written to the chatlog by the superintendent's initial-prompt tool-
+// calls appeared BEFORE that offset and were therefore never delivered.
+//
+// Fix: watchCommands() is now launched right after startAllTeams(), before
+// waitForAgentsReady(). With the chatlog freshly cleared at startup, the
+// Watch() offset is 0, so every subsequent write — including TEAM_CREATE
+// commands from the superintendent's initial prompt — is observed.
+//
+// This test verifies the post-fix behaviour: a TEAM_CREATE written to the
+// chatlog while watchCommands() is running must be picked up and processed.
+func TestWatchCommandsPicksUpEarlyTeamCreate(t *testing.T) {
+	dir := t.TempDir()
+	issuesDir := filepath.Join(dir, "issues")
+	os.MkdirAll(issuesDir, 0755)
+	os.MkdirAll(filepath.Join(dir, "memos"), 0755)
+
+	// Clear chatlog to simulate Run() startup state.
+	chatlogPath := filepath.Join(dir, "chatlog.txt")
+	os.WriteFile(chatlogPath, nil, 0644)
+
+	cfg := testConfig(dir)
+	orc := New(cfg, dir, t.TempDir())
+
+	// Create an open issue that the superintendent would want to assign.
+	store := orc.Store()
+	iss, err := store.Create("テスト機能", "テスト本文")
+	if err != nil {
+		t.Fatalf("create issue: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+
+	// Launch watchCommands() early — this is the post-fix behaviour where it
+	// starts before waitForAgentsReady() with offset=0 on the fresh chatlog.
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		orc.watchCommands(ctx)
+	}()
+
+	// Give the Watch() goroutine time to set up its ticker (500 ms interval).
+	time.Sleep(100 * time.Millisecond)
+
+	// Simulate the superintendent writing TEAM_CREATE during initial-prompt
+	// processing (i.e. before it would call markReady()).
+	cl := chatlog.New(chatlogPath)
+	if err := cl.Append("orchestrator", "superintendent", "TEAM_CREATE "+iss.ID); err != nil {
+		t.Fatalf("append TEAM_CREATE: %v", err)
+	}
+
+	// Poll until the issue transitions to in_progress (watchCommands processed
+	// the TEAM_CREATE and handleTeamCreate updated the status).
+	deadline := time.Now().Add(4 * time.Second)
+	for time.Now().Before(deadline) {
+		updated, getErr := store.Get(iss.ID)
+		if getErr == nil && updated.Status == issue.StatusInProgress {
+			cancel() // success — stop watchCommands
+			<-done
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	cancel()
+	<-done
+	t.Error("TEAM_CREATE written before agents are ready was not processed — watchCommands may have started too late")
+}
+
 // error) when the context is cancelled while startAllTeams is still running.
 // Previously the system returned "wait for agents ready: context canceled"
 // which looked like a crash to the user (GitHub Issue #104).


### PR DESCRIPTION
## 概要

### 根本原因 (local-001)

オーケストレーター無応答の根本原因は **`watchCommands()` の起動タイミング**にあった。

従来の起動順序:
1. `startAllTeams()` — エンジニアエージェント起動
2. `waitForAgentsReady()` — エージェントの初期化完了待ち（数分かかる場合あり）
3. **`watchCommands()` ← ここで初めて chatlog の監視を開始**

`chatlog.Watch()` はコール時点のファイルオフセットを記録する。そのため、
監督エージェントが初期プロンプト処理中（`waitForAgentsReady()` 完了前）に
Bash ツール経由で chatlog に書き込んだ `TEAM_CREATE` コマンドは、
`watchCommands()` が起動した時点では「過去のオフセット」に存在しており、
**永遠にスキップされる**という問題が発生していた。

### 修正内容

`watchCommands()` を `startAllTeams()` 直後（`waitForAgentsReady()` より前）に
起動するよう移動した。

`Run()` 起動時に chatlog は空にリセット済みのため `Watch()` のオフセットは 0 から始まり、
その後に書き込まれる全メッセージ（監督の初期プロンプトからの `TEAM_CREATE` を含む）が
確実に観測される。

### 変更ファイル

- `internal/orchestrator/orchestrator.go`: `watchCommands()` 起動位置を移動
- `internal/orchestrator/orchestrator_test.go`: リグレッションテスト `TestWatchCommandsPicksUpEarlyTeamCreate` を追加

### テスト計画

- [x] `go build ./...` — ビルド成功
- [x] `go test ./...` — 全 13 パッケージのテスト通過
- [x] `TestWatchCommandsPicksUpEarlyTeamCreate` — 新規リグレッションテスト通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)