### PR TITLE
ytnobody-MADFLOW-202: データディレクトリ・チャットログのパーミッションを制限する

### DIFF
--- a/docs/specs/file-permission-restriction.md
+++ b/docs/specs/file-permission-restriction.md
@@ -1,0 +1,45 @@
+# File Permission Restriction Specification
+
+## Overview
+
+MADFLOW stores sensitive information on disk, including GitHub issue content and LLM conversation logs (chatlog). When these files are created with world-readable permissions (`0755` for directories, `0644` for files), other users on the same host can read them, causing a potential information leak.
+
+This spec defines the restrictive permission policy for all data directories and sensitive files.
+
+## Affected Files
+
+### Data Directories
+
+All data directories managed by MADFLOW must be created with permission `0700` (owner read/write/execute only):
+
+| Package | File | Location |
+|---------|------|----------|
+| `internal/orchestrator` | `orchestrator.go` | `Run()` — sub-directories (issues, memos) |
+| `internal/project` | `project.go` | `Add()` — base dir and sub-directories |
+| `internal/issue` | `issue.go` | `Store.Create()` — issues dir |
+| `internal/reset` | `reset.go` | `SaveMemoWithLang()` — memos dir |
+
+### Sensitive Files
+
+All sensitive files (chatlog, memos) must be created/written with permission `0600` (owner read/write only):
+
+| Package | File | Location |
+|---------|------|----------|
+| `internal/orchestrator` | `orchestrator.go` | `Run()` — chatlog truncate |
+| `internal/chatlog` | `chatlog.go` | `Append()` — chatlog append |
+| `internal/chatlog` | `chatlog.go` | `TruncateOldEntries()` — chatlog tmp write |
+| `internal/agent` | `agent.go` | `rescueChatLogMessages()` — chatlog append |
+| `internal/team` | `team.go` | `appendLine()` — chatlog append |
+| `internal/reset` | `reset.go` | `SaveMemoWithLang()` — memo write |
+
+## Permissions
+
+| Resource Type | Old Permission | New Permission | Rationale |
+|--------------|---------------|---------------|-----------|
+| Data directories | `0755` | `0700` | Prevent other users from listing or accessing directory contents |
+| Sensitive files | `0644` | `0600` | Prevent other users from reading chatlog and memo content |
+
+## Edge Cases
+
+- Existing files/directories are not retroactively `chmod`'d — only newly created files/directories use restrictive permissions. Operators should manually fix permissions on existing deployments.
+- Test files in `_test.go` files are intentionally excluded from this change as they operate on temporary test directories and do not contain real sensitive data.

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -188,7 +188,7 @@ func buildMessagePrompt(msgs []chatlog.Message, lang string) string {
 // and writes them to the chatlog file. This handles the case where the AI
 // model returns chatlog messages as text output instead of using bash echo.
 func (a *Agent) rescueChatLogMessages(response string) {
-	f, err := os.OpenFile(a.ChatLog.Path(), os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	f, err := os.OpenFile(a.ChatLog.Path(), os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0600)
 	if err != nil {
 		return
 	}

--- a/internal/chatlog/chatlog.go
+++ b/internal/chatlog/chatlog.go
@@ -64,7 +64,7 @@ func FormatMessage(recipient, sender, body string) string {
 
 // Append writes a new formatted message to the chatlog file.
 func (c *ChatLog) Append(recipient, sender, body string) error {
-	f, err := os.OpenFile(c.path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	f, err := os.OpenFile(c.path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0600)
 	if err != nil {
 		return fmt.Errorf("open chatlog for append: %w", err)
 	}
@@ -257,7 +257,7 @@ func (c *ChatLog) Truncate(maxLines int) error {
 	newContent := strings.Join(lines, "\n") + "\n"
 
 	tmpPath := c.path + ".tmp"
-	if err := os.WriteFile(tmpPath, []byte(newContent), 0644); err != nil {
+	if err := os.WriteFile(tmpPath, []byte(newContent), 0600); err != nil {
 		return fmt.Errorf("write temp chatlog: %w", err)
 	}
 

--- a/internal/chatlog/chatlog_test.go
+++ b/internal/chatlog/chatlog_test.go
@@ -417,3 +417,53 @@ func TestReadFrom_TruncationPreservesNewMessages(t *testing.T) {
 		t.Errorf("expected body 'TEAM_CREATE 6', got: %s", messages[0].Body)
 	}
 }
+
+// TestAppendCreatesFileWithRestrictedPermissions verifies that Append creates
+// the chatlog file with 0600 permissions (owner read/write only).
+func TestAppendCreatesFileWithRestrictedPermissions(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "chatlog.txt")
+
+	cl := New(path)
+	if err := cl.Append("recipient", "sender", "hello"); err != nil {
+		t.Fatalf("Append failed: %v", err)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat chatlog: %v", err)
+	}
+	got := info.Mode().Perm()
+	want := os.FileMode(0600)
+	if got != want {
+		t.Errorf("chatlog permission: got %04o, want %04o", got, want)
+	}
+}
+
+// TestTruncatePreservesRestrictedPermissions verifies that Truncate writes the
+// temp file with 0600 permissions.
+func TestTruncatePreservesRestrictedPermissions(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "chatlog.txt")
+
+	cl := New(path)
+	for i := 0; i < 5; i++ {
+		if err := cl.Append("recipient", "sender", "line"); err != nil {
+			t.Fatalf("Append failed: %v", err)
+		}
+	}
+
+	if err := cl.Truncate(2); err != nil {
+		t.Fatalf("Truncate failed: %v", err)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat chatlog after truncate: %v", err)
+	}
+	got := info.Mode().Perm()
+	want := os.FileMode(0600)
+	if got != want {
+		t.Errorf("chatlog permission after truncate: got %04o, want %04o", got, want)
+	}
+}

--- a/internal/issue/issue.go
+++ b/internal/issue/issue.go
@@ -97,7 +97,7 @@ func (s *Store) Dir() string {
 
 // Create creates a new local issue with auto-incremented ID.
 func (s *Store) Create(title, body string) (*Issue, error) {
-	if err := os.MkdirAll(s.dir, 0755); err != nil {
+	if err := os.MkdirAll(s.dir, 0700); err != nil {
 		return nil, fmt.Errorf("create issues dir: %w", err)
 	}
 

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -103,13 +103,13 @@ func (o *Orchestrator) Config() *config.Config {
 func (o *Orchestrator) Run(ctx context.Context) error {
 	// Ensure data directories exist
 	for _, sub := range []string{"issues", "memos"} {
-		os.MkdirAll(filepath.Join(o.dataDir, sub), 0755)
+		os.MkdirAll(filepath.Join(o.dataDir, sub), 0700)
 	}
 
 	// Truncate chatlog to start with a clean slate. Stale messages from
 	// previous runs confuse the superintendent (e.g. referencing engineers
 	// like engineer-4 that no longer exist, causing phantom TEAM_CREATE).
-	os.WriteFile(o.chatLog.Path(), nil, 0644)
+	os.WriteFile(o.chatLog.Path(), nil, 0600)
 
 	log.Println("[orchestrator] starting")
 

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -51,7 +51,7 @@ func Init(name string, paths []string) error {
 		return err
 	}
 
-	if err := os.MkdirAll(base, 0755); err != nil {
+	if err := os.MkdirAll(base, 0700); err != nil {
 		return fmt.Errorf("create base dir: %w", err)
 	}
 
@@ -81,7 +81,7 @@ func Init(name string, paths []string) error {
 
 	dataDir := filepath.Join(base, name)
 	for _, sub := range []string{"issues", "memos"} {
-		if err := os.MkdirAll(filepath.Join(dataDir, sub), 0755); err != nil {
+		if err := os.MkdirAll(filepath.Join(dataDir, sub), 0700); err != nil {
 			return fmt.Errorf("create data dir: %w", err)
 		}
 	}

--- a/internal/project/project_test.go
+++ b/internal/project/project_test.go
@@ -93,3 +93,32 @@ func TestDetectNotFound(t *testing.T) {
 		t.Fatal("expected error for unregistered directory")
 	}
 }
+
+// TestInitCreatesDirectoriesWithRestrictedPermissions verifies that Init creates
+// data directories with 0700 permissions.
+func TestInitCreatesDirectoriesWithRestrictedPermissions(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+
+	projectDir := filepath.Join(tmpHome, "perm-test-app")
+	if err := os.MkdirAll(projectDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := Init("perm-test-app", []string{projectDir}); err != nil {
+		t.Fatal(err)
+	}
+
+	dataDir := filepath.Join(tmpHome, madflowDir, "perm-test-app")
+	for _, sub := range []string{"issues", "memos"} {
+		info, err := os.Stat(filepath.Join(dataDir, sub))
+		if err != nil {
+			t.Fatalf("expected %s dir to exist: %v", sub, err)
+		}
+		got := info.Mode().Perm()
+		want := os.FileMode(0700)
+		if got != want {
+			t.Errorf("data dir %s permission: got %04o, want %04o", sub, got, want)
+		}
+	}
+}

--- a/internal/reset/reset.go
+++ b/internal/reset/reset.go
@@ -24,7 +24,7 @@ func SaveMemo(memosDir string, memo WorkMemo) (string, error) {
 
 // SaveMemoWithLang writes a work memo to the memos directory with localized headers.
 func SaveMemoWithLang(memosDir string, memo WorkMemo, lang string) (string, error) {
-	if err := os.MkdirAll(memosDir, 0755); err != nil {
+	if err := os.MkdirAll(memosDir, 0700); err != nil {
 		return "", fmt.Errorf("create memos dir: %w", err)
 	}
 
@@ -84,7 +84,7 @@ Date: %s
 		)
 	}
 
-	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
 		return "", fmt.Errorf("write memo: %w", err)
 	}
 	return path, nil

--- a/internal/reset/reset_test.go
+++ b/internal/reset/reset_test.go
@@ -94,6 +94,46 @@ func TestLoadLatestMemoDirNotExist(t *testing.T) {
 	}
 }
 
+// TestSaveMemoCreatesFileWithRestrictedPermissions verifies that SaveMemo
+// creates memo files with 0600 permissions and the memos directory with 0700.
+func TestSaveMemoCreatesFileWithRestrictedPermissions(t *testing.T) {
+	dir := t.TempDir()
+	memosDir := filepath.Join(dir, "memos")
+
+	memo := WorkMemo{
+		AgentID:      "engineer-1",
+		Timestamp:    time.Date(2026, 2, 21, 10, 8, 0, 0, time.UTC),
+		CurrentState: "test",
+	}
+
+	path, err := SaveMemo(memosDir, memo)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Check memo file permissions (0600)
+	fileInfo, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat memo file: %v", err)
+	}
+	gotFile := fileInfo.Mode().Perm()
+	wantFile := os.FileMode(0600)
+	if gotFile != wantFile {
+		t.Errorf("memo file permission: got %04o, want %04o", gotFile, wantFile)
+	}
+
+	// Check memos directory permissions (0700)
+	dirInfo, err := os.Stat(memosDir)
+	if err != nil {
+		t.Fatalf("stat memos dir: %v", err)
+	}
+	gotDir := dirInfo.Mode().Perm()
+	wantDir := os.FileMode(0700)
+	if gotDir != wantDir {
+		t.Errorf("memos dir permission: got %04o, want %04o", gotDir, wantDir)
+	}
+}
+
 func TestTimer(t *testing.T) {
 	timer := NewTimer(100 * time.Millisecond)
 

--- a/internal/team/team.go
+++ b/internal/team/team.go
@@ -45,7 +45,7 @@ func announceStart(team *Team) {
 
 // appendLine はチャットログファイルに1行追記する。
 func appendLine(path, line string) {
-	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0600)
 	if err != nil {
 		log.Printf("[team] announce: open %s: %v", path, err)
 		return


### PR DESCRIPTION
Issue: ytnobody-MADFLOW-202

## Summary

- Data directories created with `0700` (was `0755`) to prevent other users from listing or accessing directory contents
- Chatlog and memo files created with `0600` (was `0644`) to prevent other users from reading sensitive conversation logs and GitHub issue data

## Changed files

- `internal/orchestrator/orchestrator.go` — `0755→0700` (sub-dirs), `0644→0600` (chatlog truncate)
- `internal/chatlog/chatlog.go` — `0644→0600` (Append and Truncate)
- `internal/agent/agent.go` — `0644→0600` (rescueChatLogMessages)
- `internal/team/team.go` — `0644→0600` (appendLine)
- `internal/project/project.go` — `0755→0700` (base dir and sub-dirs)
- `internal/issue/issue.go` — `0755→0700` (issues dir)
- `internal/reset/reset.go` — `0755→0700` (memos dir), `0644→0600` (memo file)

## Spec

`docs/specs/file-permission-restriction.md` added.

## Tests

New tests added in:
- `internal/chatlog/chatlog_test.go` — `TestAppendCreatesFileWithRestrictedPermissions`, `TestTruncatePreservesRestrictedPermissions`
- `internal/project/project_test.go` — `TestInitCreatesDirectoriesWithRestrictedPermissions`
- `internal/reset/reset_test.go` — `TestSaveMemoCreatesFileWithRestrictedPermissions`

All 13 packages pass.