### PR TITLE
feat: add SHA256 checksum verification to binary auto-update (#200)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,13 @@ jobs:
           GOOS=darwin  GOARCH=arm64 go build -ldflags "${LDFLAGS}" -o dist/madflow-darwin-arm64  ./cmd/madflow
           GOOS=windows GOARCH=amd64 go build -ldflags "${LDFLAGS}" -o dist/madflow-windows-amd64.exe ./cmd/madflow
 
+      - name: Generate SHA256 checksums
+        run: |
+          cd dist
+          for f in madflow-linux-amd64 madflow-linux-arm64 madflow-darwin-amd64 madflow-darwin-arm64 madflow-windows-amd64.exe; do
+            sha256sum "$f" | awk '{print $1}' > "${f}.sha256"
+          done
+
       - name: Create or Update GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
@@ -50,6 +57,11 @@ jobs:
               dist/madflow-darwin-amd64 \
               dist/madflow-darwin-arm64 \
               dist/madflow-windows-amd64.exe \
+              dist/madflow-linux-amd64.sha256 \
+              dist/madflow-linux-arm64.sha256 \
+              dist/madflow-darwin-amd64.sha256 \
+              dist/madflow-darwin-arm64.sha256 \
+              dist/madflow-windows-amd64.exe.sha256 \
               --clobber
           else
             echo "Creating new release $VERSION..."
@@ -59,5 +71,10 @@ jobs:
               dist/madflow-linux-arm64 \
               dist/madflow-darwin-amd64 \
               dist/madflow-darwin-arm64 \
-              dist/madflow-windows-amd64.exe
+              dist/madflow-windows-amd64.exe \
+              dist/madflow-linux-amd64.sha256 \
+              dist/madflow-linux-arm64.sha256 \
+              dist/madflow-darwin-amd64.sha256 \
+              dist/madflow-darwin-arm64.sha256 \
+              dist/madflow-windows-amd64.exe.sha256
           fi

--- a/cmd/madflow/upgrade.go
+++ b/cmd/madflow/upgrade.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -46,18 +48,25 @@ func cmdUpgrade(currentVersion string) error {
 
 	// Determine the target binary name based on current platform.
 	binaryName := getBinaryName()
+	checksumName := binaryName + ".sha256"
 	fmt.Printf("Looking for asset: %s\n", binaryName)
 
-	// Find the matching asset.
+	// Find the matching binary asset and checksum asset.
 	downloadURL := ""
+	checksumURL := ""
 	for _, asset := range release.Assets {
-		if asset.Name == binaryName {
+		switch asset.Name {
+		case binaryName:
 			downloadURL = asset.BrowserDownloadURL
-			break
+		case checksumName:
+			checksumURL = asset.BrowserDownloadURL
 		}
 	}
 	if downloadURL == "" {
 		return fmt.Errorf("no matching asset found for %s in release %s", binaryName, latestVersion)
+	}
+	if checksumURL == "" {
+		return fmt.Errorf("no checksum asset found for %s in release %s (expected %s)", binaryName, latestVersion, checksumName)
 	}
 
 	// Get current executable path.
@@ -72,6 +81,18 @@ func cmdUpgrade(currentVersion string) error {
 		return fmt.Errorf("failed to download binary: %w", err)
 	}
 	defer os.Remove(newBinary)
+
+	// Download and verify the SHA256 checksum before installing.
+	fmt.Printf("Verifying SHA256 checksum from %s...\n", checksumURL)
+	expectedChecksum, err := downloadChecksum(checksumURL)
+	if err != nil {
+		return fmt.Errorf("failed to download checksum: %w", err)
+	}
+
+	if err := verifyChecksum(newBinary, expectedChecksum); err != nil {
+		return fmt.Errorf("checksum verification failed: %w", err)
+	}
+	fmt.Println("Checksum verification passed.")
 
 	// Backup current binary.
 	backupPath := exePath + ".bak"
@@ -170,6 +191,62 @@ func downloadBinary(url string) (string, error) {
 	}
 
 	return tmpFile.Name(), nil
+}
+
+// downloadChecksum downloads a SHA256 checksum file from the given URL and
+// returns the expected hex digest string.
+func downloadChecksum(url string) (string, error) {
+	resp, err := http.Get(url) //nolint:gosec // URL is validated from GitHub API
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("checksum download returned status %d", resp.StatusCode)
+	}
+
+	// Read at most 128 bytes — a SHA256 hex digest is 64 characters.
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 128))
+	if err != nil {
+		return "", fmt.Errorf("failed to read checksum response: %w", err)
+	}
+
+	digest := strings.TrimSpace(string(body))
+	if digest == "" {
+		return "", fmt.Errorf("checksum file is empty")
+	}
+	// Validate that the digest looks like a lowercase hex SHA256 hash (64 chars).
+	if len(digest) != 64 {
+		return "", fmt.Errorf("unexpected checksum length %d (want 64 hex characters)", len(digest))
+	}
+	for _, c := range digest {
+		if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f')) {
+			return "", fmt.Errorf("checksum contains invalid character %q (expected lowercase hex)", c)
+		}
+	}
+	return digest, nil
+}
+
+// verifyChecksum computes the SHA256 hash of the file at filePath and
+// compares it to expectedHex. Returns an error if they do not match.
+func verifyChecksum(filePath, expectedHex string) error {
+	f, err := os.Open(filePath)
+	if err != nil {
+		return fmt.Errorf("failed to open file for checksum: %w", err)
+	}
+	defer f.Close()
+
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return fmt.Errorf("failed to compute checksum: %w", err)
+	}
+
+	actualHex := hex.EncodeToString(h.Sum(nil))
+	if actualHex != expectedHex {
+		return fmt.Errorf("SHA256 mismatch: got %s, want %s", actualHex, expectedHex)
+	}
+	return nil
 }
 
 // copyFile copies a file from src to dst, overwriting dst if it exists.

--- a/cmd/madflow/upgrade_test.go
+++ b/cmd/madflow/upgrade_test.go
@@ -1,7 +1,10 @@
 package main
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -144,5 +147,194 @@ func TestDownloadBinary_HTTPError(t *testing.T) {
 	_, err := downloadBinary(ts.URL + "/nonexistent")
 	if err == nil {
 		t.Error("downloadBinary() should return error on HTTP 404")
+	}
+}
+
+func TestDownloadChecksum(t *testing.T) {
+	expectedDigest := "a3f5b2c1d4e6f7890123456789abcdef0123456789abcdef0123456789abcdef"
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintln(w, expectedDigest)
+	}))
+	defer ts.Close()
+
+	got, err := downloadChecksum(ts.URL + "/madflow-linux-amd64.sha256")
+	if err != nil {
+		t.Fatalf("downloadChecksum() error: %v", err)
+	}
+	if got != expectedDigest {
+		t.Errorf("downloadChecksum() = %q, want %q", got, expectedDigest)
+	}
+}
+
+func TestDownloadChecksum_HTTPError(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer ts.Close()
+
+	_, err := downloadChecksum(ts.URL + "/nonexistent.sha256")
+	if err == nil {
+		t.Error("downloadChecksum() should return error on HTTP 404")
+	}
+}
+
+func TestDownloadChecksum_EmptyBody(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		// Empty body
+	}))
+	defer ts.Close()
+
+	_, err := downloadChecksum(ts.URL + "/empty.sha256")
+	if err == nil {
+		t.Error("downloadChecksum() should return error for empty body")
+	}
+}
+
+func TestDownloadChecksum_WrongLength(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintln(w, "tooshort")
+	}))
+	defer ts.Close()
+
+	_, err := downloadChecksum(ts.URL + "/bad.sha256")
+	if err == nil {
+		t.Error("downloadChecksum() should return error for wrong-length digest")
+	}
+}
+
+func TestDownloadChecksum_InvalidChars(t *testing.T) {
+	// 64 chars but contains uppercase (invalid for lowercase hex requirement).
+	invalidDigest := "A3F5B2C1D4E6F7890123456789ABCDEF0123456789ABCDEF0123456789ABCDEF"
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintln(w, invalidDigest)
+	}))
+	defer ts.Close()
+
+	_, err := downloadChecksum(ts.URL + "/bad.sha256")
+	if err == nil {
+		t.Error("downloadChecksum() should return error for non-lowercase-hex digest")
+	}
+}
+
+func TestVerifyChecksum_Match(t *testing.T) {
+	content := []byte("test binary data for checksum verification")
+	h := sha256.Sum256(content)
+	expectedHex := hex.EncodeToString(h[:])
+
+	tmpDir := t.TempDir()
+	filePath := filepath.Join(tmpDir, "testbin")
+	if err := os.WriteFile(filePath, content, 0644); err != nil {
+		t.Fatalf("failed to write test file: %v", err)
+	}
+
+	if err := verifyChecksum(filePath, expectedHex); err != nil {
+		t.Errorf("verifyChecksum() unexpected error: %v", err)
+	}
+}
+
+func TestVerifyChecksum_Mismatch(t *testing.T) {
+	content := []byte("test binary data for checksum verification")
+	wrongHex := strings.Repeat("0", 64)
+
+	tmpDir := t.TempDir()
+	filePath := filepath.Join(tmpDir, "testbin")
+	if err := os.WriteFile(filePath, content, 0644); err != nil {
+		t.Fatalf("failed to write test file: %v", err)
+	}
+
+	err := verifyChecksum(filePath, wrongHex)
+	if err == nil {
+		t.Error("verifyChecksum() should return error on digest mismatch")
+	}
+	if !strings.Contains(err.Error(), "SHA256 mismatch") {
+		t.Errorf("verifyChecksum() error should mention SHA256 mismatch, got: %v", err)
+	}
+}
+
+func TestVerifyChecksum_FileNotFound(t *testing.T) {
+	err := verifyChecksum("/nonexistent/path/to/file", strings.Repeat("0", 64))
+	if err == nil {
+		t.Error("verifyChecksum() should return error for nonexistent file")
+	}
+}
+
+func TestChecksumVerification_TamperedBinary(t *testing.T) {
+	// Integration-style test: binary content differs from what the checksum covers.
+	realContent := []byte("this is the authentic binary content")
+	fakeContent := []byte("this is a tampered binary content!!!")
+
+	h := sha256.Sum256(realContent)
+	correctChecksum := hex.EncodeToString(h[:])
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/binary":
+			// Serve the tampered binary.
+			w.WriteHeader(http.StatusOK)
+			w.Write(fakeContent)
+		case "/checksum":
+			// Serve checksum of the real content.
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprintln(w, correctChecksum)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer ts.Close()
+
+	tmpPath, err := downloadBinary(ts.URL + "/binary")
+	if err != nil {
+		t.Fatalf("downloadBinary() error: %v", err)
+	}
+	defer os.Remove(tmpPath)
+
+	expected, err := downloadChecksum(ts.URL + "/checksum")
+	if err != nil {
+		t.Fatalf("downloadChecksum() error: %v", err)
+	}
+
+	err = verifyChecksum(tmpPath, expected)
+	if err == nil {
+		t.Error("verifyChecksum() should have failed for tampered binary")
+	}
+}
+
+func TestChecksumVerification_HappyPath(t *testing.T) {
+	// Integration-style test: binary content matches published checksum.
+	content := []byte("this is the authentic binary content")
+	h := sha256.Sum256(content)
+	checksumHex := hex.EncodeToString(h[:])
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/binary":
+			w.WriteHeader(http.StatusOK)
+			w.Write(content)
+		case "/checksum":
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprintln(w, checksumHex)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer ts.Close()
+
+	tmpPath, err := downloadBinary(ts.URL + "/binary")
+	if err != nil {
+		t.Fatalf("downloadBinary() error: %v", err)
+	}
+	defer os.Remove(tmpPath)
+
+	expected, err := downloadChecksum(ts.URL + "/checksum")
+	if err != nil {
+		t.Fatalf("downloadChecksum() error: %v", err)
+	}
+
+	if err := verifyChecksum(tmpPath, expected); err != nil {
+		t.Errorf("verifyChecksum() unexpected error for matching checksum: %v", err)
 	}
 }

--- a/docs/specs/sha256-checksum-verification.md
+++ b/docs/specs/sha256-checksum-verification.md
@@ -1,0 +1,75 @@
+# SHA256 Checksum Verification for Binary Auto-Update
+
+## Overview
+
+When `madflow upgrade` downloads a binary from GitHub Releases, it must verify the SHA256 checksum of the downloaded file before replacing the current executable. This prevents malicious binary replacement in the event of a GitHub Release compromise or a man-in-the-middle (MITM) attack.
+
+## Related Issue
+
+- Issue: [#200 バイナリ自動更新時にSHA256チェックサム検証を追加する](https://github.com/ytnobody/MADFLOW/issues/200)
+- Security Audit: `SECURITY_AUDIT_REPORT.md` section 3.3
+
+## Design
+
+### Checksum File Format
+
+For each binary release asset, a corresponding SHA256 checksum file is published alongside it. The checksum file name follows the pattern:
+
+```
+{binary-name}.sha256
+```
+
+For example:
+- Binary: `madflow-linux-amd64`
+- Checksum: `madflow-linux-amd64.sha256`
+
+The content of the checksum file is a single line containing the lowercase hex-encoded SHA256 digest of the binary, followed by a newline:
+
+```
+<hex-sha256-digest>
+```
+
+This format is intentionally simple (digest only, no filename), compatible with standard `sha256sum` output when trimmed.
+
+### Verification Flow
+
+1. Fetch the latest release info from the GitHub Releases API.
+2. Locate the binary asset matching the current platform (`madflow-{os}-{arch}`).
+3. Locate the checksum asset for that binary (`madflow-{os}-{arch}.sha256`).
+4. If the checksum asset is not found in the release, abort with an error.
+5. Download the binary to a temporary file.
+6. Download the checksum file (in memory).
+7. Compute the SHA256 digest of the downloaded temporary binary.
+8. Compare the computed digest with the expected digest from the checksum file.
+9. If they do not match, delete the temporary file and abort with an error.
+10. If they match, proceed with replacing the current executable.
+
+### Error Handling
+
+- If the checksum asset is not present in the release, the upgrade is aborted. This makes checksum verification mandatory (fail-closed).
+- If the downloaded checksum content is malformed (empty, unexpected format), the upgrade is aborted.
+- If the checksums do not match, the upgrade is aborted and the temporary binary is deleted.
+
+## Release Workflow Changes
+
+The `.github/workflows/release.yml` workflow is updated to generate and upload checksum files for each binary artifact:
+
+```bash
+cd dist
+for f in madflow-linux-amd64 madflow-linux-arm64 madflow-darwin-amd64 madflow-darwin-arm64 madflow-windows-amd64.exe; do
+  sha256sum "$f" | awk '{print $1}' > "${f}.sha256"
+done
+```
+
+The resulting `.sha256` files are uploaded to the GitHub Release alongside the binary files.
+
+## Security Properties
+
+- **Integrity**: Any modification to the binary after release will cause checksum mismatch and the upgrade will be rejected.
+- **Fail-closed**: If a checksum file is missing from the release, the upgrade is refused rather than proceeding without verification.
+- **No trust-on-first-use**: The checksum file and binary are both fetched from the same GitHub Release; the verification catches corruption or tampering of the binary relative to the published checksum.
+
+## Limitations
+
+- This does not provide cryptographic authenticity (i.e., it does not prove the release was made by the legitimate maintainer). For stronger guarantees, GPG signing of checksums would be needed.
+- Both the binary and checksum file are served from GitHub. A full GitHub Release compromise would affect both. However, this protects against MITM attacks on the download transport and accidental binary corruption.


### PR DESCRIPTION
## Summary

- Adds mandatory SHA256 checksum verification to `madflow upgrade` before installing a new binary (fail-closed: upgrade is refused if checksum asset is absent or digest mismatches)
- Updates `.github/workflows/release.yml` to generate and upload `.sha256` sidecar files for each binary artifact during release
- Adds spec documentation in `docs/specs/sha256-checksum-verification.md`

## Changes

- `cmd/madflow/upgrade.go`: added `downloadChecksum()`, `verifyChecksum()`, and wired them into `cmdUpgrade()` between download and install steps
- `cmd/madflow/upgrade_test.go`: added tests for all new functions including tampered-binary rejection and happy-path scenarios
- `.github/workflows/release.yml`: new "Generate SHA256 checksums" step + uploads `.sha256` files to each release
- `docs/specs/sha256-checksum-verification.md`: spec document

## Test plan

- [ ] `go build ./...` passes
- [ ] `go test ./...` passes (all packages green)
- [ ] `TestDownloadChecksum` — verifies valid digest accepted
- [ ] `TestDownloadChecksum_EmptyBody` / `_WrongLength` / `_InvalidChars` — verifies malformed checksum files are rejected
- [ ] `TestVerifyChecksum_Match` — verifies matching digest accepted
- [ ] `TestVerifyChecksum_Mismatch` — verifies mismatched digest rejected with clear error
- [ ] `TestChecksumVerification_TamperedBinary` — verifies tampered binary is refused
- [ ] `TestChecksumVerification_HappyPath` — verifies authentic binary is accepted

Closes #200

🤖 Generated with [Claude Code](https://claude.com/claude-code)