### PR TITLE
ytnobody-MADFLOW-213: madflow initでauthorized_usersを指定できるようにする

### DIFF
--- a/cmd/madflow/main.go
+++ b/cmd/madflow/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bufio"
 	"context"
 	"errors"
 	"fmt"
@@ -79,9 +80,46 @@ func main() {
 	}
 }
 
+// isTerminal returns true when f is connected to an interactive terminal.
+func isTerminal(f *os.File) bool {
+	info, err := f.Stat()
+	if err != nil {
+		return false
+	}
+	return (info.Mode() & os.ModeCharDevice) != 0
+}
+
+// parseAuthorizedUsers splits a comma-separated string of GitHub usernames,
+// trims whitespace from each entry, and drops empty strings.
+func parseAuthorizedUsers(raw string) []string {
+	parts := strings.Split(raw, ",")
+	var users []string
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p != "" {
+			users = append(users, p)
+		}
+	}
+	return users
+}
+
+// buildAuthorizedUsersLine formats the authorized_users TOML line.
+// Returns an empty string when users is nil or empty.
+func buildAuthorizedUsersLine(users []string) string {
+	if len(users) == 0 {
+		return ""
+	}
+	var quoted []string
+	for _, u := range users {
+		quoted = append(quoted, fmt.Sprintf("%q", u))
+	}
+	return fmt.Sprintf("authorized_users = [%s]\n\n", strings.Join(quoted, ", "))
+}
+
 func cmdInit() error {
 	name := ""
 	var repoPaths []string
+	authorizedUsersRaw := ""
 
 	args := os.Args[2:]
 	for i := 0; i < len(args); i++ {
@@ -95,6 +133,11 @@ func cmdInit() error {
 			if i+1 < len(args) {
 				i++
 				repoPaths = append(repoPaths, args[i])
+			}
+		case "--authorized-users":
+			if i+1 < len(args) {
+				i++
+				authorizedUsersRaw = args[i]
 			}
 		}
 	}
@@ -116,6 +159,17 @@ func cmdInit() error {
 		repoPaths = []string{cwd}
 	}
 
+	// If --authorized-users was not given and stdin is a terminal, prompt interactively.
+	if authorizedUsersRaw == "" && isTerminal(os.Stdin) {
+		fmt.Print("Enter authorized GitHub usernames (comma-separated, press Enter to skip): ")
+		scanner := bufio.NewScanner(os.Stdin)
+		if scanner.Scan() {
+			authorizedUsersRaw = scanner.Text()
+		}
+	}
+
+	authorizedUsers := parseAuthorizedUsers(authorizedUsersRaw)
+
 	if err := project.Init(name, repoPaths); err != nil {
 		return err
 	}
@@ -124,7 +178,8 @@ func cmdInit() error {
 	cwd, _ := os.Getwd()
 	configPath := filepath.Join(cwd, "madflow.toml")
 	if _, err := os.Stat(configPath); os.IsNotExist(err) {
-		tmpl := fmt.Sprintf(`[project]
+		authorizedUsersLine := buildAuthorizedUsersLine(authorizedUsers)
+		tmpl := fmt.Sprintf(`%s[project]
 name = "%s"
 
 [[project.repos]]
@@ -142,7 +197,7 @@ engineer = "claude-sonnet-4-6"
 main = "main"
 develop = "develop"
 feature_prefix = "feature/issue-"
-`, name, filepath.Base(repoPaths[0]), repoPaths[0])
+`, authorizedUsersLine, name, filepath.Base(repoPaths[0]), repoPaths[0])
 		if err := os.WriteFile(configPath, []byte(tmpl), 0644); err != nil {
 			return fmt.Errorf("create config: %w", err)
 		}

--- a/cmd/madflow/main_test.go
+++ b/cmd/madflow/main_test.go
@@ -155,3 +155,145 @@ func TestRoleColors_DoesNotContainDeprecatedRoles(t *testing.T) {
 		}
 	}
 }
+
+func TestCmdInit_AuthorizedUsersFlag(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	origDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get cwd: %v", err)
+	}
+	defer os.Chdir(origDir) //nolint:errcheck
+
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatalf("failed to chdir: %v", err)
+	}
+
+	origArgs := os.Args
+	os.Args = []string{"madflow", "init", "--name", "testproject", "--repo", tmpDir, "--authorized-users", "alice,bob"}
+	defer func() { os.Args = origArgs }()
+
+	if err := cmdInit(); err != nil {
+		t.Fatalf("cmdInit() error: %v", err)
+	}
+
+	configPath := filepath.Join(tmpDir, "madflow.toml")
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("failed to read generated madflow.toml: %v", err)
+	}
+
+	content := string(data)
+
+	// Verify authorized_users is included with the specified users.
+	if !strings.Contains(content, `authorized_users = ["alice", "bob"]`) {
+		t.Errorf("generated madflow.toml does not contain expected authorized_users; got:\n%s", content)
+	}
+}
+
+func TestCmdInit_AuthorizedUsersFlag_SingleUser(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	origDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get cwd: %v", err)
+	}
+	defer os.Chdir(origDir) //nolint:errcheck
+
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatalf("failed to chdir: %v", err)
+	}
+
+	origArgs := os.Args
+	os.Args = []string{"madflow", "init", "--name", "testproject", "--repo", tmpDir, "--authorized-users", "charlie"}
+	defer func() { os.Args = origArgs }()
+
+	if err := cmdInit(); err != nil {
+		t.Fatalf("cmdInit() error: %v", err)
+	}
+
+	configPath := filepath.Join(tmpDir, "madflow.toml")
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("failed to read generated madflow.toml: %v", err)
+	}
+
+	content := string(data)
+
+	if !strings.Contains(content, `authorized_users = ["charlie"]`) {
+		t.Errorf("generated madflow.toml does not contain expected authorized_users; got:\n%s", content)
+	}
+}
+
+func TestCmdInit_NoAuthorizedUsers_NonInteractive(t *testing.T) {
+	// When no --authorized-users flag is given and stdin is not a terminal,
+	// authorized_users should not appear in the generated config.
+	tmpDir := t.TempDir()
+
+	origDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get cwd: %v", err)
+	}
+	defer os.Chdir(origDir) //nolint:errcheck
+
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatalf("failed to chdir: %v", err)
+	}
+
+	origArgs := os.Args
+	os.Args = []string{"madflow", "init", "--name", "testproject", "--repo", tmpDir}
+	defer func() { os.Args = origArgs }()
+
+	if err := cmdInit(); err != nil {
+		t.Fatalf("cmdInit() error: %v", err)
+	}
+
+	configPath := filepath.Join(tmpDir, "madflow.toml")
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("failed to read generated madflow.toml: %v", err)
+	}
+
+	content := string(data)
+
+	// In non-interactive mode (tests run without a terminal), authorized_users
+	// should be omitted from the generated config.
+	if strings.Contains(content, "authorized_users") {
+		t.Errorf("generated madflow.toml unexpectedly contains authorized_users in non-interactive mode:\n%s", content)
+	}
+}
+
+func TestCmdInit_AuthorizedUsersFlag_WithSpaces(t *testing.T) {
+	// Ensure usernames are trimmed of surrounding spaces.
+	tmpDir := t.TempDir()
+
+	origDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get cwd: %v", err)
+	}
+	defer os.Chdir(origDir) //nolint:errcheck
+
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatalf("failed to chdir: %v", err)
+	}
+
+	origArgs := os.Args
+	os.Args = []string{"madflow", "init", "--name", "testproject", "--repo", tmpDir, "--authorized-users", " alice , bob "}
+	defer func() { os.Args = origArgs }()
+
+	if err := cmdInit(); err != nil {
+		t.Fatalf("cmdInit() error: %v", err)
+	}
+
+	configPath := filepath.Join(tmpDir, "madflow.toml")
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("failed to read generated madflow.toml: %v", err)
+	}
+
+	content := string(data)
+
+	if !strings.Contains(content, `authorized_users = ["alice", "bob"]`) {
+		t.Errorf("generated madflow.toml does not contain trimmed authorized_users; got:\n%s", content)
+	}
+}

--- a/docs/specs/init-authorized-users.md
+++ b/docs/specs/init-authorized-users.md
@@ -1,0 +1,85 @@
+# Spec: madflow init - authorized_users Configuration
+
+## Overview
+
+`madflow init` must prompt users to specify `authorized_users` during project initialization. This ensures that projects using GitHub integration have the required security configuration set from the start.
+
+## Behavior
+
+### CLI Flag
+
+`madflow init` accepts a new flag:
+
+- `--authorized-users <users>` — Comma-separated list of GitHub usernames to authorize (e.g., `--authorized-users alice,bob`).
+
+### Interactive Prompt
+
+If `--authorized-users` is not provided and stdin is a terminal (interactive session), `madflow init` prompts the user:
+
+```
+Enter authorized GitHub usernames (comma-separated, press Enter to skip):
+```
+
+- The user enters a comma-separated list of GitHub usernames (e.g., `alice, bob`).
+- Each username is trimmed of whitespace.
+- Empty strings after trimming are ignored.
+- If the user presses Enter without input, the `authorized_users` field is omitted from the generated config.
+
+### Non-Interactive Mode
+
+If `--authorized-users` is not provided and stdin is NOT a terminal (piped/scripted input), no prompt is shown and `authorized_users` is omitted from the generated config.
+
+### Generated Config
+
+When `authorized_users` are specified (either via flag or interactive prompt):
+
+```toml
+authorized_users = ["alice", "bob"]
+
+[project]
+name = "myproject"
+...
+```
+
+When no users are specified, the `authorized_users` field is omitted from the generated config.
+
+## Examples
+
+### Via CLI Flag
+
+```bash
+madflow init --authorized-users alice,bob
+```
+
+Generated `madflow.toml` includes:
+```toml
+authorized_users = ["alice", "bob"]
+```
+
+### Via Interactive Prompt
+
+```
+$ madflow init
+Enter authorized GitHub usernames (comma-separated, press Enter to skip): alice, bob
+Project 'myproject' initialized.
+```
+
+### Skip (empty input or non-interactive)
+
+```
+$ madflow init
+Enter authorized GitHub usernames (comma-separated, press Enter to skip): [Enter]
+Project 'myproject' initialized.
+```
+
+Config does not include `authorized_users`.
+
+## Notes
+
+- `authorized_users` is only **required** at runtime when the `[github]` section is present (see `authorized-users-required.md`). If not using GitHub integration, users may safely skip this.
+- If `madflow.toml` already exists, `cmdInit` does not overwrite it, so the `authorized_users` prompt behavior only applies when creating a new config file.
+
+## Affected Files
+
+- `cmd/madflow/main.go` — parse `--authorized-users` flag, add interactive prompt, update config template
+- `cmd/madflow/main_test.go` — add tests for new flag and generated config


### PR DESCRIPTION
Issue: ytnobody-MADFLOW-213

## 変更内容

- Project 'team-2' initialized.
Config: /home/ytnobody/MADFLOW/.worktrees/team-2/madflow.toml
Prompts: /home/ytnobody/MADFLOW/.worktrees/team-2/promptsにフラグを追加（カンマ区切りのGitHubユーザー名リスト）
- が指定された場合、生成されたにフィールドを追加
- インタラクティブなターミナルでが省略された場合、ユーザーに入力を促すプロンプトを表示
- 非インタラクティブモード（テスト等）では自動的にプロンプトをスキップ
- ユーザー名の前後の空白を自動トリム
- スペックドキュメント追加: `docs/specs/init-authorized-users.md`