### PR TITLE
ytnobody-MADFLOW-194: TODO実装を抑止するCIチェックを追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,17 @@ jobs:
       - name: go vet
         run: go vet ./...
 
+      - name: TODO check
+        run: |
+          TODOS=$(grep -rn "// TODO\|/\* TODO" --include="*.go" . 2>/dev/null || true)
+          if [ -n "$TODOS" ]; then
+            echo "TODO comments found in Go source files:"
+            echo "$TODOS"
+            echo "Please remove or implement all TODO items before merging."
+            exit 1
+          fi
+          echo "No TODO comments found."
+
       - name: go test
         run: go test -race -timeout 120s ./...
 

--- a/Makefile
+++ b/Makefile
@@ -29,11 +29,18 @@ install: build
 test:
 	go test ./...
 
-# lint runs gofmt and go vet.
+# lint runs gofmt, go vet, and TODO comment check.
 .PHONY: lint
 lint:
 	gofmt -l ./... | grep . && exit 1 || true
 	go vet ./...
+	@TODOS=$$(grep -rn "// TODO\|/\* TODO" --include="*.go" . 2>/dev/null); \
+	if [ -n "$$TODOS" ]; then \
+		echo "TODO comments found in Go source files:"; \
+		echo "$$TODOS"; \
+		echo "Please remove or implement all TODO items before merging."; \
+		exit 1; \
+	fi
 
 # clean removes the built binary.
 .PHONY: clean
@@ -73,7 +80,7 @@ help:
 	@echo "  make build    - Build the madflow binary"
 	@echo "  make install  - Build and install binary to INSTALL_DIR (default: ~/bin)"
 	@echo "  make test     - Run all tests"
-	@echo "  make lint     - Run gofmt and go vet"
+	@echo "  make lint     - Run gofmt, go vet, and TODO comment check"
 	@echo "  make clean    - Remove the built binary"
 	@echo "  make rebuild  - Build, install, and stop running process (for restart by supervisor)"
 	@echo "  make restart  - Stop the running madflow process"

--- a/docs/specs/no-todo-implementation.md
+++ b/docs/specs/no-todo-implementation.md
@@ -1,0 +1,55 @@
+# Spec: TODO実装の抑止 (No TODO Implementation)
+
+## 概要
+
+Goソースコード内に `// TODO` コメント（未実装のプレースホルダー）が含まれていた場合、CIおよびlintチェックで検出し、マージを防止する。
+
+## 背景
+
+`// TODO: implement` のような未実装のプレースホルダーがコードに残ったままマージされることを防ぐ必要がある。
+
+## 対象
+
+- `**/*.go` ファイル内のすべての `// TODO` コメント
+
+## チェック仕様
+
+### 検出対象パターン
+
+以下のパターンをGoソースファイル内で検出する（大文字小文字を区別する）:
+
+- `// TODO`（行コメント形式のTODO）
+- `/* TODO`（ブロックコメント形式のTODO）
+
+### チェック範囲
+
+- プロジェクト内の全Goソースファイル（`*.go`）
+- vendorディレクトリは除外する
+
+### 動作
+
+- TODO コメントが検出された場合: エラーを出力してexit code 1で終了
+- TODO コメントが検出されない場合: 正常終了（exit code 0）
+
+## 実装方法
+
+### 1. Makefile の lint ターゲットに追加
+
+`make lint` 実行時にTODOチェックを行う。
+
+### 2. CI ワークフロー (.github/workflows/ci.yml) に追加
+
+CIパイプラインの lint ステップとしてTODOチェックを追加する。
+
+## エラーメッセージ例
+
+```
+TODO comments found in Go source files:
+internal/foo/bar.go:42: // TODO: implement this
+Please remove or implement all TODO items before merging.
+```
+
+## 除外対象
+
+- テストファイル（`*_test.go`）は除外しない（テストコードにもTODOは残すべきでない）
+- `vendor/` ディレクトリは除外する


### PR DESCRIPTION
Issue: ytnobody-MADFLOW-194

## 概要

GoソースコードにTODOコメント（`// TODO` / `/* TODO`）が含まれていた場合にCIとlintで検出し、マージを防止するチェックを追加しました。

## 変更内容

- `Makefile`: `lint` ターゲットにTODOコメント検出ステップを追加
- `.github/workflows/ci.yml`: CIパイプラインに「TODO check」ステップを追加
- `docs/specs/no-todo-implementation.md`: 仕様ドキュメントを追加