### PR TITLE
ytnobody-MADFLOW-196: Implement claude-api-standard and claude-api-cheap presets

### DIFF
--- a/cmd/madflow/use.go
+++ b/cmd/madflow/use.go
@@ -42,6 +42,14 @@ var presets = map[string]presetModels{
 		Superintendent: "claude-sonnet-4-6",
 		Engineer:       "gemini-2.5-flash",
 	},
+	"claude-api-standard": {
+		Superintendent: "anthropic/claude-sonnet-4-6",
+		Engineer:       "anthropic/claude-haiku-4-5",
+	},
+	"claude-api-cheap": {
+		Superintendent: "anthropic/claude-haiku-4-5",
+		Engineer:       "anthropic/claude-haiku-4-5",
+	},
 }
 
 // cmdUse switches the active model preset in madflow.toml.
@@ -104,6 +112,7 @@ func updateModelsSection(content, superintendent, engineer string) (string, erro
 func formatPresets() string {
 	names := []string{
 		"claude", "gemini", "claude-cheap", "gemini-cheap", "hybrid", "hybrid-cheap",
+		"claude-api-standard", "claude-api-cheap",
 	}
 	var sb strings.Builder
 	for _, name := range names {

--- a/cmd/madflow/use_test.go
+++ b/cmd/madflow/use_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestPresets_AllDefined(t *testing.T) {
-	expectedPresets := []string{"claude", "gemini", "claude-cheap", "gemini-cheap", "hybrid", "hybrid-cheap"}
+	expectedPresets := []string{"claude", "gemini", "claude-cheap", "gemini-cheap", "hybrid", "hybrid-cheap", "claude-api-standard", "claude-api-cheap"}
 	for _, name := range expectedPresets {
 		if _, ok := presets[name]; !ok {
 			t.Errorf("preset %q is not defined", name)
@@ -26,6 +26,8 @@ func TestPresets_Models(t *testing.T) {
 		{"gemini-cheap", "gemini-2.5-flash", "gemini-2.5-flash"},
 		{"hybrid", "claude-sonnet-4-6", "gemini-2.5-pro"},
 		{"hybrid-cheap", "claude-sonnet-4-6", "gemini-2.5-flash"},
+		{"claude-api-standard", "anthropic/claude-sonnet-4-6", "anthropic/claude-haiku-4-5"},
+		{"claude-api-cheap", "anthropic/claude-haiku-4-5", "anthropic/claude-haiku-4-5"},
 	}
 
 	for _, tt := range tests {
@@ -128,7 +130,7 @@ superintendent = "claude-sonnet-4-6"
 
 func TestFormatPresets(t *testing.T) {
 	out := formatPresets()
-	expectedPresets := []string{"claude", "gemini", "claude-cheap", "gemini-cheap", "hybrid", "hybrid-cheap"}
+	expectedPresets := []string{"claude", "gemini", "claude-cheap", "gemini-cheap", "hybrid", "hybrid-cheap", "claude-api-standard", "claude-api-cheap"}
 	for _, name := range expectedPresets {
 		if !strings.Contains(out, name) {
 			t.Errorf("formatPresets output missing preset %q", name)

--- a/docs/specs/anthropic-api-preset.md
+++ b/docs/specs/anthropic-api-preset.md
@@ -1,0 +1,84 @@
+# Anthropic API Key Preset Specification
+
+## Overview
+
+The `claude-api-standard` and `claude-api-cheap` presets allow MADFLOW to call the
+Anthropic Messages API directly using `ANTHROPIC_API_KEY` instead of the Claude Code CLI.
+
+This is useful when users do not have a Claude Pro/Max subscription and prefer to pay
+per-request using the Anthropic API.
+
+## Presets
+
+| Preset              | Superintendent Model         | Engineer Model               |
+|---------------------|------------------------------|------------------------------|
+| `claude-api-standard` | `anthropic/claude-sonnet-4-6` | `anthropic/claude-haiku-4-5` |
+| `claude-api-cheap`  | `anthropic/claude-haiku-4-5` | `anthropic/claude-haiku-4-5` |
+
+Model strings use the `anthropic/` prefix to distinguish them from Claude CLI models.
+
+## Backend: AnthropicAPIProcess
+
+When a model string starts with `anthropic/`, a new `AnthropicAPIProcess` is created
+instead of the default `ClaudeStreamProcess`.
+
+### API Details
+
+- Endpoint: `https://api.anthropic.com/v1/messages`
+- Auth: `x-api-key: <ANTHROPIC_API_KEY>` header
+- API Version: `anthropic-version: 2023-06-01`
+- Environment variable: `ANTHROPIC_API_KEY`
+
+### Agentic Loop
+
+`AnthropicAPIProcess.Send()` implements an agentic loop similar to `GeminiAPIProcess`:
+
+1. Send the prompt to the API
+2. If the model uses `tool_use` blocks, execute them (bash only)
+3. Feed the results back as `tool_result` user messages
+4. Repeat until no tool calls or `anthropicMaxIter` reached
+
+### Tool
+
+Only the `bash` tool is exposed:
+
+```json
+{
+  "name": "bash",
+  "description": "Execute a bash command and return stdout/stderr.",
+  "input_schema": {
+    "type": "object",
+    "properties": {
+      "command": {"type": "string", "description": "The bash command to execute"}
+    },
+    "required": ["command"]
+  }
+}
+```
+
+### Error Handling
+
+- Missing `ANTHROPIC_API_KEY`: return an error immediately
+- HTTP 429 / rate-limit body: return `*RateLimitError` (triggers dormancy system)
+- Other HTTP 4xx/5xx: return an error
+- `stop_reason == "max_tokens"`: return partial text, no error
+- Max iterations reached: return `*MaxIterationsError`
+
+### Model Name Stripping
+
+The `anthropic/` prefix is stripped before sending to the API.
+Example: `anthropic/claude-sonnet-4-6` → API model `claude-sonnet-4-6`.
+
+## Configuration (use command)
+
+`madflow use claude-api-standard` writes the preset models to `madflow.toml`:
+
+```toml
+[agent.models]
+superintendent = "anthropic/claude-sonnet-4-6"
+engineer       = "anthropic/claude-haiku-4-5"
+```
+
+## formatPresets
+
+The `formatPresets()` function in `use.go` includes both new presets in its output.

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -63,6 +63,13 @@ func NewAgent(cfg AgentConfig) *Agent {
 				WorkDir:      cfg.WorkDir,
 				BashTimeout:  cfg.BashTimeout,
 			})
+		case strings.HasPrefix(cfg.Model, "anthropic/"):
+			proc = NewAnthropicAPIProcess(AnthropicAPIOptions{
+				SystemPrompt: cfg.SystemPrompt,
+				Model:        cfg.Model,
+				WorkDir:      cfg.WorkDir,
+				BashTimeout:  cfg.BashTimeout,
+			})
 		default:
 			proc = NewClaudeStreamProcess(ClaudeOptions{
 				SystemPrompt: cfg.SystemPrompt,

--- a/internal/agent/anthropic_api.go
+++ b/internal/agent/anthropic_api.go
@@ -1,0 +1,337 @@
+package agent
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const (
+	anthropicAPIEndpoint = "https://api.anthropic.com/v1/messages"
+	anthropicVersion     = "2023-06-01"
+	anthropicMaxTokens   = 8096
+	anthropicMaxIter     = 25 // maximum agentic loop iterations
+)
+
+// AnthropicAPIOptions configures the Anthropic API-based agent process.
+type AnthropicAPIOptions struct {
+	SystemPrompt string
+	Model        string
+	WorkDir      string
+	BashTimeout  time.Duration
+}
+
+// AnthropicAPIProcess sends prompts to the Anthropic Messages API using ANTHROPIC_API_KEY.
+// It implements an agentic loop: if the model calls tools (bash), it executes them
+// and feeds the results back until the model finishes.
+type AnthropicAPIProcess struct {
+	opts       AnthropicAPIOptions
+	client     *http.Client
+	testAPIURL string // overrides the endpoint in tests
+}
+
+// NewAnthropicAPIProcess creates a new AnthropicAPIProcess.
+func NewAnthropicAPIProcess(opts AnthropicAPIOptions) *AnthropicAPIProcess {
+	return &AnthropicAPIProcess{
+		opts:   opts,
+		client: &http.Client{Timeout: 300 * time.Second},
+	}
+}
+
+func (a *AnthropicAPIProcess) Reset(ctx context.Context) error { return nil }
+func (a *AnthropicAPIProcess) Close() error                    { return nil }
+
+// apiURL returns the effective API endpoint (test override or production).
+func (a *AnthropicAPIProcess) apiURL() string {
+	if a.testAPIURL != "" {
+		return a.testAPIURL
+	}
+	return anthropicAPIEndpoint
+}
+
+// modelName returns the bare model name with the "anthropic/" prefix stripped.
+func (a *AnthropicAPIProcess) modelName() string {
+	return strings.TrimPrefix(a.opts.Model, "anthropic/")
+}
+
+// --- Anthropic API request/response types ---
+
+type anthropicRequest struct {
+	Model     string             `json:"model"`
+	MaxTokens int                `json:"max_tokens"`
+	System    string             `json:"system,omitempty"`
+	Messages  []anthropicMessage `json:"messages"`
+	Tools     []anthropicTool    `json:"tools,omitempty"`
+}
+
+type anthropicMessage struct {
+	Role    string `json:"role"`
+	Content any    `json:"content"` // string or []anthropicContentBlock
+}
+
+type anthropicContentBlock struct {
+	Type  string          `json:"type"`
+	Text  string          `json:"text,omitempty"`
+	ID    string          `json:"id,omitempty"`
+	Name  string          `json:"name,omitempty"`
+	Input json.RawMessage `json:"input,omitempty"`
+	// For tool_result blocks
+	ToolUseID string `json:"tool_use_id,omitempty"`
+	Content   string `json:"content,omitempty"`
+}
+
+type anthropicTool struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	InputSchema any    `json:"input_schema"`
+}
+
+type anthropicResponse struct {
+	ID         string                  `json:"id"`
+	Type       string                  `json:"type"`
+	Role       string                  `json:"role"`
+	Content    []anthropicContentBlock `json:"content"`
+	StopReason string                  `json:"stop_reason"`
+	Error      *anthropicError         `json:"error,omitempty"`
+}
+
+type anthropicError struct {
+	Type    string `json:"type"`
+	Message string `json:"message"`
+}
+
+// anthropicBashTool is the tool declaration for the bash tool.
+var anthropicBashTool = anthropicTool{
+	Name:        "bash",
+	Description: "Execute a bash command in the working directory and return stdout/stderr. Use this for all file operations, git commands, and shell tasks.",
+	InputSchema: map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"command": map[string]any{
+				"type":        "string",
+				"description": "The bash command to execute",
+			},
+		},
+		"required": []string{"command"},
+	},
+}
+
+// Send implements the Process interface.
+// It calls the Anthropic Messages API with an agentic loop:
+//  1. Send the prompt
+//  2. If the model uses tool_use blocks, execute them and feed results back
+//  3. Repeat until stop_reason is end_turn/max_tokens or max iterations reached
+func (a *AnthropicAPIProcess) Send(ctx context.Context, prompt string) (string, error) {
+	apiKey := os.Getenv("ANTHROPIC_API_KEY")
+	if apiKey == "" {
+		return "", fmt.Errorf("ANTHROPIC_API_KEY is not set; claude-api backend requires an Anthropic API key")
+	}
+
+	messages := []anthropicMessage{
+		{Role: "user", Content: prompt},
+	}
+
+	var lastText string
+	for range anthropicMaxIter {
+		resp, err := a.callAPI(ctx, apiKey, messages)
+		if err != nil {
+			return "", err
+		}
+
+		// Check for API-level error in the response body
+		if resp.Error != nil {
+			errMsg := resp.Error.Message
+			errType := resp.Error.Type
+			if strings.Contains(errType, "rate_limit") || strings.Contains(errType, "overloaded") ||
+				containsRateLimitKeyword(errMsg) {
+				return "", &RateLimitError{Wrapped: fmt.Errorf("anthropic API rate limit: %s", errMsg)}
+			}
+			return "", fmt.Errorf("anthropic API error (%s): %s", errType, errMsg)
+		}
+
+		// Track last text from this response
+		if text := a.extractText(resp.Content); text != "" {
+			lastText = text
+		}
+
+		// Handle stop reasons
+		switch resp.StopReason {
+		case "max_tokens":
+			return lastText, nil
+		case "end_turn":
+			return a.extractText(resp.Content), nil
+		}
+
+		// Check for tool_use blocks
+		toolUses := a.extractToolUses(resp.Content)
+		if len(toolUses) == 0 {
+			// No tool calls, return text
+			return a.extractText(resp.Content), nil
+		}
+
+		// Append assistant message with the full content
+		messages = append(messages, anthropicMessage{
+			Role:    "assistant",
+			Content: resp.Content,
+		})
+
+		// Execute tools and collect results
+		var toolResults []anthropicContentBlock
+		for _, tu := range toolUses {
+			result, _ := a.executeTool(ctx, tu.Name, tu.Input)
+			toolResults = append(toolResults, anthropicContentBlock{
+				Type:      "tool_result",
+				ToolUseID: tu.ID,
+				Content:   result,
+			})
+		}
+
+		// Append tool results as user message
+		messages = append(messages, anthropicMessage{
+			Role:    "user",
+			Content: toolResults,
+		})
+	}
+
+	return "", &MaxIterationsError{PartialResponse: lastText}
+}
+
+// callAPI sends a single request to the Anthropic Messages API.
+func (a *AnthropicAPIProcess) callAPI(ctx context.Context, apiKey string, messages []anthropicMessage) (*anthropicResponse, error) {
+	reqBody := anthropicRequest{
+		Model:     a.modelName(),
+		MaxTokens: anthropicMaxTokens,
+		Messages:  messages,
+		Tools:     []anthropicTool{anthropicBashTool},
+	}
+	if a.opts.SystemPrompt != "" {
+		reqBody.System = a.opts.SystemPrompt
+	}
+
+	data, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("marshal request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, a.apiURL(), bytes.NewReader(data))
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("x-api-key", apiKey)
+	req.Header.Set("anthropic-version", anthropicVersion)
+
+	httpResp, err := a.client.Do(req)
+	if err != nil {
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+		return nil, fmt.Errorf("http request failed: %w", err)
+	}
+	defer httpResp.Body.Close()
+
+	body, err := io.ReadAll(httpResp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read response body: %w", err)
+	}
+
+	// Handle HTTP-level rate limit errors
+	if httpResp.StatusCode == 429 || httpResp.StatusCode == 529 {
+		return nil, &RateLimitError{
+			Wrapped: fmt.Errorf("anthropic API rate limit (HTTP %d): %s", httpResp.StatusCode, strings.TrimSpace(string(body))),
+		}
+	}
+	if httpResp.StatusCode >= 400 {
+		bodyStr := string(body)
+		if containsRateLimitKeyword(bodyStr) || strings.Contains(bodyStr, "overloaded") {
+			return nil, &RateLimitError{
+				Wrapped: fmt.Errorf("anthropic API rate limit (HTTP %d): %s", httpResp.StatusCode, strings.TrimSpace(bodyStr)),
+			}
+		}
+		return nil, fmt.Errorf("anthropic API HTTP %d: %s", httpResp.StatusCode, strings.TrimSpace(bodyStr))
+	}
+
+	var resp anthropicResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return nil, fmt.Errorf("decode response: %w (body: %s)", err, string(body))
+	}
+
+	return &resp, nil
+}
+
+// extractText collects all text blocks from the response content.
+func (a *AnthropicAPIProcess) extractText(content []anthropicContentBlock) string {
+	var texts []string
+	for _, block := range content {
+		if block.Type == "text" && block.Text != "" {
+			texts = append(texts, block.Text)
+		}
+	}
+	return strings.TrimSpace(strings.Join(texts, "\n"))
+}
+
+// extractToolUses returns all tool_use blocks from the response content.
+func (a *AnthropicAPIProcess) extractToolUses(content []anthropicContentBlock) []anthropicContentBlock {
+	var uses []anthropicContentBlock
+	for _, block := range content {
+		if block.Type == "tool_use" {
+			uses = append(uses, block)
+		}
+	}
+	return uses
+}
+
+// executeTool runs the requested tool and returns (output, isError).
+func (a *AnthropicAPIProcess) executeTool(ctx context.Context, toolName string, input json.RawMessage) (string, bool) {
+	switch toolName {
+	case "bash":
+		var params struct {
+			Command string `json:"command"`
+		}
+		if err := json.Unmarshal(input, &params); err != nil {
+			return fmt.Sprintf("failed to parse bash input: %v", err), true
+		}
+		return a.runBash(ctx, params.Command)
+	default:
+		return fmt.Sprintf("unknown tool: %s", toolName), true
+	}
+}
+
+// runBash executes a bash command and returns (output, isError).
+func (a *AnthropicAPIProcess) runBash(ctx context.Context, command string) (string, bool) {
+	if a.opts.BashTimeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, a.opts.BashTimeout)
+		defer cancel()
+	}
+
+	cmd := exec.CommandContext(ctx, "bash", "-c", command)
+	if a.opts.WorkDir != "" {
+		cmd.Dir = a.opts.WorkDir
+	}
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
+	result := strings.TrimSpace(stdout.String())
+	if stderr.Len() > 0 {
+		if result != "" {
+			result += "\n"
+		}
+		result += "STDERR:\n" + strings.TrimSpace(stderr.String())
+	}
+	if result == "" && err != nil {
+		result = fmt.Sprintf("command failed: %v", err)
+	}
+
+	return result, err != nil
+}

--- a/internal/agent/anthropic_api_test.go
+++ b/internal/agent/anthropic_api_test.go
@@ -1,0 +1,315 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestAnthropicAPIProcess_Send_NoAPIKey verifies that missing ANTHROPIC_API_KEY returns an error.
+func TestAnthropicAPIProcess_Send_NoAPIKey(t *testing.T) {
+	prev := os.Getenv("ANTHROPIC_API_KEY")
+	os.Unsetenv("ANTHROPIC_API_KEY")
+	defer func() {
+		if prev != "" {
+			os.Setenv("ANTHROPIC_API_KEY", prev)
+		}
+	}()
+
+	p := NewAnthropicAPIProcess(AnthropicAPIOptions{Model: "anthropic/claude-sonnet-4-6"})
+	_, err := p.Send(context.Background(), "hello")
+	if err == nil {
+		t.Fatal("expected error when ANTHROPIC_API_KEY is not set")
+	}
+	if !strings.Contains(err.Error(), "ANTHROPIC_API_KEY") {
+		t.Errorf("expected ANTHROPIC_API_KEY in error message, got: %v", err)
+	}
+}
+
+// TestAnthropicAPIProcess_Send_EndTurn verifies a successful text response (stop_reason=end_turn).
+func TestAnthropicAPIProcess_Send_EndTurn(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Verify required headers
+		if r.Header.Get("x-api-key") == "" {
+			t.Error("expected x-api-key header")
+		}
+		if r.Header.Get("anthropic-version") == "" {
+			t.Error("expected anthropic-version header")
+		}
+
+		resp := anthropicResponse{
+			Content: []anthropicContentBlock{
+				{Type: "text", Text: "Hello from mock Anthropic API!"},
+			},
+			StopReason: "end_turn",
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	os.Setenv("ANTHROPIC_API_KEY", "test-key")
+	defer os.Unsetenv("ANTHROPIC_API_KEY")
+
+	p := NewAnthropicAPIProcess(AnthropicAPIOptions{Model: "anthropic/claude-sonnet-4-6"})
+	p.client = server.Client()
+	p.testAPIURL = server.URL + "/v1/messages"
+
+	result, err := p.Send(context.Background(), "hello")
+	if err != nil {
+		t.Fatalf("Send failed: %v", err)
+	}
+	if result != "Hello from mock Anthropic API!" {
+		t.Errorf("unexpected result: %q", result)
+	}
+}
+
+// TestAnthropicAPIProcess_Send_RateLimit429 verifies HTTP 429 is detected as a RateLimitError.
+func TestAnthropicAPIProcess_Send_RateLimit429(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(429)
+		w.Write([]byte(`{"type":"error","error":{"type":"rate_limit_error","message":"Too many requests"}}`))
+	}))
+	defer server.Close()
+
+	os.Setenv("ANTHROPIC_API_KEY", "test-key")
+	defer os.Unsetenv("ANTHROPIC_API_KEY")
+
+	p := NewAnthropicAPIProcess(AnthropicAPIOptions{Model: "anthropic/claude-sonnet-4-6"})
+	p.client = server.Client()
+	p.testAPIURL = server.URL + "/v1/messages"
+
+	_, err := p.Send(context.Background(), "hello")
+	if err == nil {
+		t.Fatal("expected error for 429")
+	}
+	if !IsRateLimitError(err) {
+		t.Errorf("expected RateLimitError, got: %v", err)
+	}
+}
+
+// TestAnthropicAPIProcess_Send_ToolUseLoop verifies the agentic tool-use loop.
+func TestAnthropicAPIProcess_Send_ToolUseLoop(t *testing.T) {
+	callCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		w.Header().Set("Content-Type", "application/json")
+		if callCount == 1 {
+			// First call: return tool_use
+			resp := anthropicResponse{
+				Content: []anthropicContentBlock{
+					{
+						Type:  "tool_use",
+						ID:    "tool-1",
+						Name:  "bash",
+						Input: json.RawMessage(`{"command":"echo tool_result"}`),
+					},
+				},
+				StopReason: "tool_use",
+			}
+			json.NewEncoder(w).Encode(resp)
+		} else {
+			// Second call: return text
+			resp := anthropicResponse{
+				Content: []anthropicContentBlock{
+					{Type: "text", Text: "Done after tool use"},
+				},
+				StopReason: "end_turn",
+			}
+			json.NewEncoder(w).Encode(resp)
+		}
+	}))
+	defer server.Close()
+
+	os.Setenv("ANTHROPIC_API_KEY", "test-key")
+	defer os.Unsetenv("ANTHROPIC_API_KEY")
+
+	p := NewAnthropicAPIProcess(AnthropicAPIOptions{Model: "anthropic/claude-sonnet-4-6"})
+	p.client = server.Client()
+	p.testAPIURL = server.URL + "/v1/messages"
+
+	result, err := p.Send(context.Background(), "run a command")
+	if err != nil {
+		t.Fatalf("Send failed: %v", err)
+	}
+	if result != "Done after tool use" {
+		t.Errorf("expected 'Done after tool use', got %q", result)
+	}
+	if callCount != 2 {
+		t.Errorf("expected 2 API calls for tool-use loop, got %d", callCount)
+	}
+}
+
+// TestAnthropicAPIProcess_Send_MaxTokens verifies stop_reason=max_tokens returns partial text without error.
+func TestAnthropicAPIProcess_Send_MaxTokens(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := anthropicResponse{
+			Content: []anthropicContentBlock{
+				{Type: "text", Text: "truncated response text"},
+			},
+			StopReason: "max_tokens",
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	os.Setenv("ANTHROPIC_API_KEY", "test-key")
+	defer os.Unsetenv("ANTHROPIC_API_KEY")
+
+	p := NewAnthropicAPIProcess(AnthropicAPIOptions{Model: "anthropic/claude-sonnet-4-6"})
+	p.client = server.Client()
+	p.testAPIURL = server.URL + "/v1/messages"
+
+	result, err := p.Send(context.Background(), "generate a long response")
+	if err != nil {
+		t.Fatalf("expected no error for max_tokens, got: %v", err)
+	}
+	if result != "truncated response text" {
+		t.Errorf("expected 'truncated response text', got %q", result)
+	}
+}
+
+// TestAnthropicAPIProcess_Send_MaxIterationsError verifies that reaching max iterations returns MaxIterationsError.
+func TestAnthropicAPIProcess_Send_MaxIterationsError(t *testing.T) {
+	// Always return a tool_use so the loop never terminates naturally
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := anthropicResponse{
+			Content: []anthropicContentBlock{
+				{Type: "text", Text: "partial work"},
+				{
+					Type:  "tool_use",
+					ID:    "tool-x",
+					Name:  "bash",
+					Input: json.RawMessage(`{"command":"echo iteration"}`),
+				},
+			},
+			StopReason: "tool_use",
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	os.Setenv("ANTHROPIC_API_KEY", "test-key")
+	defer os.Unsetenv("ANTHROPIC_API_KEY")
+
+	p := NewAnthropicAPIProcess(AnthropicAPIOptions{Model: "anthropic/claude-sonnet-4-6"})
+	p.client = server.Client()
+	p.testAPIURL = server.URL + "/v1/messages"
+
+	_, err := p.Send(context.Background(), "do something complex")
+	if err == nil {
+		t.Fatal("expected error when max iterations reached")
+	}
+
+	var maxIterErr *MaxIterationsError
+	if !errors.As(err, &maxIterErr) {
+		t.Fatalf("expected MaxIterationsError, got: %T: %v", err, err)
+	}
+}
+
+// TestAnthropicAPIProcess_Send_SystemPrompt verifies system prompt is included in the request.
+func TestAnthropicAPIProcess_Send_SystemPrompt(t *testing.T) {
+	var receivedReq anthropicRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewDecoder(r.Body).Decode(&receivedReq)
+		resp := anthropicResponse{
+			Content:    []anthropicContentBlock{{Type: "text", Text: "ok"}},
+			StopReason: "end_turn",
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	os.Setenv("ANTHROPIC_API_KEY", "test-key")
+	defer os.Unsetenv("ANTHROPIC_API_KEY")
+
+	p := NewAnthropicAPIProcess(AnthropicAPIOptions{
+		Model:        "anthropic/claude-sonnet-4-6",
+		SystemPrompt: "You are a helpful assistant",
+	})
+	p.client = server.Client()
+	p.testAPIURL = server.URL + "/v1/messages"
+
+	_, err := p.Send(context.Background(), "hello")
+	if err != nil {
+		t.Fatalf("Send failed: %v", err)
+	}
+
+	if receivedReq.System != "You are a helpful assistant" {
+		t.Errorf("expected system prompt to be set, got: %q", receivedReq.System)
+	}
+}
+
+// TestAnthropicAPIProcess_Send_ModelPrefixStripped verifies anthropic/ prefix is stripped from model name.
+func TestAnthropicAPIProcess_Send_ModelPrefixStripped(t *testing.T) {
+	var receivedReq anthropicRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewDecoder(r.Body).Decode(&receivedReq)
+		resp := anthropicResponse{
+			Content:    []anthropicContentBlock{{Type: "text", Text: "ok"}},
+			StopReason: "end_turn",
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	os.Setenv("ANTHROPIC_API_KEY", "test-key")
+	defer os.Unsetenv("ANTHROPIC_API_KEY")
+
+	p := NewAnthropicAPIProcess(AnthropicAPIOptions{Model: "anthropic/claude-sonnet-4-6"})
+	p.client = server.Client()
+	p.testAPIURL = server.URL + "/v1/messages"
+
+	_, err := p.Send(context.Background(), "hello")
+	if err != nil {
+		t.Fatalf("Send failed: %v", err)
+	}
+
+	if receivedReq.Model != "claude-sonnet-4-6" {
+		t.Errorf("expected model 'claude-sonnet-4-6', got: %q", receivedReq.Model)
+	}
+}
+
+// TestAnthropicAPIProcess_Send_OverloadedError verifies overloaded error is treated as rate limit.
+func TestAnthropicAPIProcess_Send_OverloadedError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(529)
+		w.Write([]byte(`{"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}`))
+	}))
+	defer server.Close()
+
+	os.Setenv("ANTHROPIC_API_KEY", "test-key")
+	defer os.Unsetenv("ANTHROPIC_API_KEY")
+
+	p := NewAnthropicAPIProcess(AnthropicAPIOptions{Model: "anthropic/claude-sonnet-4-6"})
+	p.client = server.Client()
+	p.testAPIURL = server.URL + "/v1/messages"
+
+	_, err := p.Send(context.Background(), "hello")
+	if err == nil {
+		t.Fatal("expected error for overloaded")
+	}
+	if !IsRateLimitError(err) {
+		t.Errorf("expected RateLimitError for overloaded_error, got: %v", err)
+	}
+}
+
+// TestAnthropicAPIProcess_ResetAndClose verifies Reset and Close are no-ops.
+func TestAnthropicAPIProcess_ResetAndClose(t *testing.T) {
+	p := NewAnthropicAPIProcess(AnthropicAPIOptions{Model: "anthropic/claude-sonnet-4-6"})
+	if err := p.Reset(context.Background()); err != nil {
+		t.Errorf("Reset returned error: %v", err)
+	}
+	if err := p.Close(); err != nil {
+		t.Errorf("Close returned error: %v", err)
+	}
+}


### PR DESCRIPTION
Issue: ytnobody-MADFLOW-196

## Summary

- Added `AnthropicAPIProcess` in `internal/agent/anthropic_api.go` that calls the Anthropic Messages API directly using `ANTHROPIC_API_KEY`, following the same agentic-loop pattern as the existing `GeminiAPIProcess`
- Updated `NewAgent()` in `agent.go` to dispatch models with the `anthropic/` prefix to `AnthropicAPIProcess`
- Added `claude-api-standard` (`anthropic/claude-sonnet-4-6` / `anthropic/claude-haiku-4-5`) and `claude-api-cheap` (`anthropic/claude-haiku-4-5` / `anthropic/claude-haiku-4-5`) to the presets map and `formatPresets()` in `use.go`

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes — all 13 packages green
- [x] New `TestAnthropicAPIProcess_*` tests cover: missing API key, end_turn response, HTTP 429 rate limit, tool-use agentic loop, max_tokens partial response, max iterations, system prompt, model prefix stripping, overloaded error, Reset/Close no-ops
- [x] `TestPresets_AllDefined` and `TestPresets_Models` updated to verify `claude-api-standard` and `claude-api-cheap`
- [x] `TestFormatPresets` updated to verify both new presets appear in formatted output

🤖 Generated with [Claude Code](https://claude.com/claude-code)