### PR TITLE
ytnobody-MADFLOW-204: GitHub APIレート制限の事前チェックを追加する

### DIFF
--- a/docs/specs/github-rate-limit-check.md
+++ b/docs/specs/github-rate-limit-check.md
@@ -1,0 +1,74 @@
+# GitHub API Rate Limit Pre-Check
+
+## Overview
+
+Before making GitHub API calls, the `Syncer` checks the remaining rate limit.
+If the remaining count is at or below a configurable threshold, the Syncer waits
+until the rate limit resets before proceeding, or returns an error to skip the
+current sync cycle.
+
+## Design
+
+### New Fields on `Syncer`
+
+- `rateLimitThreshold int` — minimum remaining API calls required before
+  proceeding. Default: `10`. A value of `0` disables the pre-check.
+
+### New Builder Method
+
+```go
+func (s *Syncer) WithRateLimitThreshold(n int) *Syncer
+```
+
+Sets the rate-limit threshold. Calling with `0` disables the check.
+
+### Rate Limit Structs
+
+```go
+// ghRateLimitResponse is the parsed JSON from `gh api rate_limit`.
+type ghRateLimitResponse struct {
+    Resources struct {
+        Core ghRateLimitResource `json:"core"`
+    } `json:"resources"`
+}
+
+type ghRateLimitResource struct {
+    Limit     int   `json:"limit"`
+    Remaining int   `json:"remaining"`
+    Reset     int64 `json:"reset"` // Unix timestamp
+    Used      int   `json:"used"`
+}
+```
+
+### `checkRateLimit()` Behavior
+
+1. If `rateLimitThreshold == 0`, return `nil` immediately (check disabled).
+2. Execute `gh api rate_limit` to fetch current rate limit state.
+3. Parse the JSON response into `ghRateLimitResponse`.
+4. If `core.Remaining > rateLimitThreshold`, return `nil` (safe to proceed).
+5. If `core.Remaining <= rateLimitThreshold`:
+   - Calculate wait duration: `time.Until(time.Unix(core.Reset, 0)) + 1s buffer`
+   - If wait duration ≤ 0, return `nil` (reset has already passed).
+   - If wait duration > `rateLimitMaxWait` (default 10 minutes), return an
+     error to skip the current sync cycle instead of waiting too long.
+   - Otherwise, log a warning and wait the calculated duration.
+
+### Integration
+
+`checkRateLimit()` is called at the start of:
+- `fetchIssues(repo string)`
+- `fetchComments(repo string, issueNumber int)`
+
+Both functions return an error if `checkRateLimit()` returns an error.
+
+## Constants
+
+- `defaultRateLimitThreshold = 10` — default minimum remaining calls
+- `rateLimitMaxWait = 10 * time.Minute` — maximum time to wait for reset
+
+## Edge Cases
+
+- If `gh api rate_limit` fails (e.g. no network), the pre-check logs a warning
+  and returns `nil` to allow the sync attempt to proceed (fail-open behavior).
+- If the reset time is in the past, proceed immediately.
+- If wait time exceeds `rateLimitMaxWait`, return an error to skip (not block).

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -101,24 +101,26 @@ type ghLabel struct {
 
 // Syncer synchronizes GitHub Issues to local issue files.
 type Syncer struct {
-	store           *issue.Store
-	owner           string
-	repos           []string
-	interval        time.Duration
-	idleDetector    *IdleDetector    // nil = no adaptive behavior
-	idleInterval    time.Duration    // effective only when idleDetector is set
-	authorizedUsers []string         // empty = all users trusted
-	botPatterns     []*regexp.Regexp // compiled bot comment patterns; nil = no pattern check
-	skipComments    bool             // if true, skip comment sync (for fast startup)
+	store              *issue.Store
+	owner              string
+	repos              []string
+	interval           time.Duration
+	idleDetector       *IdleDetector    // nil = no adaptive behavior
+	idleInterval       time.Duration    // effective only when idleDetector is set
+	authorizedUsers    []string         // empty = all users trusted
+	botPatterns        []*regexp.Regexp // compiled bot comment patterns; nil = no pattern check
+	skipComments       bool             // if true, skip comment sync (for fast startup)
+	rateLimitThreshold int              // minimum remaining API calls before waiting/skipping; 0 disables
 }
 
 // NewSyncer creates a new GitHub issue syncer.
 func NewSyncer(store *issue.Store, owner string, repos []string, interval time.Duration) *Syncer {
 	return &Syncer{
-		store:    store,
-		owner:    owner,
-		repos:    repos,
-		interval: interval,
+		store:              store,
+		owner:              owner,
+		repos:              repos,
+		interval:           interval,
+		rateLimitThreshold: defaultRateLimitThreshold,
 	}
 }
 
@@ -451,6 +453,10 @@ func (s *Syncer) syncComments(repo string, issueNumber int, localID string) {
 
 // fetchComments fetches all comments for a GitHub issue via gh CLI.
 func (s *Syncer) fetchComments(repo string, issueNumber int) ([]ghComment, error) {
+	if err := s.checkRateLimit(); err != nil {
+		return nil, err
+	}
+
 	endpoint := fmt.Sprintf("repos/%s/%s/issues/%d/comments", s.owner, repo, issueNumber)
 	cmd := exec.Command("gh", "api", endpoint, "--paginate")
 
@@ -471,6 +477,10 @@ func (s *Syncer) fetchComments(repo string, issueNumber int) ([]ghComment, error
 }
 
 func (s *Syncer) fetchIssues(repo string) ([]ghIssue, error) {
+	if err := s.checkRateLimit(); err != nil {
+		return nil, err
+	}
+
 	fullRepo := fmt.Sprintf("%s/%s", s.owner, repo)
 	cmd := exec.Command("gh", "issue", "list",
 		"-R", fullRepo,

--- a/internal/github/ratelimit.go
+++ b/internal/github/ratelimit.go
@@ -1,0 +1,114 @@
+package github
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"os/exec"
+	"time"
+)
+
+const (
+	// defaultRateLimitThreshold is the minimum number of remaining GitHub API
+	// calls required before the Syncer will proceed with an API request.
+	// When remaining <= threshold, the Syncer waits for the rate limit to reset
+	// or skips the current sync cycle if the wait would be too long.
+	defaultRateLimitThreshold = 10
+
+	// rateLimitMaxWait is the maximum duration the Syncer will wait for the
+	// GitHub API rate limit to reset. If the reset time is further away than
+	// this duration, the sync cycle is skipped instead of waiting.
+	rateLimitMaxWait = 10 * time.Minute
+)
+
+// ghRateLimitResponse represents the JSON response from `gh api rate_limit`.
+type ghRateLimitResponse struct {
+	Resources struct {
+		Core ghRateLimitResource `json:"core"`
+	} `json:"resources"`
+}
+
+// ghRateLimitResource holds the rate limit details for a single resource category.
+type ghRateLimitResource struct {
+	Limit     int   `json:"limit"`
+	Remaining int   `json:"remaining"`
+	Reset     int64 `json:"reset"` // Unix timestamp when the rate limit resets
+	Used      int   `json:"used"`
+}
+
+// WithRateLimitThreshold sets the minimum remaining GitHub API calls required
+// before the Syncer will proceed. When the remaining count is at or below this
+// threshold, the Syncer either waits for the rate limit to reset (if the reset
+// is within rateLimitMaxWait) or skips the current sync cycle.
+//
+// Setting threshold to 0 disables the rate limit pre-check entirely.
+func (s *Syncer) WithRateLimitThreshold(n int) *Syncer {
+	s.rateLimitThreshold = n
+	return s
+}
+
+// checkRateLimit fetches the current GitHub API rate limit and waits or returns
+// an error if the remaining count is at or below the configured threshold.
+//
+// If the threshold is 0, the check is disabled and nil is always returned.
+// If the gh CLI call fails, a warning is logged and nil is returned (fail-open).
+func (s *Syncer) checkRateLimit() error {
+	if s.rateLimitThreshold == 0 {
+		return nil
+	}
+
+	out, err := exec.Command("gh", "api", "rate_limit").Output()
+	if err != nil {
+		// Fail open: log a warning but allow the API call to proceed.
+		log.Printf("[github-sync] rate limit check failed (proceeding anyway): %v", err)
+		return nil
+	}
+
+	var resp ghRateLimitResponse
+	if err := json.Unmarshal(out, &resp); err != nil {
+		log.Printf("[github-sync] rate limit parse failed (proceeding anyway): %v", err)
+		return nil
+	}
+
+	return s.checkRateLimitWithData(resp)
+}
+
+// checkRateLimitWithData evaluates the rate limit response and decides whether
+// to wait, skip, or proceed. It is separated from checkRateLimit to allow
+// unit testing without invoking the gh CLI.
+func (s *Syncer) checkRateLimitWithData(resp ghRateLimitResponse) error {
+	if s.rateLimitThreshold == 0 {
+		return nil
+	}
+
+	core := resp.Resources.Core
+	if core.Remaining > s.rateLimitThreshold {
+		return nil
+	}
+
+	resetAt := time.Unix(core.Reset, 0)
+	waitDuration := time.Until(resetAt)
+
+	if waitDuration <= 0 {
+		// Reset has already occurred; proceed immediately.
+		return nil
+	}
+
+	if waitDuration > rateLimitMaxWait {
+		return fmt.Errorf(
+			"github rate limit nearly exhausted (remaining=%d, threshold=%d); "+
+				"reset in %v exceeds max wait %v — skipping sync cycle",
+			core.Remaining, s.rateLimitThreshold, waitDuration.Round(time.Second), rateLimitMaxWait,
+		)
+	}
+
+	// Wait until the rate limit resets, with a small buffer.
+	waitWithBuffer := waitDuration + time.Second
+	log.Printf(
+		"[github-sync] rate limit nearly exhausted (remaining=%d, threshold=%d); "+
+			"waiting %v for reset",
+		core.Remaining, s.rateLimitThreshold, waitWithBuffer.Round(time.Second),
+	)
+	time.Sleep(waitWithBuffer)
+	return nil
+}

--- a/internal/github/ratelimit_test.go
+++ b/internal/github/ratelimit_test.go
@@ -1,0 +1,177 @@
+package github
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+// TestWithRateLimitThreshold verifies that the builder method sets the field correctly.
+func TestWithRateLimitThreshold(t *testing.T) {
+	s := NewSyncer(nil, "owner", []string{"repo"}, time.Minute).
+		WithRateLimitThreshold(20)
+	if s.rateLimitThreshold != 20 {
+		t.Errorf("expected rateLimitThreshold=20, got %d", s.rateLimitThreshold)
+	}
+}
+
+// TestWithRateLimitThreshold_Zero verifies that 0 disables the check.
+func TestWithRateLimitThreshold_Zero(t *testing.T) {
+	s := NewSyncer(nil, "owner", []string{"repo"}, time.Minute).
+		WithRateLimitThreshold(0)
+	if s.rateLimitThreshold != 0 {
+		t.Errorf("expected rateLimitThreshold=0, got %d", s.rateLimitThreshold)
+	}
+}
+
+// TestWithRateLimitThreshold_DefaultValue verifies the default threshold is applied
+// when WithRateLimitThreshold is not called.
+func TestWithRateLimitThreshold_DefaultValue(t *testing.T) {
+	s := NewSyncer(nil, "owner", []string{"repo"}, time.Minute)
+	if s.rateLimitThreshold != defaultRateLimitThreshold {
+		t.Errorf("expected default rateLimitThreshold=%d, got %d", defaultRateLimitThreshold, s.rateLimitThreshold)
+	}
+}
+
+// TestWithRateLimitThreshold_Chaining verifies that the builder method can be chained.
+func TestWithRateLimitThreshold_Chaining(t *testing.T) {
+	s := NewSyncer(nil, "owner", []string{"repo"}, time.Minute).
+		WithRateLimitThreshold(15).
+		WithSkipComments(true)
+	if s.rateLimitThreshold != 15 {
+		t.Errorf("expected rateLimitThreshold=15, got %d", s.rateLimitThreshold)
+	}
+	if !s.skipComments {
+		t.Error("expected skipComments=true after chaining")
+	}
+}
+
+// TestGhRateLimitResponseParsing verifies the JSON parsing of the rate_limit API response.
+func TestGhRateLimitResponseParsing(t *testing.T) {
+	raw := `{
+		"resources": {
+			"core": {
+				"limit": 5000,
+				"remaining": 4998,
+				"reset": 1700000000,
+				"used": 2
+			}
+		}
+	}`
+
+	var resp ghRateLimitResponse
+	if err := json.Unmarshal([]byte(raw), &resp); err != nil {
+		t.Fatalf("unexpected parse error: %v", err)
+	}
+
+	if resp.Resources.Core.Limit != 5000 {
+		t.Errorf("limit: expected 5000, got %d", resp.Resources.Core.Limit)
+	}
+	if resp.Resources.Core.Remaining != 4998 {
+		t.Errorf("remaining: expected 4998, got %d", resp.Resources.Core.Remaining)
+	}
+	if resp.Resources.Core.Reset != 1700000000 {
+		t.Errorf("reset: expected 1700000000, got %d", resp.Resources.Core.Reset)
+	}
+	if resp.Resources.Core.Used != 2 {
+		t.Errorf("used: expected 2, got %d", resp.Resources.Core.Used)
+	}
+}
+
+// TestCheckRateLimit_Disabled verifies that when threshold=0 the check is skipped.
+func TestCheckRateLimit_Disabled(t *testing.T) {
+	s := NewSyncer(nil, "owner", []string{"repo"}, time.Minute).
+		WithRateLimitThreshold(0)
+
+	// Even with a very low (non-existent) rate limit, disabled check should return nil.
+	// We directly test the check-disabled path.
+	if s.rateLimitThreshold != 0 {
+		t.Fatal("precondition: threshold should be 0")
+	}
+
+	// checkRateLimit should short-circuit without calling gh when threshold == 0.
+	// We can verify this by calling it and ensuring no external process error occurs
+	// on a stub that doesn't exist — but since the gh binary may or may not exist,
+	// we test the logic path indirectly by asserting the threshold-zero guard.
+	err := s.checkRateLimitWithData(ghRateLimitResponse{}) // helper with injected data
+	if err != nil {
+		t.Errorf("expected nil error when threshold=0, got: %v", err)
+	}
+}
+
+// TestCheckRateLimit_SufficientRemaining verifies no wait when remaining > threshold.
+func TestCheckRateLimit_SufficientRemaining(t *testing.T) {
+	s := NewSyncer(nil, "owner", []string{"repo"}, time.Minute).
+		WithRateLimitThreshold(10)
+
+	resp := ghRateLimitResponse{}
+	resp.Resources.Core.Limit = 5000
+	resp.Resources.Core.Remaining = 100
+	resp.Resources.Core.Reset = time.Now().Add(time.Hour).Unix()
+
+	err := s.checkRateLimitWithData(resp)
+	if err != nil {
+		t.Errorf("expected nil error when remaining=%d > threshold=%d, got: %v",
+			resp.Resources.Core.Remaining, s.rateLimitThreshold, err)
+	}
+}
+
+// TestCheckRateLimit_ExactlyAtThreshold verifies rate limit is triggered when remaining == threshold.
+func TestCheckRateLimit_ExactlyAtThreshold(t *testing.T) {
+	s := NewSyncer(nil, "owner", []string{"repo"}, time.Minute).
+		WithRateLimitThreshold(10)
+
+	// Reset already passed → should return nil (no wait needed, reset occurred)
+	resp := ghRateLimitResponse{}
+	resp.Resources.Core.Limit = 5000
+	resp.Resources.Core.Remaining = 10 // exactly at threshold
+	resp.Resources.Core.Reset = time.Now().Add(-time.Second).Unix() // reset in past
+
+	err := s.checkRateLimitWithData(resp)
+	if err != nil {
+		t.Errorf("expected nil error when reset is in the past, got: %v", err)
+	}
+}
+
+// TestCheckRateLimit_BelowThreshold_ResetFarFuture verifies error is returned when
+// remaining <= threshold and reset is too far in the future.
+func TestCheckRateLimit_BelowThreshold_ResetFarFuture(t *testing.T) {
+	s := NewSyncer(nil, "owner", []string{"repo"}, time.Minute).
+		WithRateLimitThreshold(10)
+
+	resp := ghRateLimitResponse{}
+	resp.Resources.Core.Limit = 5000
+	resp.Resources.Core.Remaining = 5 // below threshold
+	resp.Resources.Core.Reset = time.Now().Add(rateLimitMaxWait + time.Minute).Unix() // far future
+
+	err := s.checkRateLimitWithData(resp)
+	if err == nil {
+		t.Error("expected error when remaining < threshold and reset is too far in the future")
+	}
+}
+
+// TestCheckRateLimit_ZeroRemaining_ResetFarFuture verifies error when remaining=0.
+func TestCheckRateLimit_ZeroRemaining_ResetFarFuture(t *testing.T) {
+	s := NewSyncer(nil, "owner", []string{"repo"}, time.Minute).
+		WithRateLimitThreshold(10)
+
+	resp := ghRateLimitResponse{}
+	resp.Resources.Core.Limit = 5000
+	resp.Resources.Core.Remaining = 0
+	resp.Resources.Core.Reset = time.Now().Add(rateLimitMaxWait + time.Minute).Unix()
+
+	err := s.checkRateLimitWithData(resp)
+	if err == nil {
+		t.Error("expected error when remaining=0 and reset is too far in the future")
+	}
+}
+
+// TestRateLimitConstants verifies the expected constant values.
+func TestRateLimitConstants(t *testing.T) {
+	if defaultRateLimitThreshold <= 0 {
+		t.Errorf("defaultRateLimitThreshold should be positive, got %d", defaultRateLimitThreshold)
+	}
+	if rateLimitMaxWait <= 0 {
+		t.Error("rateLimitMaxWait should be positive")
+	}
+}

--- a/internal/github/ratelimit_test.go
+++ b/internal/github/ratelimit_test.go
@@ -124,7 +124,7 @@ func TestCheckRateLimit_ExactlyAtThreshold(t *testing.T) {
 	// Reset already passed → should return nil (no wait needed, reset occurred)
 	resp := ghRateLimitResponse{}
 	resp.Resources.Core.Limit = 5000
-	resp.Resources.Core.Remaining = 10 // exactly at threshold
+	resp.Resources.Core.Remaining = 10                              // exactly at threshold
 	resp.Resources.Core.Reset = time.Now().Add(-time.Second).Unix() // reset in past
 
 	err := s.checkRateLimitWithData(resp)
@@ -141,7 +141,7 @@ func TestCheckRateLimit_BelowThreshold_ResetFarFuture(t *testing.T) {
 
 	resp := ghRateLimitResponse{}
 	resp.Resources.Core.Limit = 5000
-	resp.Resources.Core.Remaining = 5 // below threshold
+	resp.Resources.Core.Remaining = 5                                                 // below threshold
 	resp.Resources.Core.Reset = time.Now().Add(rateLimitMaxWait + time.Minute).Unix() // far future
 
 	err := s.checkRateLimitWithData(resp)


### PR DESCRIPTION
Issue: ytnobody-MADFLOW-204

## 概要

GitHub APIのレート制限について、API呼び出し前に残数を確認し、閾値以下の場合は待機またはスキップする機構を追加します。

## 変更内容

- `internal/github/ratelimit.go` (新規): レート制限チェック実装
  - `ghRateLimitResponse` / `ghRateLimitResource` 構造体（JSONパース用）
  - `checkRateLimit()`: `gh api rate_limit` を呼び出し、残数を評価
  - `checkRateLimitWithData()`: データを注入してテスト可能なロジック
  - `WithRateLimitThreshold(n int)`: 閾値設定のビルダーメソッド
  - 定数: `defaultRateLimitThreshold = 10`, `rateLimitMaxWait = 10 * time.Minute`
- `internal/github/github.go`: `Syncer` 構造体に `rateLimitThreshold` フィールド追加、`fetchIssues()` と `fetchComments()` でレート制限チェックを呼び出すよう変更
- `internal/github/ratelimit_test.go` (新規): 上記の網羅的なユニットテスト
- `docs/specs/github-rate-limit-check.md` (新規): 仕様ドキュメント

## 動作

- 残数 > 閾値: 即時続行
- 残数 ≤ 閾値、リセットまで rateLimitMaxWait 以内: 待機してから続行
- 残数 ≤ 閾値、リセットが rateLimitMaxWait 超: エラーを返し今回の同期をスキップ
- `gh api rate_limit` 失敗時: 警告ログを出力してフェイルオープン（同期を続行）
- 閾値=0: チェックを無効化