### PR TITLE
feat: reduce chatlog bloat from issue patrol reminders

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -62,7 +62,9 @@ type AgentConfig struct {
 	// to check for new issues and take action. Without this periodic trigger, the
 	// superintendent only reacts to chatlog messages and may stop patrolling for
 	// issues during long idle periods.
-	// 0 triggers the default of 5 minutes. Set to -1 to disable.
+	// The patrol is suppressed when the chatlog has not changed since the last
+	// reminder, and the timer is reset whenever the superintendent sends a message.
+	// 0 triggers the default of 20 minutes. Set to -1 to disable.
 	IssuePatrolIntervalMinutes int `toml:"issue_patrol_interval_minutes"`
 	// WorktreeCleanupIntervalMinutes specifies how often to check for and remove
 	// orphaned git worktrees (those not associated with any active team).
@@ -175,7 +177,7 @@ func setDefaults(cfg *Config) {
 		cfg.Agent.BashTimeoutMinutes = 5
 	}
 	if cfg.Agent.IssuePatrolIntervalMinutes == 0 {
-		cfg.Agent.IssuePatrolIntervalMinutes = 5
+		cfg.Agent.IssuePatrolIntervalMinutes = 20
 	}
 	if cfg.Agent.Language == "" {
 		cfg.Agent.Language = "en"

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -684,8 +684,8 @@ path = "."
 		t.Fatal(err)
 	}
 
-	if cfg.Agent.IssuePatrolIntervalMinutes != 5 {
-		t.Errorf("expected default issue_patrol_interval_minutes 5, got %d", cfg.Agent.IssuePatrolIntervalMinutes)
+	if cfg.Agent.IssuePatrolIntervalMinutes != 20 {
+		t.Errorf("expected default issue_patrol_interval_minutes 20, got %d", cfg.Agent.IssuePatrolIntervalMinutes)
 	}
 }
 

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -1100,21 +1100,69 @@ const issuePatrolPrompt = `定期イシュー巡回の時間です。
 // runIssuePatrol periodically prompts the superintendent to check for new issues.
 // This prevents the superintendent from becoming idle during long periods without
 // chatlog messages, which was reported as GitHub Issue #155.
+//
+// Improvements to reduce chatlog bloat (local issue local-001):
+//   - Proposal 2: Skips the reminder if the chatlog has not grown since the last
+//     patrol was sent, indicating no new activity.
+//   - Proposal 3: Resets the patrol timer whenever the superintendent sends a
+//     message, so reminders are deferred when the superintendent is already active.
 func (o *Orchestrator) runIssuePatrol(ctx context.Context) {
 	interval := time.Duration(o.cfg.Agent.IssuePatrolIntervalMinutes) * time.Minute
 	log.Printf("[issue-patrol] started (interval: %v)", interval)
 
-	ticker := time.NewTicker(interval)
-	defer ticker.Stop()
+	// Record chatlog size at startup to detect subsequent activity.
+	var lastSize int64
+	if info, err := os.Stat(o.chatLog.Path()); err == nil {
+		lastSize = info.Size()
+	}
+
+	// Watch all chatlog messages so we can detect superintendent activity and
+	// reset the patrol timer (Proposal 3).
+	allMsgCh := o.chatLog.WatchAll(ctx)
+
+	timer := time.NewTimer(interval)
+	defer timer.Stop()
 
 	for {
 		select {
 		case <-ctx.Done():
 			log.Println("[issue-patrol] stopped")
 			return
-		case <-ticker.C:
+
+		case msg, ok := <-allMsgCh:
+			if !ok {
+				return
+			}
+			// Whenever the superintendent sends a message it is actively working;
+			// reset the patrol timer so we don't interrupt it with a reminder.
+			if msg.Sender == "superintendent" {
+				if !timer.Stop() {
+					select {
+					case <-timer.C:
+					default:
+					}
+				}
+				timer.Reset(interval)
+				log.Printf("[issue-patrol] timer reset: superintendent is active")
+			}
+
+		case <-timer.C:
+			// Skip the reminder if the chatlog has not grown since the last patrol
+			// was sent. No new activity means there is nothing new to patrol.
+			info, err := os.Stat(o.chatLog.Path())
+			if err == nil {
+				currentSize := info.Size()
+				if currentSize <= lastSize {
+					log.Println("[issue-patrol] no chatlog activity since last patrol, skipping reminder")
+					timer.Reset(interval)
+					break
+				}
+				lastSize = currentSize
+			}
+
 			log.Println("[issue-patrol] sending issue patrol request to superintendent")
 			o.appendOrLog("superintendent", "orchestrator", issuePatrolPrompt)
+			timer.Reset(interval)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

- Change default `IssuePatrolIntervalMinutes` from 5 to 20 minutes (Proposal 1)
- Skip patrol reminder when chatlog has not grown since the last reminder — no new activity means nothing new to patrol (Proposal 2)
- Reset patrol timer whenever superintendent sends a message, deferring reminders when the superintendent is already active (Proposal 3)

## Background

The orchestrator was sending patrol reminders every 5 minutes regardless of activity, causing chatlog bloat with ~20 lines of identical content per cycle.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes (all packages)
- [x] `TestIssuePatrolIntervalDefault` updated to expect 20 minutes

Resolves: local-001