### PR TITLE
ytnobody-MADFLOW-201: ブランチ名・イシューIDのパストラバーサル対策を追加する

### DIFF
--- a/docs/specs/path-traversal-protection.md
+++ b/docs/specs/path-traversal-protection.md
@@ -1,0 +1,43 @@
+# Path Traversal Protection for Branch Names and Issue IDs
+
+## Overview
+
+When `filepath.Join()` is used to compose worktree directory paths from external input (branch names, issue IDs), a crafted value containing `..` or path separators could escape the intended `.worktrees/` directory. This spec defines the validation rules and implementation details for protecting against such path traversal attacks.
+
+## Background
+
+- **Affected code**: `internal/git/git.go` — `PrepareWorktree`, `AddWorktree`, `CleanWorktrees`, `CleanOrphanedWorktrees`
+- **Input source**: Branch names and issue IDs are derived from GitHub issues (external input)
+- **Risk**: A crafted issue ID such as `../../sensitive` could cause worktree operations to target paths outside `.worktrees/`
+- **Reference**: `SECURITY_AUDIT_REPORT.md` section 3.3
+
+## Validation Rules
+
+A safe name (branch name component or issue ID) must satisfy all of the following:
+
+1. **Non-empty**: Empty strings are rejected.
+2. **No `..` sequences**: Strings containing `..` are rejected to prevent directory traversal.
+3. **No path separators**: Strings containing `/` or `\` are rejected.
+4. **No null bytes**: Strings containing `\x00` are rejected.
+
+## Implementation
+
+### Function: `ValidateSafeName(name string) error`
+
+Located in `internal/git/git.go`. Returns a non-nil error if `name` violates any validation rule.
+
+### Integration Points
+
+`PrepareWorktree` validates its `featureBranch` argument using `ValidateSafeName` before proceeding.
+
+Note: `CleanWorktrees` and `CleanOrphanedWorktrees` read directory names via `os.ReadDir`, which cannot return `..` entries; these functions are safe without additional validation. The validation at `PrepareWorktree` covers the write path where external input is used.
+
+## Test Coverage
+
+Tests in `internal/git/git_test.go` cover:
+- Valid names that should pass (alphanumeric, hyphens, dots in non-traversal positions)
+- Strings with `..` (rejected)
+- Strings with `/` or `\` (rejected)
+- Empty string (rejected)
+- Null byte (rejected)
+- Integration: `PrepareWorktree` rejects a crafted traversal branch name

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -194,9 +194,32 @@ func (r *Repo) CleanOrphanedWorktrees(activeTeamDirs map[string]bool) (removed [
 	return removed
 }
 
+// ValidateSafeName validates that name is safe to use as a branch name component
+// or issue ID in file path operations. It rejects empty strings, strings
+// containing ".." (path traversal), path separators ("/" or "\"), and null bytes.
+func ValidateSafeName(name string) error {
+	if name == "" {
+		return fmt.Errorf("name must not be empty")
+	}
+	if strings.Contains(name, "..") {
+		return fmt.Errorf("name %q contains prohibited sequence \"..\"", name)
+	}
+	if strings.ContainsAny(name, "/\\") {
+		return fmt.Errorf("name %q contains prohibited path separator", name)
+	}
+	if strings.ContainsRune(name, '\x00') {
+		return fmt.Errorf("name %q contains null byte", name)
+	}
+	return nil
+}
+
 // PrepareWorktree ensures the develop branch exists (creating from main if needed)
 // and creates a worktree with a new feature branch based on develop.
+// It validates featureBranch to prevent path traversal attacks.
 func (r *Repo) PrepareWorktree(path, featureBranch, developBranch, mainBranch string) error {
+	if err := ValidateSafeName(featureBranch); err != nil {
+		return fmt.Errorf("invalid feature branch name: %w", err)
+	}
 	if err := r.EnsureBranch(developBranch, mainBranch); err != nil {
 		return fmt.Errorf("ensure develop branch: %w", err)
 	}

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -529,3 +529,66 @@ func TestMergeConflict(t *testing.T) {
 	// and the merge was aborted). Both are acceptable.
 	_ = err
 }
+
+func TestValidateSafeName(t *testing.T) {
+	validCases := []string{
+		"feature-issue-123",
+		"gh-121",
+		"local-001",
+		"ytnobody-MADFLOW-201",
+		"abc",
+		"a",
+		"issue.123",
+	}
+	for _, name := range validCases {
+		t.Run("valid/"+name, func(t *testing.T) {
+			if err := ValidateSafeName(name); err != nil {
+				t.Errorf("expected %q to be valid, got error: %v", name, err)
+			}
+		})
+	}
+
+	invalidCases := []struct {
+		name string
+		desc string
+	}{
+		{"", "empty string"},
+		{"..", "double dot alone"},
+		{"foo/../bar", "path traversal with .."},
+		{"../secret", "leading .."},
+		{"foo/bar", "forward slash"},
+		{"foo\\bar", "backslash"},
+		{"/absolute", "absolute path with slash"},
+		{"foo\x00bar", "null byte"},
+	}
+	for _, tc := range invalidCases {
+		t.Run("invalid/"+tc.desc, func(t *testing.T) {
+			if err := ValidateSafeName(tc.name); err == nil {
+				t.Errorf("expected %q (%s) to be invalid, but got no error", tc.name, tc.desc)
+			}
+		})
+	}
+}
+
+func TestPrepareWorktreeRejectsTraversalBranchName(t *testing.T) {
+	repo := initTestRepo(t)
+
+	baseBranch, err := repo.CurrentBranch()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	wtDir := filepath.Join(t.TempDir(), "wt-traversal")
+
+	// A crafted branch name containing ".." should be rejected before any
+	// filesystem or git operation is attempted.
+	err = repo.PrepareWorktree(wtDir, "../../evil", "develop", baseBranch)
+	if err == nil {
+		t.Fatal("expected error for path traversal branch name, got nil")
+	}
+
+	// The worktree directory must not have been created.
+	if _, statErr := os.Stat(wtDir); !os.IsNotExist(statErr) {
+		t.Error("worktree directory must not exist after rejected traversal attempt")
+	}
+}


### PR DESCRIPTION
## Summary

- Add `ValidateSafeName()` function in `internal/git/git.go` that rejects strings containing `..`, `/`, `\`, null bytes, or empty strings
- Integrate validation into `PrepareWorktree()` so externally-supplied branch names (from GitHub issue IDs) cannot escape the `.worktrees/` directory via `filepath.Join()`
- Add comprehensive unit tests (`TestValidateSafeName`, `TestPrepareWorktreeRejectsTraversalBranchName`) and spec documentation

## Related Issue

Closes #201

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes (all 13 packages)
- [x] `TestValidateSafeName` covers valid and invalid name cases
- [x] `TestPrepareWorktreeRejectsTraversalBranchName` verifies the integration point rejects traversal inputs

🤖 Generated with [Claude Code](https://claude.com/claude-code)