### PR TITLE
fix: reject TEAM_CREATE early when at max_teams capacity (#180)

### DIFF
--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -1351,6 +1351,9 @@ func (o *Orchestrator) runConfigWatcher(ctx context.Context) {
 			o.cfgMu.Lock()
 			o.cfg = newCfg
 			o.cfgMu.Unlock()
+			// Propagate max_teams changes to the team manager so that
+			// hot-reload updates take effect without restarting the process.
+			o.teams.SetMaxTeams(newCfg.Agent.MaxTeams)
 			log.Println("[config-watcher] active config updated")
 		}
 	}

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -1437,3 +1437,86 @@ func TestHandleTeamCreateRejectsWhenAtMaxCapacityAllBusy(t *testing.T) {
 		t.Error("expected chatlog to contain capacity-limit message for superintendent")
 	}
 }
+
+// TestConfigWatcherPropagatesMaxTeams verifies that when madflow.toml is updated
+// with a new max_teams value, runConfigWatcher propagates the change to the
+// team.Manager via SetMaxTeams.
+// This is the hot-reload fix for GitHub Issue #180.
+func TestConfigWatcherPropagatesMaxTeams(t *testing.T) {
+	dir := t.TempDir()
+
+	// Write an initial config TOML with max_teams=2.
+	cfgPath := filepath.Join(dir, "madflow.toml")
+	initialTOML := `[project]
+name = "test"
+
+[[project.repos]]
+name = "main"
+path = "` + dir + `"
+
+[agent]
+max_teams = 2
+
+[branches]
+main = "main"
+develop = "develop"
+feature_prefix = "feature/issue-"
+`
+	if err := os.WriteFile(cfgPath, []byte(initialTOML), 0644); err != nil {
+		t.Fatalf("write initial config: %v", err)
+	}
+
+	cfg := testConfig(dir)
+	cfg.Agent.MaxTeams = 2
+
+	orc := New(cfg, dir, t.TempDir())
+	orc.WithConfigPath(cfgPath)
+	// Replace team manager with a known initial cap of 2.
+	orc.teams = team.NewManager(newMockTeamFactory(t), 2)
+
+	if orc.teams.Cap() != 2 {
+		t.Fatalf("expected initial Cap()=2, got %d", orc.teams.Cap())
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Start the config watcher in the background.
+	go orc.runConfigWatcher(ctx)
+
+	// Update madflow.toml to set max_teams=5.
+	updatedTOML := `[project]
+name = "test"
+
+[[project.repos]]
+name = "main"
+path = "` + dir + `"
+
+[agent]
+max_teams = 5
+
+[branches]
+main = "main"
+develop = "develop"
+feature_prefix = "feature/issue-"
+`
+	// Give the watcher a moment to record the initial mod time before we change the file.
+	time.Sleep(600 * time.Millisecond)
+
+	if err := os.WriteFile(cfgPath, []byte(updatedTOML), 0644); err != nil {
+		t.Fatalf("write updated config: %v", err)
+	}
+
+	// Poll for the change to propagate (watcher polls every 500ms; allow up to 3s).
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if orc.teams.Cap() == 5 {
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	if orc.teams.Cap() != 5 {
+		t.Errorf("expected Cap()=5 after config hot-reload, got %d", orc.teams.Cap())
+	}
+}

--- a/internal/team/team.go
+++ b/internal/team/team.go
@@ -290,7 +290,22 @@ func (m *Manager) Full() bool {
 
 // Cap returns the configured maximum number of concurrent teams.
 func (m *Manager) Cap() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	return m.maxTeams
+}
+
+// SetMaxTeams updates the maximum number of concurrent teams.
+// This is called by the orchestrator's config hot-reload watcher to propagate
+// max_teams changes from madflow.toml without restarting the process.
+// If n <= 0, the value is reset to DefaultMaxTeams.
+func (m *Manager) SetMaxTeams(n int) {
+	if n <= 0 {
+		n = DefaultMaxTeams
+	}
+	m.mu.Lock()
+	m.maxTeams = n
+	m.mu.Unlock()
 }
 
 // TeamInfo is a read-only snapshot of a team's state.

--- a/internal/team/team_test.go
+++ b/internal/team/team_test.go
@@ -532,3 +532,52 @@ func TestCapDefaultMaxTeams(t *testing.T) {
 		t.Errorf("expected Cap()=%d, got %d", DefaultMaxTeams, m.Cap())
 	}
 }
+
+// TestSetMaxTeams verifies that SetMaxTeams updates the limit dynamically.
+func TestSetMaxTeams(t *testing.T) {
+	factory := newMockFactory(t)
+	m := NewManager(factory, 2)
+
+	if m.Cap() != 2 {
+		t.Errorf("expected initial Cap()=2, got %d", m.Cap())
+	}
+
+	// Increase the limit
+	m.SetMaxTeams(4)
+	if m.Cap() != 4 {
+		t.Errorf("expected Cap()=4 after SetMaxTeams(4), got %d", m.Cap())
+	}
+
+	// Create 4 teams — all should succeed under the new limit
+	for i := 1; i <= 4; i++ {
+		createAndCancel(t, m, fmt.Sprintf("issue-set-%03d", i))
+	}
+	if m.Count() != 4 {
+		t.Errorf("expected 4 teams after SetMaxTeams(4), got %d", m.Count())
+	}
+
+	// 5th creation should fail
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err := m.Create(ctx, "issue-set-over", "")
+	if err == nil {
+		t.Fatal("expected error when exceeding new max, got nil")
+	}
+
+	// Reduce the limit — existing teams are not disbanded, but new creates fail
+	m.SetMaxTeams(2)
+	if m.Cap() != 2 {
+		t.Errorf("expected Cap()=2 after SetMaxTeams(2), got %d", m.Cap())
+	}
+	// Count is still 4 (existing teams not evicted), but new creates fail
+	_, err = m.Create(ctx, "issue-set-extra", "")
+	if err == nil {
+		t.Fatal("expected error when exceeding reduced max, got nil")
+	}
+
+	// SetMaxTeams(0) should reset to DefaultMaxTeams
+	m.SetMaxTeams(0)
+	if m.Cap() != DefaultMaxTeams {
+		t.Errorf("expected Cap()=%d after SetMaxTeams(0), got %d", DefaultMaxTeams, m.Cap())
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `Full() bool` and `Cap() int` methods to `team.Manager` to expose capacity state
- In `handleTeamCreate`, after `AssignIdle` fails, checks `Full()` before marking issue as `in_progress` or sending ACK — if at capacity, rejects immediately with a clear "保留" message
- Updates `issuePatrolPrompt` so the superintendent understands that a capacity-pending response means "wait for a team slot to become available"
- Adds unit tests: `TestFullAndCap`, `TestCapDefaultMaxTeams`, `TestHandleTeamCreateRejectsWhenAtMaxCapacityAllBusy`

**Root cause of #180**: When all `max_teams` slots were occupied by busy teams and `AssignIdle` found no idle team, the orchestrator sent a misleading ACK ("受信しました。チーム作成を開始します。") then silently failed in a goroutine. The issue was reset to `open` and the superintendent retried endlessly without understanding why.

Issue: ytnobody-MADFLOW-180

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/team/...` — all pass including new `TestFullAndCap`, `TestCapDefaultMaxTeams`
- [x] `go test ./internal/orchestrator/...` — all pass including new `TestHandleTeamCreateRejectsWhenAtMaxCapacityAllBusy`
- [x] Integration test failures are pre-existing on develop branch (confirmed independently)

🤖 Generated with [Claude Code](https://claude.com/claude-code)