### PR TITLE
feat: add configurable agent message language

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -24,6 +24,7 @@ type Agent struct {
 	ResetInterval time.Duration
 	SystemPrompt  string
 	OriginalTask  string
+	Language      string
 	Dormancy      *Dormancy
 	Throttle      *Throttle
 	ready         chan struct{}
@@ -41,6 +42,7 @@ type AgentConfig struct {
 	ResetInterval time.Duration
 	BashTimeout   time.Duration
 	OriginalTask  string
+	Language      string
 	Process       Process
 	Dormancy      *Dormancy
 	Throttle      *Throttle
@@ -68,6 +70,11 @@ func NewAgent(cfg AgentConfig) *Agent {
 		}
 	}
 
+	lang := cfg.Language
+	if lang == "" {
+		lang = "en"
+	}
+
 	return &Agent{
 		ID:            cfg.ID,
 		Process:       proc,
@@ -76,6 +83,7 @@ func NewAgent(cfg AgentConfig) *Agent {
 		ResetInterval: cfg.ResetInterval,
 		SystemPrompt:  cfg.SystemPrompt,
 		OriginalTask:  cfg.OriginalTask,
+		Language:      lang,
 		Dormancy:      cfg.Dormancy,
 		Throttle:      cfg.Throttle,
 		ready:         make(chan struct{}),
@@ -130,7 +138,7 @@ func (a *Agent) Run(ctx context.Context, msgCh <-chan chatlog.Message) error {
 					log.Printf("[%s] reset failed: %v", recipient, err)
 				}
 			}
-			prompt := buildMessagePrompt(messages)
+			prompt := buildMessagePrompt(messages, a.Language)
 			response, err := a.send(ctx, prompt)
 			if err != nil {
 				if ctx.Err() != nil {
@@ -152,17 +160,18 @@ func (a *Agent) Run(ctx context.Context, msgCh <-chan chatlog.Message) error {
 }
 
 // buildMessagePrompt creates a single prompt from one or more messages.
-func buildMessagePrompt(messages []chatlog.Message) string {
-	if len(messages) == 1 {
-		return fmt.Sprintf("チャットログに新しいメッセージがあります:\n\n%s\n\n適切に対応してください。", messages[0].Raw)
+func buildMessagePrompt(msgs []chatlog.Message, lang string) string {
+	m := getMessages(lang)
+	if len(msgs) == 1 {
+		return fmt.Sprintf(m.NewMessageSingle, msgs[0].Raw)
 	}
 	var sb strings.Builder
-	sb.WriteString(fmt.Sprintf("チャットログに新しいメッセージが %d 件あります:\n\n", len(messages)))
-	for _, m := range messages {
-		sb.WriteString(m.Raw)
+	sb.WriteString(fmt.Sprintf(m.NewMessageMultiple, len(msgs)))
+	for _, msg := range msgs {
+		sb.WriteString(msg.Raw)
 		sb.WriteString("\n")
 	}
-	sb.WriteString("\nすべてのメッセージに適切に対応してください。")
+	sb.WriteString(m.RespondAll)
 	return sb.String()
 }
 
@@ -192,13 +201,13 @@ func (a *Agent) performReset(ctx context.Context, timer *reset.Timer) error {
 	recipient := a.ID.String()
 	log.Printf("[%s] context reset triggered", recipient)
 
-	distilled, err := a.send(ctx, reset.DistillPrompt)
+	distilled, err := a.send(ctx, reset.GetDistillPrompt(a.Language))
 	if err != nil {
 		return fmt.Errorf("distill failed: %w", err)
 	}
 
 	memo := parseDistilledMemo(recipient, distilled)
-	memoPath, err := reset.SaveMemo(a.MemosDir, memo)
+	memoPath, err := reset.SaveMemoWithLang(a.MemosDir, memo, a.Language)
 	if err != nil {
 		return fmt.Errorf("save memo: %w", err)
 	}
@@ -220,31 +229,29 @@ func (a *Agent) performReset(ctx context.Context, timer *reset.Timer) error {
 }
 
 func (a *Agent) buildInitialPrompt(memo string) string {
+	m := getMessages(a.Language)
 	var sb strings.Builder
-	sb.WriteString("あなたは以下の役割で動作するエージェントです。\n\n")
+	sb.WriteString(m.RoleIntro)
 	if a.OriginalTask != "" {
-		sb.WriteString("## 元の依頼内容\n")
+		sb.WriteString(m.OriginalTaskHeader)
 		sb.WriteString(a.OriginalTask)
 		sb.WriteString("\n\n")
 	}
 	if memo != "" {
-		sb.WriteString("## 直近の作業メモ（前回のコンテキストリセットから引き継ぎ）\n")
+		sb.WriteString(m.MemoHeader)
 		sb.WriteString(memo)
 		sb.WriteString("\n\n")
 	}
-	sb.WriteString("チャットログのパス: ")
+	sb.WriteString(m.ChatLogPathLabel)
 	sb.WriteString(a.ChatLog.Path())
 	sb.WriteString("\n\n")
-	sb.WriteString("チャットログへの書き込みには以下のコマンドを使用してください:\n")
+	sb.WriteString(m.ChatLogWriteInstr)
 	sb.WriteString(fmt.Sprintf(`echo "[$(date +%%Y-%%m-%%dT%%H:%%M:%%S)] [@宛先] %s: メッセージ内容" >> %s`, a.ID.String(), a.ChatLog.Path()))
 	sb.WriteString("\n\n")
 	if a.OriginalTask != "" {
-		// イシューが割り当て済みの場合は即座に実装開始を指示する。
-		// これにより、チャットログ経由の割り当てメッセージが届かなかった場合でも
-		// エンジニアが作業を開始できる。
-		sb.WriteString("上記の依頼内容に従い、すぐに実装を開始してください。実装完了後は監督に報告してください。その後もチャットログへのメンションを監視し、追加の指示に対応してください。")
+		sb.WriteString(m.StartImplement)
 	} else {
-		sb.WriteString("自分宛のメンションがチャットログに投稿されるのを待ち、適切に対応してください。")
+		sb.WriteString(m.WaitForMention)
 	}
 	return sb.String()
 }
@@ -271,14 +278,14 @@ func parseDistilledMemo(agentID, raw string) reset.WorkMemo {
 }
 
 const (
-	sendMaxRetries     = 3
-	sendRetryBaseWait  = 2 * time.Second
-	maxContinuations   = 3 // max auto-continuations on MaxIterationsError (total: 4 × 25 = 100 tool calls)
-	continuationPrompt = "作業の途中で中断されました。現在のディレクトリの状態を確認し（git status等）、中断した作業を再開してください。"
+	sendMaxRetries    = 3
+	sendRetryBaseWait = 2 * time.Second
+	maxContinuations  = 3 // max auto-continuations on MaxIterationsError (total: 4 × 25 = 100 tool calls)
 )
 
 func (a *Agent) send(ctx context.Context, prompt string) (string, error) {
 	currentPrompt := prompt
+	m := getMessages(a.Language)
 	for continuation := 0; ; continuation++ {
 		resp, err := a.sendOnce(ctx, currentPrompt)
 
@@ -286,7 +293,7 @@ func (a *Agent) send(ctx context.Context, prompt string) (string, error) {
 		var maxIterErr *MaxIterationsError
 		if errors.As(err, &maxIterErr) && continuation < maxContinuations {
 			log.Printf("[%s] max iterations reached, continuing (%d/%d)", a.ID.String(), continuation+1, maxContinuations)
-			currentPrompt = continuationPrompt
+			currentPrompt = m.Continuation
 			continue
 		}
 

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -58,7 +58,7 @@ func TestBuildInitialPrompt(t *testing.T) {
 
 	prompt := agent.buildInitialPrompt("")
 
-	if !strings.Contains(prompt, "元の依頼内容") {
+	if !strings.Contains(prompt, "Original Request") {
 		t.Error("expected original task in prompt")
 	}
 	if !strings.Contains(prompt, "Issue #001 の管理") {
@@ -67,7 +67,7 @@ func TestBuildInitialPrompt(t *testing.T) {
 	if !strings.Contains(prompt, "/tmp/test/chatlog.txt") {
 		t.Error("expected chatlog path in prompt")
 	}
-	if strings.Contains(prompt, "作業メモ") {
+	if strings.Contains(prompt, "Work Memo") || strings.Contains(prompt, "作業メモ") {
 		t.Error("should not contain memo section when memo is empty")
 	}
 }
@@ -81,7 +81,7 @@ func TestBuildInitialPromptWithMemo(t *testing.T) {
 
 	prompt := agent.buildInitialPrompt("前回の作業状態")
 
-	if !strings.Contains(prompt, "作業メモ") {
+	if !strings.Contains(prompt, "work memo") && !strings.Contains(prompt, "Work Memo") && !strings.Contains(prompt, "inherited from last context reset") {
 		t.Error("expected memo section in prompt")
 	}
 	if !strings.Contains(prompt, "前回の作業状態") {
@@ -103,11 +103,11 @@ func TestBuildInitialPromptWithOriginalTaskStartsImmediately(t *testing.T) {
 	prompt := ag.buildInitialPrompt("")
 
 	// OriginalTask がある場合は即座に実装開始を指示する
-	if !strings.Contains(prompt, "実装を開始してください") {
-		t.Error("expected prompt to contain '実装を開始してください' when OriginalTask is set")
+	if !strings.Contains(prompt, "start implementation immediately") {
+		t.Error("expected prompt to contain 'start implementation immediately' when OriginalTask is set")
 	}
 	// スタンバイ時の待機指示は含まれないはず
-	if strings.Contains(prompt, "投稿されるのを待ち") {
+	if strings.Contains(prompt, "Wait for mentions") {
 		t.Error("expected prompt NOT to contain wait instruction when OriginalTask is set")
 	}
 }
@@ -124,11 +124,11 @@ func TestBuildInitialPromptWithoutOriginalTaskWaits(t *testing.T) {
 	prompt := ag.buildInitialPrompt("")
 
 	// OriginalTask がない場合はチャットログのメッセージを待つ
-	if !strings.Contains(prompt, "投稿されるのを待ち") {
+	if !strings.Contains(prompt, "Wait for mentions") {
 		t.Error("expected prompt to contain wait instruction when OriginalTask is empty")
 	}
 	// 実装開始の指示は含まれないはず
-	if strings.Contains(prompt, "実装を開始してください") {
+	if strings.Contains(prompt, "start implementation immediately") {
 		t.Error("expected prompt NOT to contain immediate start instruction when OriginalTask is empty")
 	}
 }
@@ -380,7 +380,7 @@ func TestSendContinuation(t *testing.T) {
 	}
 	// Second and third calls should use continuation prompt
 	for i := 1; i < len(proc.lastPrompts); i++ {
-		if proc.lastPrompts[i] != continuationPrompt {
+		if proc.lastPrompts[i] != getMessages("en").Continuation {
 			t.Errorf("call %d: expected continuation prompt, got %q", i+1, proc.lastPrompts[i])
 		}
 	}

--- a/internal/agent/language.go
+++ b/internal/agent/language.go
@@ -1,0 +1,63 @@
+package agent
+
+// messages holds localized message templates for agent communication.
+type messages struct {
+	// Initial prompt messages
+	RoleIntro          string // "You are an agent operating in the following role."
+	OriginalTaskHeader string // "## Original Request"
+	MemoHeader         string // "## Recent work memo (inherited from last context reset)"
+	ChatLogPathLabel   string // "Chat log path: "
+	ChatLogWriteInstr  string // "Use the following command to write to the chat log:"
+	WaitForMention     string // "Wait for mentions addressed to you in the chat log, and respond appropriately."
+	StartImplement     string // "Follow the request above and start implementation immediately. Report to the superintendent when done. Continue monitoring the chat log for mentions and respond to additional instructions."
+
+	// Message prompt messages
+	NewMessageSingle   string // "There is a new message in the chat log:"
+	NewMessageMultiple string // "There are %d new messages in the chat log:"
+	RespondAll         string // "Respond appropriately to all messages."
+	RespondSingle      string // "Respond appropriately."
+
+	// Continuation prompt
+	Continuation string // "Work was interrupted midway. Check the current directory state (git status, etc.) and resume the interrupted work."
+}
+
+// langMessages maps language codes to their message sets.
+var langMessages = map[string]messages{
+	"en": {
+		RoleIntro:          "You are an agent operating in the following role.\n\n",
+		OriginalTaskHeader: "## Original Request\n",
+		MemoHeader:         "## Recent work memo (inherited from last context reset)\n",
+		ChatLogPathLabel:   "Chat log path: ",
+		ChatLogWriteInstr:  "Use the following command to write to the chat log:\n",
+		WaitForMention:     "Wait for mentions addressed to you in the chat log, and respond appropriately.",
+		StartImplement:     "Follow the request above and start implementation immediately. Report to the superintendent when done. Continue monitoring the chat log for mentions and respond to additional instructions.",
+		NewMessageSingle:   "There is a new message in the chat log:\n\n%s\n\nRespond appropriately.",
+		NewMessageMultiple: "There are %d new messages in the chat log:\n\n",
+		RespondAll:         "\nRespond appropriately to all messages.",
+		RespondSingle:      "Respond appropriately.",
+		Continuation:       "Work was interrupted midway. Check the current directory state (git status, etc.) and resume the interrupted work.",
+	},
+	"ja": {
+		RoleIntro:          "あなたは以下の役割で動作するエージェントです。\n\n",
+		OriginalTaskHeader: "## 元の依頼内容\n",
+		MemoHeader:         "## 直近の作業メモ（前回のコンテキストリセットから引き継ぎ）\n",
+		ChatLogPathLabel:   "チャットログのパス: ",
+		ChatLogWriteInstr:  "チャットログへの書き込みには以下のコマンドを使用してください:\n",
+		WaitForMention:     "自分宛のメンションがチャットログに投稿されるのを待ち、適切に対応してください。",
+		StartImplement:     "上記の依頼内容に従い、すぐに実装を開始してください。実装完了後は監督に報告してください。その後もチャットログへのメンションを監視し、追加の指示に対応してください。",
+		NewMessageSingle:   "チャットログに新しいメッセージがあります:\n\n%s\n\n適切に対応してください。",
+		NewMessageMultiple: "チャットログに新しいメッセージが %d 件あります:\n\n",
+		RespondAll:         "\nすべてのメッセージに適切に対応してください。",
+		RespondSingle:      "適切に対応してください。",
+		Continuation:       "作業の途中で中断されました。現在のディレクトリの状態を確認し（git status等）、中断した作業を再開してください。",
+	},
+}
+
+// getMessages returns the message set for the given language code.
+// Falls back to English if the language is not supported.
+func getMessages(lang string) messages {
+	if m, ok := langMessages[lang]; ok {
+		return m
+	}
+	return langMessages["en"]
+}

--- a/internal/agent/language_test.go
+++ b/internal/agent/language_test.go
@@ -1,0 +1,66 @@
+package agent
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/ytnobody/madflow/internal/chatlog"
+)
+
+func TestGetMessagesEN(t *testing.T) {
+	m := getMessages("en")
+	if !strings.Contains(m.RoleIntro, "agent operating") {
+		t.Errorf("expected English role intro, got %q", m.RoleIntro)
+	}
+	if !strings.Contains(m.Continuation, "interrupted") {
+		t.Errorf("expected English continuation, got %q", m.Continuation)
+	}
+}
+
+func TestGetMessagesJA(t *testing.T) {
+	m := getMessages("ja")
+	if !strings.Contains(m.RoleIntro, "エージェント") {
+		t.Errorf("expected Japanese role intro, got %q", m.RoleIntro)
+	}
+	if !strings.Contains(m.Continuation, "中断") {
+		t.Errorf("expected Japanese continuation, got %q", m.Continuation)
+	}
+}
+
+func TestGetMessagesUnknownFallsBackToEN(t *testing.T) {
+	m := getMessages("fr")
+	en := getMessages("en")
+	if m.RoleIntro != en.RoleIntro {
+		t.Errorf("expected fallback to English, got %q", m.RoleIntro)
+	}
+}
+
+func TestBuildMessagePromptEN(t *testing.T) {
+	msgs := []chatlog.Message{{Raw: "test message"}}
+	result := buildMessagePrompt(msgs, "en")
+	if !strings.Contains(result, "new message") {
+		t.Errorf("expected English message prompt, got %q", result)
+	}
+	if !strings.Contains(result, "test message") {
+		t.Errorf("expected message content, got %q", result)
+	}
+}
+
+func TestBuildMessagePromptJA(t *testing.T) {
+	msgs := []chatlog.Message{{Raw: "テストメッセージ"}}
+	result := buildMessagePrompt(msgs, "ja")
+	if !strings.Contains(result, "チャットログ") {
+		t.Errorf("expected Japanese message prompt, got %q", result)
+	}
+}
+
+func TestBuildMessagePromptMultiple(t *testing.T) {
+	msgs := []chatlog.Message{
+		{Raw: "message 1"},
+		{Raw: "message 2"},
+	}
+	result := buildMessagePrompt(msgs, "en")
+	if !strings.Contains(result, "2 new messages") {
+		t.Errorf("expected '2 new messages', got %q", result)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -71,6 +71,10 @@ type AgentConfig struct {
 	// ExtraPrompt is appended to the system prompt of every agent.
 	// Use this to inject project-specific instructions that apply to all agents.
 	ExtraPrompt string `toml:"extra_prompt"`
+	// Language specifies the language for agent messages (e.g. "en", "ja").
+	// Defaults to "en". This controls the language of internal agent
+	// communication messages such as chatlog prompts and initial instructions.
+	Language string `toml:"language"`
 }
 
 type ModelConfig struct {
@@ -172,6 +176,9 @@ func setDefaults(cfg *Config) {
 	}
 	if cfg.Agent.IssuePatrolIntervalMinutes == 0 {
 		cfg.Agent.IssuePatrolIntervalMinutes = 5
+	}
+	if cfg.Agent.Language == "" {
+		cfg.Agent.Language = "en"
 	}
 	if cfg.Branches.Main == "" {
 		cfg.Branches.Main = "main"

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -781,6 +781,59 @@ bot_comment_patterns = ["^\\*\\*\\[", "\\[bot\\]$"]
 	}
 }
 
+func TestLanguageDefault(t *testing.T) {
+	content := `
+[project]
+name = "test-app"
+
+[[project.repos]]
+name = "main"
+path = "."
+`
+	dir := t.TempDir()
+	path := filepath.Join(dir, "madflow.toml")
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if cfg.Agent.Language != "en" {
+		t.Errorf("expected default language 'en', got %q", cfg.Agent.Language)
+	}
+}
+
+func TestLanguageCustom(t *testing.T) {
+	content := `
+[project]
+name = "test-app"
+
+[[project.repos]]
+name = "main"
+path = "."
+
+[agent]
+language = "ja"
+`
+	dir := t.TempDir()
+	path := filepath.Join(dir, "madflow.toml")
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if cfg.Agent.Language != "ja" {
+		t.Errorf("expected language 'ja', got %q", cfg.Agent.Language)
+	}
+}
+
 func TestGitHubBotCommentPatterns_Empty(t *testing.T) {
 	// When bot_comment_patterns is not configured, it should default to nil/empty.
 	content := `

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -372,6 +372,7 @@ func (o *Orchestrator) startResidentAgents(ctx context.Context, wg *sync.WaitGro
 			MemosDir:      filepath.Join(o.dataDir, "memos"),
 			ResetInterval: resetInterval,
 			BashTimeout:   bashTimeout,
+			Language:      o.cfg.Agent.Language,
 			Dormancy:      o.dormancy,
 		}
 		if strings.HasPrefix(r.model, "gemini-") {
@@ -976,6 +977,7 @@ func (o *Orchestrator) CreateTeamAgents(teamNum int, issueID string) (engineer *
 			ResetInterval: resetInterval,
 			BashTimeout:   bashTimeout,
 			OriginalTask:  originalTask,
+			Language:      o.cfg.Agent.Language,
 			Dormancy:      o.dormancy,
 		}
 		if strings.HasPrefix(r.model, "gemini-") {

--- a/internal/reset/reset.go
+++ b/internal/reset/reset.go
@@ -19,6 +19,11 @@ type WorkMemo struct {
 
 // SaveMemo writes a work memo to the memos directory.
 func SaveMemo(memosDir string, memo WorkMemo) (string, error) {
+	return SaveMemoWithLang(memosDir, memo, "")
+}
+
+// SaveMemoWithLang writes a work memo to the memos directory with localized headers.
+func SaveMemoWithLang(memosDir string, memo WorkMemo, lang string) (string, error) {
 	if err := os.MkdirAll(memosDir, 0755); err != nil {
 		return "", fmt.Errorf("create memos dir: %w", err)
 	}
@@ -29,7 +34,10 @@ func SaveMemo(memosDir string, memo WorkMemo) (string, error) {
 	)
 	path := filepath.Join(memosDir, filename)
 
-	content := fmt.Sprintf(`# 作業メモ: %s
+	var content string
+	switch lang {
+	case "ja":
+		content = fmt.Sprintf(`# 作業メモ: %s
 日時: %s
 
 ## 現在の状態
@@ -44,13 +52,37 @@ func SaveMemo(memosDir string, memo WorkMemo) (string, error) {
 ## 次の一手
 %s
 `,
-		memo.AgentID,
-		memo.Timestamp.Format("2006-01-02 15:04:05"),
-		memo.CurrentState,
-		memo.Decisions,
-		memo.OpenIssues,
-		memo.NextStep,
-	)
+			memo.AgentID,
+			memo.Timestamp.Format("2006-01-02 15:04:05"),
+			memo.CurrentState,
+			memo.Decisions,
+			memo.OpenIssues,
+			memo.NextStep,
+		)
+	default:
+		content = fmt.Sprintf(`# Work Memo: %s
+Date: %s
+
+## Current State
+%s
+
+## Decisions
+%s
+
+## Open Issues
+%s
+
+## Next Step
+%s
+`,
+			memo.AgentID,
+			memo.Timestamp.Format("2006-01-02 15:04:05"),
+			memo.CurrentState,
+			memo.Decisions,
+			memo.OpenIssues,
+			memo.NextStep,
+		)
+	}
 
 	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
 		return "", fmt.Errorf("write memo: %w", err)
@@ -124,8 +156,23 @@ func (t *Timer) Reset() {
 	t.started = time.Now()
 }
 
-// DistillPrompt returns the prompt to send to Claude to extract a work memo.
-const DistillPrompt = `あなたの現在の作業状態を以下の4項目で簡潔にまとめてください。各項目は1-3文で記述してください。
+// DistillPrompt is the default (Japanese) prompt for backward compatibility.
+const DistillPrompt = distillPromptJA
+
+const distillPromptEN = `Please summarize your current work state in the following 4 items concisely. Each item should be 1-3 sentences.
+
+1. Current state: What you are currently doing
+2. Decisions: What has been decided so far
+3. Open issues: Problems that have not been resolved yet
+4. Next step: What should be done next
+
+Please output in the following format:
+STATE: <current state>
+DECISIONS: <decisions>
+OPEN: <open issues>
+NEXT: <next step>`
+
+const distillPromptJA = `あなたの現在の作業状態を以下の4項目で簡潔にまとめてください。各項目は1-3文で記述してください。
 
 1. 現在の状態: 今何をしているか
 2. 決定事項: これまでに決まったこと
@@ -137,3 +184,13 @@ STATE: <現在の状態>
 DECISIONS: <決定事項>
 OPEN: <未解決の課題>
 NEXT: <次の一手>`
+
+// GetDistillPrompt returns the distill prompt for the given language.
+func GetDistillPrompt(lang string) string {
+	switch lang {
+	case "ja":
+		return distillPromptJA
+	default:
+		return distillPromptEN
+	}
+}


### PR DESCRIPTION
## Summary

- Add `language` setting to `[agent]` section in `madflow.toml` (default: `"en"`, supports `"ja"`)
- Localize all internal agent communication messages (chatlog prompts, initial instructions, context reset memos, distill prompts)
- Add `internal/agent/language.go` with message templates for English and Japanese

Closes #171

**Note:** Implemented directly by superintendent due to orchestrator/engineer unavailability (TEAM_CREATE requested 3 times with no response).

## Test plan

- [x] `go build ./...` passes
- [x] New tests for language selection (`TestGetMessagesEN`, `TestGetMessagesJA`, `TestGetMessagesUnknownFallsBackToEN`)
- [x] New tests for message prompt localization (`TestBuildMessagePromptEN`, `TestBuildMessagePromptJA`, `TestBuildMessagePromptMultiple`)
- [x] Config tests for default and custom language settings (`TestLanguageDefault`, `TestLanguageCustom`)
- [x] Updated existing tests to work with English default
- [x] `go test ./internal/agent/... ./internal/config/... ./internal/reset/...` all pass