### PR TITLE
ytnobody-MADFLOW-198: Make authorized_users required when GitHub integration is enabled

### DIFF
--- a/docs/specs/authorized-users-required.md
+++ b/docs/specs/authorized-users-required.md
@@ -1,0 +1,68 @@
+# Spec: authorized_users Required Configuration
+
+## Overview
+
+The `authorized_users` configuration field is **mandatory** when GitHub integration (`[github]` section) is enabled. When not set (or set to an empty list), MADFLOW must refuse to start and print a clear error message.
+
+This prevents a critical security vulnerability where any GitHub user could submit issues to a public repository and have MADFLOW process them, potentially enabling prompt injection attacks that lead to arbitrary command execution.
+
+## Behavior
+
+### Config Validation
+
+When `config.Load()` is called:
+
+1. If `cfg.GitHub != nil` (GitHub integration is enabled) **and** `len(cfg.AuthorizedUsers) == 0` (no authorized users are configured), the function must return an error:
+   ```
+   validate config: authorized_users is required when github integration is enabled; set authorized_users to a list of GitHub logins allowed to interact with MADFLOW
+   ```
+
+2. If `cfg.GitHub == nil` (no GitHub integration), the `authorized_users` field is not required and may remain empty.
+
+3. If `authorized_users` contains at least one entry, validation passes normally.
+
+### `isAuthorized()` Behavior
+
+The `isAuthorized(login string, authorizedUsers []string) bool` function in `internal/github/github.go`:
+
+- **Before** (insecure): When `authorizedUsers` is empty, returns `true` (permit all).
+- **After** (secure): When `authorizedUsers` is empty, returns `false` (deny all).
+
+This change is defense-in-depth; the config validation above should prevent the empty-list case from ever reaching `isAuthorized` in production.
+
+| `authorizedUsers` | `login`       | Result  |
+|-------------------|---------------|---------|
+| empty / nil       | (any)         | `false` |
+| `["alice"]`       | `"alice"`     | `true`  |
+| `["alice"]`       | `"bob"`       | `false` |
+| `["alice", "bob"]`| `"bob"`       | `true`  |
+| `["alice", "bob"]`| `"charlie"`   | `false` |
+
+## Configuration Example
+
+```toml
+# Required when [github] section is present
+authorized_users = ["myusername"]
+
+[github]
+owner = "myorg"
+repos = ["myrepo"]
+```
+
+## Security Context
+
+This change addresses the root attack vector for the following risks documented in `SECURITY_AUDIT_REPORT.md`:
+
+- **MEDIUM** (direct fix): Default all-user trust (`github.go:155-165`)
+- **CRITICAL** (attack path blocked): LLM response arbitrary command execution (`gemini_api.go:405`)
+- **CRITICAL** (attack path blocked): Claude CLI `--dangerously-skip-permissions` compound risk (`claude.go:93`)
+- **HIGH** (attack path blocked): Prompt injection via issue body (`prompt.go:70-74`)
+
+By requiring explicit opt-in for trusted users, MADFLOW will not process issues from unknown users even if the configuration is incomplete.
+
+## Affected Files
+
+- `internal/config/config.go` — validation logic and field comment
+- `internal/github/github.go` — `isAuthorized()` default behavior
+- `internal/config/config_test.go` — updated/new tests for validation
+- `internal/github/github_test.go` — updated test for `isAuthorized()` with empty list

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -15,8 +15,11 @@ type Config struct {
 	GitHub     *GitHubConfig `toml:"github,omitempty"`
 	PromptsDir string        `toml:"prompts_dir,omitempty"`
 	// AuthorizedUsers is a list of GitHub user logins that are allowed to create
-	// issues, PRs, and comments that MADFLOW will process. When empty (the default),
-	// all users are trusted. When non-empty, only listed users are trusted.
+	// issues, PRs, and comments that MADFLOW will process.
+	// This field is required when [github] integration is enabled.
+	// Leaving it empty while GitHub integration is active is a security risk:
+	// it would allow any GitHub user to interact with MADFLOW, enabling prompt
+	// injection attacks from arbitrary third parties on public repositories.
 	AuthorizedUsers []string `toml:"authorized_users,omitempty"`
 }
 
@@ -228,6 +231,9 @@ func validate(cfg *Config) error {
 		if r.Path == "" {
 			return fmt.Errorf("project.repos[%d].path is required", i)
 		}
+	}
+	if cfg.GitHub != nil && len(cfg.AuthorizedUsers) == 0 {
+		return fmt.Errorf("authorized_users is required when github integration is enabled; set authorized_users to a list of GitHub logins allowed to interact with MADFLOW")
 	}
 	return nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -104,6 +104,8 @@ path = "."
 
 func TestLoadWithGitHub(t *testing.T) {
 	content := `
+authorized_users = ["testuser"]
+
 [project]
 name = "test-app"
 
@@ -140,6 +142,8 @@ sync_interval_minutes = 10
 
 func TestEventPollSecondsDefault(t *testing.T) {
 	content := `
+authorized_users = ["testuser"]
+
 [project]
 name = "test-app"
 
@@ -172,6 +176,8 @@ repos = ["api"]
 
 func TestEventPollSecondsCustom(t *testing.T) {
 	content := `
+authorized_users = ["testuser"]
+
 [project]
 name = "test-app"
 
@@ -398,6 +404,8 @@ extra_prompt = "このプロジェクトはGoで書かれています。コー�
 }
 
 func TestAuthorizedUsersDefault(t *testing.T) {
+	// When GitHub integration is not configured, authorized_users is not required
+	// and defaults to empty.
 	content := `
 [project]
 name = "test-app"
@@ -419,6 +427,33 @@ path = "."
 
 	if len(cfg.AuthorizedUsers) != 0 {
 		t.Errorf("expected empty authorized_users by default, got %v", cfg.AuthorizedUsers)
+	}
+}
+
+func TestLoadGitHubMissingAuthorizedUsers(t *testing.T) {
+	// When GitHub integration is configured but authorized_users is not set,
+	// Load must return an error to prevent the default all-permit behavior.
+	content := `
+[project]
+name = "test-app"
+
+[[project.repos]]
+name = "main"
+path = "."
+
+[github]
+owner = "myorg"
+repos = ["myrepo"]
+`
+	dir := t.TempDir()
+	path := filepath.Join(dir, "madflow.toml")
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := Load(path)
+	if err == nil {
+		t.Fatal("expected error when github is configured without authorized_users, got nil")
 	}
 }
 
@@ -747,6 +782,8 @@ issue_patrol_interval_minutes = -1
 
 func TestGitHubBotCommentPatterns(t *testing.T) {
 	content := `
+authorized_users = ["testuser"]
+
 [project]
 name = "test-app"
 
@@ -837,6 +874,8 @@ language = "ja"
 func TestGitHubBotCommentPatterns_Empty(t *testing.T) {
 	// When bot_comment_patterns is not configured, it should default to nil/empty.
 	content := `
+authorized_users = ["testuser"]
+
 [project]
 name = "test-app"
 

--- a/internal/github/events_test.go
+++ b/internal/github/events_test.go
@@ -123,7 +123,8 @@ func TestProcessIssueCommentEvent(t *testing.T) {
 		gotComment = c
 	}
 
-	w := NewEventWatcher(store, "owner", []string{"repo"}, time.Minute, cb)
+	w := NewEventWatcher(store, "owner", []string{"repo"}, time.Minute, cb).
+		WithAuthorizedUsers([]string{"alice"})
 
 	payload := ghEventPayloadComment{
 		Action: "created",
@@ -514,7 +515,8 @@ func TestProcessIssueCommentEvent_BotComment(t *testing.T) {
 		gotComment = c
 	}
 
-	w := NewEventWatcher(store, "owner", []string{"repo"}, time.Minute, cb)
+	w := NewEventWatcher(store, "owner", []string{"repo"}, time.Minute, cb).
+		WithAuthorizedUsers([]string{"my-app[bot]"})
 
 	payload := ghEventPayloadComment{
 		Action: "created",
@@ -554,7 +556,8 @@ func TestProcessIssueCommentEvent_BotLoginSuffix(t *testing.T) {
 		gotComment = c
 	}
 
-	w := NewEventWatcher(store, "owner", []string{"repo"}, time.Minute, cb)
+	w := NewEventWatcher(store, "owner", []string{"repo"}, time.Minute, cb).
+		WithAuthorizedUsers([]string{"github-actions[bot]"})
 
 	payload := ghEventPayloadComment{
 		Action: "created",
@@ -593,7 +596,8 @@ func TestProcessIssueCommentEvent_HumanComment(t *testing.T) {
 		gotComment = c
 	}
 
-	w := NewEventWatcher(store, "owner", []string{"repo"}, time.Minute, cb)
+	w := NewEventWatcher(store, "owner", []string{"repo"}, time.Minute, cb).
+		WithAuthorizedUsers([]string{"alice"})
 
 	payload := ghEventPayloadComment{
 		Action: "created",
@@ -641,7 +645,8 @@ func TestProcessIssueCommentEvent_BotPatternDetection(t *testing.T) {
 	}
 
 	w := NewEventWatcher(store, "owner", []string{"repo"}, time.Minute, cb).
-		WithBotCommentPatterns(patterns)
+		WithBotCommentPatterns(patterns).
+		WithAuthorizedUsers([]string{"ytnobody"})
 
 	payload := ghEventPayloadComment{
 		Action: "created",
@@ -683,7 +688,8 @@ func TestEventWatcher_WithBotCommentPatterns_HumanComment(t *testing.T) {
 
 	patterns, _ := CompileBotPatterns([]string{`^\*\*\[`})
 	w := NewEventWatcher(store, "owner", []string{"repo"}, time.Minute, cb).
-		WithBotCommentPatterns(patterns)
+		WithBotCommentPatterns(patterns).
+		WithAuthorizedUsers([]string{"ytnobody"})
 
 	payload := ghEventPayloadComment{
 		Action: "created",

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -151,10 +151,12 @@ func (s *Syncer) WithSkipComments(skip bool) *Syncer {
 }
 
 // isAuthorized returns true if the given GitHub login is authorized.
-// When authorizedUsers is empty, all users are authorized.
+// When authorizedUsers is empty, no users are authorized (deny-all).
+// This is defense-in-depth: config validation should prevent the empty-list
+// case from reaching production code when GitHub integration is enabled.
 func isAuthorized(login string, authorizedUsers []string) bool {
 	if len(authorizedUsers) == 0 {
-		return true
+		return false
 	}
 	for _, u := range authorizedUsers {
 		if u == login {

--- a/internal/github/github_test.go
+++ b/internal/github/github_test.go
@@ -302,12 +302,15 @@ func TestSyncer_UpdateIdleState_NilDetector(t *testing.T) {
 }
 
 func TestIsAuthorized_EmptyList(t *testing.T) {
-	// Empty authorized users means everyone is authorized.
-	if !isAuthorized("alice", nil) {
-		t.Error("expected alice to be authorized when list is empty")
+	// Empty authorized users means no one is authorized (deny-all for safety).
+	if isAuthorized("alice", nil) {
+		t.Error("expected alice to be unauthorized when list is nil (deny-all)")
 	}
-	if !isAuthorized("", nil) {
-		t.Error("expected empty login to be authorized when list is empty")
+	if isAuthorized("", nil) {
+		t.Error("expected empty login to be unauthorized when list is nil (deny-all)")
+	}
+	if isAuthorized("alice", []string{}) {
+		t.Error("expected alice to be unauthorized when list is empty slice (deny-all)")
 	}
 }
 


### PR DESCRIPTION
Issue: ytnobody-MADFLOW-198

## Summary

- Added startup validation in `config.Load()` to reject configurations that enable `[github]` integration without setting `authorized_users`, preventing the default all-permit behavior that allows arbitrary GitHub users to interact with MADFLOW
- Changed `isAuthorized()` in `internal/github/github.go` to return `false` (deny-all) when `authorizedUsers` is empty, as defense-in-depth against any misconfiguration
- Updated all affected tests to reflect the new deny-all default behavior

## Security Impact

This fix closes the attack path for 4 issues documented in `SECURITY_AUDIT_REPORT.md`:
- **CRITICAL**: Arbitrary command execution via LLM responses
- **CRITICAL**: Claude CLI `--dangerously-skip-permissions` compound risk
- **HIGH**: Prompt injection via issue body
- **MEDIUM**: Default all-user trust (direct fix target)