### PR TITLE
ytnobody-MADFLOW-203: エラーログへの機密情報混入を防止する

### DIFF
--- a/docs/specs/log-sanitization.md
+++ b/docs/specs/log-sanitization.md
@@ -1,0 +1,32 @@
+# Log Sanitization Spec
+
+## Overview
+
+Stderr output from subprocesses is logged to assist with diagnostics. However, stderr may contain sensitive information such as API keys, bearer tokens, or other credentials. This spec describes the sanitization applied before any stderr content is logged.
+
+## Patterns to Sanitize
+
+The following patterns are recognized and masked:
+
+| Pattern | Example | Masked Form |
+|---------|---------|-------------|
+| OpenAI / Anthropic-style secret keys (`sk-...`) | `sk-abc123...` | `sk-***` |
+| Bearer tokens in Authorization headers | `Bearer eyJ...` | `Bearer ***` |
+| Google / Gemini API keys (`AIza...`) | `AIzaSy...` | `AIza***` |
+| `key=<value>` query parameters | `?key=myapikey` | `?key=***` |
+| `api_key=<value>` query parameters | `api_key=secret` | `api_key=***` |
+| `token=<value>` query/form parameters | `token=abc` | `token=***` |
+
+## How Sanitization Works
+
+A `SanitizeLog(s string) string` function in `internal/agent/sanitize.go` applies a series of regular expression replacements to an input string. Each regex captures the sensitive portion and replaces it with `***`. The function is applied to:
+
+1. `internal/agent/gemini_api.go` `runBash()`: the stderr content appended to the result string (line 414).
+2. `internal/agent/claude_stream.go` `Send()`: the stderr content passed to `log.Printf` (line 110).
+
+## Edge Cases
+
+- **Multi-line output**: The regexes are applied to the full string; they will match across lines if the pattern spans a line boundary, but in practice each sensitive value appears on a single line.
+- **False positives**: Short words that happen to match (e.g., `token=abc`) will be masked. This is intentional — it is safer to over-mask than to leak credentials.
+- **Already-masked strings**: Applying the sanitizer to an already-sanitized string is idempotent because `***` does not match the sensitive patterns.
+- **Very long values**: The regexes use `[^\s&"']+` to capture the sensitive portion, so they stop at whitespace, `&`, `"`, or `'`. This avoids catastrophic backtracking.

--- a/internal/agent/claude_stream.go
+++ b/internal/agent/claude_stream.go
@@ -106,7 +106,7 @@ func (c *ClaudeStreamProcess) Send(ctx context.Context, prompt string) (string, 
 
 	result, err := c.readResult(ctx)
 	if err != nil && c.stderrBuf != nil {
-		if stderrMsg := strings.TrimSpace(c.stderrBuf.String()); stderrMsg != "" {
+		if stderrMsg := SanitizeLog(strings.TrimSpace(c.stderrBuf.String())); stderrMsg != "" {
 			log.Printf("[claude-stream] stderr: %s", stderrMsg)
 		}
 	}

--- a/internal/agent/gemini_api.go
+++ b/internal/agent/gemini_api.go
@@ -411,7 +411,7 @@ func (g *GeminiAPIProcess) runBash(ctx context.Context, command string) (string,
 		if result != "" {
 			result += "\n"
 		}
-		result += "STDERR:\n" + strings.TrimSpace(stderr.String())
+		result += "STDERR:\n" + SanitizeLog(strings.TrimSpace(stderr.String()))
 	}
 	if result == "" && err != nil {
 		result = fmt.Sprintf("command failed: %v", err)

--- a/internal/agent/sanitize.go
+++ b/internal/agent/sanitize.go
@@ -1,0 +1,35 @@
+package agent
+
+import "regexp"
+
+// sensitivePatterns is the list of regexes used to mask credentials in log output.
+// Each pattern must capture the sensitive value in group 1 so it can be replaced
+// with "***" while keeping the surrounding context intact.
+var sensitivePatterns = []*regexp.Regexp{
+	// OpenAI / Anthropic-style secret keys: sk-<value>
+	regexp.MustCompile(`(?i)(sk-)[^\s"'&]{8,}`),
+	// Google / Gemini API keys: AIza<value>
+	regexp.MustCompile(`(AIza)[^\s"'&]{8,}`),
+	// Bearer tokens in Authorization headers
+	regexp.MustCompile(`(?i)(Bearer\s+)[^\s"'&]{4,}`),
+	// URL query parameters: key=, api_key=, token=, access_token=, secret=
+	regexp.MustCompile(`(?i)(\b(?:key|api[_-]key|token|access[_-]token|secret)=)[^\s"'&]{4,}`),
+}
+
+// SanitizeLog masks known sensitive patterns (API keys, tokens, bearer credentials)
+// in s and returns the sanitized string. It is safe to call on any log message.
+func SanitizeLog(s string) string {
+	for _, re := range sensitivePatterns {
+		s = re.ReplaceAllStringFunc(s, func(match string) string {
+			// Find the prefix (captured group 1 equivalent) by re-matching.
+			sub := re.FindStringSubmatchIndex(match)
+			if len(sub) < 4 {
+				return match
+			}
+			// sub[2]..sub[3] is the position of the first capture group inside match.
+			prefix := match[sub[2]:sub[3]]
+			return prefix + "***"
+		})
+	}
+	return s
+}

--- a/internal/agent/sanitize_test.go
+++ b/internal/agent/sanitize_test.go
@@ -1,0 +1,104 @@
+package agent
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSanitizeLog(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		wantMasked  []string // substrings that must NOT appear in the output
+		wantPresent []string // substrings that must still appear in the output
+	}{
+		{
+			name:        "sk- key is masked",
+			input:       "error: invalid key sk-abc1234567890XYZ",
+			wantMasked:  []string{"sk-abc1234567890XYZ"},
+			wantPresent: []string{"sk-***", "error: invalid key"},
+		},
+		{
+			name:        "AIza key is masked",
+			input:       "using api key AIzaSyD-9tSrke72I6e49zkreH8HsGzABCD1234",
+			wantMasked:  []string{"AIzaSyD-9tSrke72I6e49zkreH8HsGzABCD1234"},
+			wantPresent: []string{"AIza***"},
+		},
+		{
+			name:        "Bearer token is masked",
+			input:       "Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9",
+			wantMasked:  []string{"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9"},
+			wantPresent: []string{"Bearer ***"},
+		},
+		{
+			name:        "bearer token case-insensitive",
+			input:       "header: bearer supersecrettoken12345",
+			wantMasked:  []string{"supersecrettoken12345"},
+			wantPresent: []string{"bearer ***"},
+		},
+		{
+			name:        "key= query parameter is masked",
+			input:       "GET /api?key=mysecretapikey123 HTTP/1.1",
+			wantMasked:  []string{"mysecretapikey123"},
+			wantPresent: []string{"key=***"},
+		},
+		{
+			name:        "api_key= is masked",
+			input:       "request failed: api_key=supersecret123",
+			wantMasked:  []string{"supersecret123"},
+			wantPresent: []string{"api_key=***"},
+		},
+		{
+			name:        "token= is masked",
+			input:       "token=abcdefghij refresh failed",
+			wantMasked:  []string{"abcdefghij"},
+			wantPresent: []string{"token=***"},
+		},
+		{
+			name:        "access_token= is masked",
+			input:       "access_token=longaccesstoken999 expired",
+			wantMasked:  []string{"longaccesstoken999"},
+			wantPresent: []string{"access_token=***"},
+		},
+		{
+			name:        "no sensitive data passes through unchanged",
+			input:       "command failed: exit status 1",
+			wantMasked:  []string{},
+			wantPresent: []string{"command failed: exit status 1"},
+		},
+		{
+			name:        "empty string",
+			input:       "",
+			wantMasked:  []string{},
+			wantPresent: []string{},
+		},
+		{
+			name:        "multiple secrets in one string",
+			input:       "key=secretkey1234 and Bearer tokenvalue5678",
+			wantMasked:  []string{"secretkey1234", "tokenvalue5678"},
+			wantPresent: []string{"key=***", "Bearer ***"},
+		},
+		{
+			name:        "idempotent on already-sanitized output",
+			input:       "sk-*** and key=***",
+			wantMasked:  []string{},
+			wantPresent: []string{"sk-***", "key=***"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := SanitizeLog(tt.input)
+			for _, banned := range tt.wantMasked {
+				if strings.Contains(got, banned) {
+					t.Errorf("SanitizeLog(%q) = %q; still contains sensitive value %q", tt.input, got, banned)
+				}
+			}
+			for _, want := range tt.wantPresent {
+				if !strings.Contains(got, want) {
+					t.Errorf("SanitizeLog(%q) = %q; expected to contain %q", tt.input, got, want)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `internal/agent/sanitize.go` with `SanitizeLog()` that masks API keys (`sk-*`, `AIza*`), bearer tokens, and query-parameter credentials (`key=`, `token=`, `api_key=`, etc.) using compiled regex patterns
- Applies `SanitizeLog()` to stderr content in `gemini_api.go` `runBash()` (line 414) before it is appended to the result string
- Applies `SanitizeLog()` to stderr content in `claude_stream.go` `Send()` before it is passed to `log.Printf`
- Adds spec document `docs/specs/log-sanitization.md`
- Adds 12 unit-test cases in `internal/agent/sanitize_test.go` covering all pattern types, the no-sensitive-data path, and idempotency

## Test plan

- [x] `go build ./...` passes with no errors
- [x] `go test ./...` passes (all 13 packages green)
- [ ] Manual review: confirm masked output in stderr-heavy scenarios (e.g. bad API key returns 401 with key in error body)

Issue: ytnobody-MADFLOW-203

🤖 Generated with [Claude Code](https://claude.com/claude-code)