### PR TITLE
ytnobody-MADFLOW-199: Migrate Gemini API key from URL query parameter to x-goog-api-key header

### DIFF
--- a/docs/specs/gemini-api-key-header-migration.md
+++ b/docs/specs/gemini-api-key-header-migration.md
@@ -1,0 +1,47 @@
+# Spec: Gemini API Key Migration to Authorization Header
+
+## Overview
+
+The Gemini API key must be passed via the `x-goog-api-key` HTTP request header instead of as a URL query parameter (`?key=<apiKey>`).
+
+## Motivation
+
+Passing secrets as URL query parameters exposes them in:
+- Server-side and proxy access logs
+- Browser history
+- Error messages that include the full URL
+
+Using an HTTP header (`x-goog-api-key`) keeps the API key out of the URL and reduces the risk of accidental exposure.
+
+## Behavior
+
+### Before (insecure)
+
+The `callAPIWithURL` function in `internal/agent/gemini_api.go` appends the API key to the request URL:
+
+```
+https://generativelanguage.googleapis.com/v1beta/models/<model>:generateContent?key=<apiKey>
+```
+
+### After (secure)
+
+The `callAPIWithURL` function sends the API key as an HTTP header:
+
+```
+POST https://generativelanguage.googleapis.com/v1beta/models/<model>:generateContent
+x-goog-api-key: <apiKey>
+```
+
+The URL must not contain the `key=` query parameter.
+
+## Implementation
+
+- File: `internal/agent/gemini_api.go`
+- Function: `callAPIWithURL`
+- Change: Remove the query parameter appending logic; add `req.Header.Set("x-goog-api-key", apiKey)` after creating the request.
+
+## Edge Cases
+
+- The URL must not contain `?key=` or `&key=` after the change.
+- The `x-goog-api-key` header must always be set when an API key is present.
+- Tests must verify the header is present and the query parameter is absent.

--- a/internal/agent/gemini_api.go
+++ b/internal/agent/gemini_api.go
@@ -304,18 +304,12 @@ func (g *GeminiAPIProcess) callAPIWithURL(ctx context.Context, apiKey string, co
 		return nil, fmt.Errorf("marshal request: %w", err)
 	}
 
-	// Append API key as query parameter
-	sep := "?"
-	if strings.Contains(url, "?") {
-		sep = "&"
-	}
-	fullURL := url + sep + "key=" + apiKey
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, fullURL, bytes.NewReader(data))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(data))
 	if err != nil {
 		return nil, fmt.Errorf("create request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("x-goog-api-key", apiKey)
 
 	httpResp, err := g.client.Do(req)
 	if err != nil {

--- a/internal/agent/gemini_api_test.go
+++ b/internal/agent/gemini_api_test.go
@@ -174,9 +174,12 @@ func TestGeminiAPIProcess_Send_NoAPIKey(t *testing.T) {
 // TestGeminiAPIProcess_Send_EndTurn uses a mock HTTP server to verify a successful response.
 func TestGeminiAPIProcess_Send_EndTurn(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// Verify API key is passed as query parameter
-		if r.URL.Query().Get("key") == "" {
-			t.Error("expected key query parameter")
+		// Verify API key is passed as x-goog-api-key header (not query parameter)
+		if r.Header.Get("x-goog-api-key") == "" {
+			t.Error("expected x-goog-api-key header")
+		}
+		if r.URL.Query().Get("key") != "" {
+			t.Error("API key must not appear as query parameter")
 		}
 
 		resp := geminiResponse{


### PR DESCRIPTION
Issue: ytnobody-MADFLOW-199

## Summary

- Removed API key from URL query parameter ()
- Added  request header to pass the API key securely
- Updated test to verify header presence and absence of key in query params
- Added spec document at docs/specs/gemini-api-key-header-migration.md