### PR TITLE
v0.6.0: Merge develop into main (release v0.6.0)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,17 @@ jobs:
       - name: go vet
         run: go vet ./...
 
+      - name: TODO check
+        run: |
+          TODOS=$(grep -rn "// TODO\|/\* TODO" --include="*.go" . 2>/dev/null || true)
+          if [ -n "$TODOS" ]; then
+            echo "TODO comments found in Go source files:"
+            echo "$TODOS"
+            echo "Please remove or implement all TODO items before merging."
+            exit 1
+          fi
+          echo "No TODO comments found."
+
       - name: go test
         run: go test -race -timeout 120s ./...
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,13 @@ jobs:
           GOOS=darwin  GOARCH=arm64 go build -ldflags "${LDFLAGS}" -o dist/madflow-darwin-arm64  ./cmd/madflow
           GOOS=windows GOARCH=amd64 go build -ldflags "${LDFLAGS}" -o dist/madflow-windows-amd64.exe ./cmd/madflow
 
+      - name: Generate SHA256 checksums
+        run: |
+          cd dist
+          for f in madflow-linux-amd64 madflow-linux-arm64 madflow-darwin-amd64 madflow-darwin-arm64 madflow-windows-amd64.exe; do
+            sha256sum "$f" | awk '{print $1}' > "${f}.sha256"
+          done
+
       - name: Create or Update GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
@@ -50,6 +57,11 @@ jobs:
               dist/madflow-darwin-amd64 \
               dist/madflow-darwin-arm64 \
               dist/madflow-windows-amd64.exe \
+              dist/madflow-linux-amd64.sha256 \
+              dist/madflow-linux-arm64.sha256 \
+              dist/madflow-darwin-amd64.sha256 \
+              dist/madflow-darwin-arm64.sha256 \
+              dist/madflow-windows-amd64.exe.sha256 \
               --clobber
           else
             echo "Creating new release $VERSION..."
@@ -59,5 +71,10 @@ jobs:
               dist/madflow-linux-arm64 \
               dist/madflow-darwin-amd64 \
               dist/madflow-darwin-arm64 \
-              dist/madflow-windows-amd64.exe
+              dist/madflow-windows-amd64.exe \
+              dist/madflow-linux-amd64.sha256 \
+              dist/madflow-linux-arm64.sha256 \
+              dist/madflow-darwin-amd64.sha256 \
+              dist/madflow-darwin-arm64.sha256 \
+              dist/madflow-windows-amd64.exe.sha256
           fi

--- a/Makefile
+++ b/Makefile
@@ -29,11 +29,18 @@ install: build
 test:
 	go test ./...
 
-# lint runs gofmt and go vet.
+# lint runs gofmt, go vet, and TODO comment check.
 .PHONY: lint
 lint:
 	gofmt -l ./... | grep . && exit 1 || true
 	go vet ./...
+	@TODOS=$$(grep -rn "// TODO\|/\* TODO" --include="*.go" . 2>/dev/null); \
+	if [ -n "$$TODOS" ]; then \
+		echo "TODO comments found in Go source files:"; \
+		echo "$$TODOS"; \
+		echo "Please remove or implement all TODO items before merging."; \
+		exit 1; \
+	fi
 
 # clean removes the built binary.
 .PHONY: clean
@@ -73,7 +80,7 @@ help:
 	@echo "  make build    - Build the madflow binary"
 	@echo "  make install  - Build and install binary to INSTALL_DIR (default: ~/bin)"
 	@echo "  make test     - Run all tests"
-	@echo "  make lint     - Run gofmt and go vet"
+	@echo "  make lint     - Run gofmt, go vet, and TODO comment check"
 	@echo "  make clean    - Remove the built binary"
 	@echo "  make rebuild  - Build, install, and stop running process (for restart by supervisor)"
 	@echo "  make restart  - Stop the running madflow process"

--- a/README.md
+++ b/README.md
@@ -102,6 +102,33 @@ repos = ["my-app"]
 sync_interval_minutes = 5
 ```
 
+#### `authorized_users` — Required when GitHub integration is enabled
+
+When the `[github]` section is present, you **must** also set `authorized_users` at the top level of `madflow.toml`. This is a list of GitHub login names whose issues, pull requests, and comments MADFLOW is allowed to process.
+
+```toml
+# List of GitHub logins that MADFLOW will accept events from.
+# Required when [github] is present. Must contain at least one entry.
+authorized_users = ["myusername", "trusted-collaborator"]
+
+[github]
+owner = "myorg"
+repos = ["my-app"]
+sync_interval_minutes = 5
+```
+
+If `authorized_users` is empty (or omitted) while GitHub integration is enabled, **MADFLOW will refuse to start** and print an error:
+
+```
+authorized_users is required when github integration is enabled; set authorized_users to a list of GitHub logins allowed to interact with MADFLOW
+```
+
+**Why is this required?**
+
+Without an explicit allowlist, any GitHub user could open an issue or post a comment on a public repository and have MADFLOW process it. This creates a prompt-injection attack surface: a malicious actor could craft an issue body that causes the LLM to execute arbitrary commands. By requiring `authorized_users`, only explicitly trusted users can drive MADFLOW's agents.
+
+> **Tip:** Add every team member and bot account that will interact with MADFLOW (e.g., opening issues or commenting) to the `authorized_users` list.
+
 ## Command Reference
 
 | Command | Description |

--- a/cmd/madflow/main.go
+++ b/cmd/madflow/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bufio"
 	"context"
 	"errors"
 	"fmt"
@@ -79,9 +80,46 @@ func main() {
 	}
 }
 
+// isTerminal returns true when f is connected to an interactive terminal.
+func isTerminal(f *os.File) bool {
+	info, err := f.Stat()
+	if err != nil {
+		return false
+	}
+	return (info.Mode() & os.ModeCharDevice) != 0
+}
+
+// parseAuthorizedUsers splits a comma-separated string of GitHub usernames,
+// trims whitespace from each entry, and drops empty strings.
+func parseAuthorizedUsers(raw string) []string {
+	parts := strings.Split(raw, ",")
+	var users []string
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p != "" {
+			users = append(users, p)
+		}
+	}
+	return users
+}
+
+// buildAuthorizedUsersLine formats the authorized_users TOML line.
+// Returns an empty string when users is nil or empty.
+func buildAuthorizedUsersLine(users []string) string {
+	if len(users) == 0 {
+		return ""
+	}
+	var quoted []string
+	for _, u := range users {
+		quoted = append(quoted, fmt.Sprintf("%q", u))
+	}
+	return fmt.Sprintf("authorized_users = [%s]\n\n", strings.Join(quoted, ", "))
+}
+
 func cmdInit() error {
 	name := ""
 	var repoPaths []string
+	authorizedUsersRaw := ""
 
 	args := os.Args[2:]
 	for i := 0; i < len(args); i++ {
@@ -95,6 +133,11 @@ func cmdInit() error {
 			if i+1 < len(args) {
 				i++
 				repoPaths = append(repoPaths, args[i])
+			}
+		case "--authorized-users":
+			if i+1 < len(args) {
+				i++
+				authorizedUsersRaw = args[i]
 			}
 		}
 	}
@@ -116,6 +159,17 @@ func cmdInit() error {
 		repoPaths = []string{cwd}
 	}
 
+	// If --authorized-users was not given and stdin is a terminal, prompt interactively.
+	if authorizedUsersRaw == "" && isTerminal(os.Stdin) {
+		fmt.Print("Enter authorized GitHub usernames (comma-separated, press Enter to skip): ")
+		scanner := bufio.NewScanner(os.Stdin)
+		if scanner.Scan() {
+			authorizedUsersRaw = scanner.Text()
+		}
+	}
+
+	authorizedUsers := parseAuthorizedUsers(authorizedUsersRaw)
+
 	if err := project.Init(name, repoPaths); err != nil {
 		return err
 	}
@@ -124,7 +178,8 @@ func cmdInit() error {
 	cwd, _ := os.Getwd()
 	configPath := filepath.Join(cwd, "madflow.toml")
 	if _, err := os.Stat(configPath); os.IsNotExist(err) {
-		tmpl := fmt.Sprintf(`[project]
+		authorizedUsersLine := buildAuthorizedUsersLine(authorizedUsers)
+		tmpl := fmt.Sprintf(`%s[project]
 name = "%s"
 
 [[project.repos]]
@@ -142,7 +197,7 @@ engineer = "claude-sonnet-4-6"
 main = "main"
 develop = "develop"
 feature_prefix = "feature/issue-"
-`, name, filepath.Base(repoPaths[0]), repoPaths[0])
+`, authorizedUsersLine, name, filepath.Base(repoPaths[0]), repoPaths[0])
 		if err := os.WriteFile(configPath, []byte(tmpl), 0644); err != nil {
 			return fmt.Errorf("create config: %w", err)
 		}

--- a/cmd/madflow/main_test.go
+++ b/cmd/madflow/main_test.go
@@ -155,3 +155,145 @@ func TestRoleColors_DoesNotContainDeprecatedRoles(t *testing.T) {
 		}
 	}
 }
+
+func TestCmdInit_AuthorizedUsersFlag(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	origDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get cwd: %v", err)
+	}
+	defer os.Chdir(origDir) //nolint:errcheck
+
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatalf("failed to chdir: %v", err)
+	}
+
+	origArgs := os.Args
+	os.Args = []string{"madflow", "init", "--name", "testproject", "--repo", tmpDir, "--authorized-users", "alice,bob"}
+	defer func() { os.Args = origArgs }()
+
+	if err := cmdInit(); err != nil {
+		t.Fatalf("cmdInit() error: %v", err)
+	}
+
+	configPath := filepath.Join(tmpDir, "madflow.toml")
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("failed to read generated madflow.toml: %v", err)
+	}
+
+	content := string(data)
+
+	// Verify authorized_users is included with the specified users.
+	if !strings.Contains(content, `authorized_users = ["alice", "bob"]`) {
+		t.Errorf("generated madflow.toml does not contain expected authorized_users; got:\n%s", content)
+	}
+}
+
+func TestCmdInit_AuthorizedUsersFlag_SingleUser(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	origDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get cwd: %v", err)
+	}
+	defer os.Chdir(origDir) //nolint:errcheck
+
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatalf("failed to chdir: %v", err)
+	}
+
+	origArgs := os.Args
+	os.Args = []string{"madflow", "init", "--name", "testproject", "--repo", tmpDir, "--authorized-users", "charlie"}
+	defer func() { os.Args = origArgs }()
+
+	if err := cmdInit(); err != nil {
+		t.Fatalf("cmdInit() error: %v", err)
+	}
+
+	configPath := filepath.Join(tmpDir, "madflow.toml")
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("failed to read generated madflow.toml: %v", err)
+	}
+
+	content := string(data)
+
+	if !strings.Contains(content, `authorized_users = ["charlie"]`) {
+		t.Errorf("generated madflow.toml does not contain expected authorized_users; got:\n%s", content)
+	}
+}
+
+func TestCmdInit_NoAuthorizedUsers_NonInteractive(t *testing.T) {
+	// When no --authorized-users flag is given and stdin is not a terminal,
+	// authorized_users should not appear in the generated config.
+	tmpDir := t.TempDir()
+
+	origDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get cwd: %v", err)
+	}
+	defer os.Chdir(origDir) //nolint:errcheck
+
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatalf("failed to chdir: %v", err)
+	}
+
+	origArgs := os.Args
+	os.Args = []string{"madflow", "init", "--name", "testproject", "--repo", tmpDir}
+	defer func() { os.Args = origArgs }()
+
+	if err := cmdInit(); err != nil {
+		t.Fatalf("cmdInit() error: %v", err)
+	}
+
+	configPath := filepath.Join(tmpDir, "madflow.toml")
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("failed to read generated madflow.toml: %v", err)
+	}
+
+	content := string(data)
+
+	// In non-interactive mode (tests run without a terminal), authorized_users
+	// should be omitted from the generated config.
+	if strings.Contains(content, "authorized_users") {
+		t.Errorf("generated madflow.toml unexpectedly contains authorized_users in non-interactive mode:\n%s", content)
+	}
+}
+
+func TestCmdInit_AuthorizedUsersFlag_WithSpaces(t *testing.T) {
+	// Ensure usernames are trimmed of surrounding spaces.
+	tmpDir := t.TempDir()
+
+	origDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get cwd: %v", err)
+	}
+	defer os.Chdir(origDir) //nolint:errcheck
+
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatalf("failed to chdir: %v", err)
+	}
+
+	origArgs := os.Args
+	os.Args = []string{"madflow", "init", "--name", "testproject", "--repo", tmpDir, "--authorized-users", " alice , bob "}
+	defer func() { os.Args = origArgs }()
+
+	if err := cmdInit(); err != nil {
+		t.Fatalf("cmdInit() error: %v", err)
+	}
+
+	configPath := filepath.Join(tmpDir, "madflow.toml")
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("failed to read generated madflow.toml: %v", err)
+	}
+
+	content := string(data)
+
+	if !strings.Contains(content, `authorized_users = ["alice", "bob"]`) {
+		t.Errorf("generated madflow.toml does not contain trimmed authorized_users; got:\n%s", content)
+	}
+}

--- a/cmd/madflow/upgrade.go
+++ b/cmd/madflow/upgrade.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -46,18 +48,25 @@ func cmdUpgrade(currentVersion string) error {
 
 	// Determine the target binary name based on current platform.
 	binaryName := getBinaryName()
+	checksumName := binaryName + ".sha256"
 	fmt.Printf("Looking for asset: %s\n", binaryName)
 
-	// Find the matching asset.
+	// Find the matching binary asset and checksum asset.
 	downloadURL := ""
+	checksumURL := ""
 	for _, asset := range release.Assets {
-		if asset.Name == binaryName {
+		switch asset.Name {
+		case binaryName:
 			downloadURL = asset.BrowserDownloadURL
-			break
+		case checksumName:
+			checksumURL = asset.BrowserDownloadURL
 		}
 	}
 	if downloadURL == "" {
 		return fmt.Errorf("no matching asset found for %s in release %s", binaryName, latestVersion)
+	}
+	if checksumURL == "" {
+		return fmt.Errorf("no checksum asset found for %s in release %s (expected %s)", binaryName, latestVersion, checksumName)
 	}
 
 	// Get current executable path.
@@ -72,6 +81,18 @@ func cmdUpgrade(currentVersion string) error {
 		return fmt.Errorf("failed to download binary: %w", err)
 	}
 	defer os.Remove(newBinary)
+
+	// Download and verify the SHA256 checksum before installing.
+	fmt.Printf("Verifying SHA256 checksum from %s...\n", checksumURL)
+	expectedChecksum, err := downloadChecksum(checksumURL)
+	if err != nil {
+		return fmt.Errorf("failed to download checksum: %w", err)
+	}
+
+	if err := verifyChecksum(newBinary, expectedChecksum); err != nil {
+		return fmt.Errorf("checksum verification failed: %w", err)
+	}
+	fmt.Println("Checksum verification passed.")
 
 	// Backup current binary.
 	backupPath := exePath + ".bak"
@@ -170,6 +191,62 @@ func downloadBinary(url string) (string, error) {
 	}
 
 	return tmpFile.Name(), nil
+}
+
+// downloadChecksum downloads a SHA256 checksum file from the given URL and
+// returns the expected hex digest string.
+func downloadChecksum(url string) (string, error) {
+	resp, err := http.Get(url) //nolint:gosec // URL is validated from GitHub API
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("checksum download returned status %d", resp.StatusCode)
+	}
+
+	// Read at most 128 bytes — a SHA256 hex digest is 64 characters.
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 128))
+	if err != nil {
+		return "", fmt.Errorf("failed to read checksum response: %w", err)
+	}
+
+	digest := strings.TrimSpace(string(body))
+	if digest == "" {
+		return "", fmt.Errorf("checksum file is empty")
+	}
+	// Validate that the digest looks like a lowercase hex SHA256 hash (64 chars).
+	if len(digest) != 64 {
+		return "", fmt.Errorf("unexpected checksum length %d (want 64 hex characters)", len(digest))
+	}
+	for _, c := range digest {
+		if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f')) {
+			return "", fmt.Errorf("checksum contains invalid character %q (expected lowercase hex)", c)
+		}
+	}
+	return digest, nil
+}
+
+// verifyChecksum computes the SHA256 hash of the file at filePath and
+// compares it to expectedHex. Returns an error if they do not match.
+func verifyChecksum(filePath, expectedHex string) error {
+	f, err := os.Open(filePath)
+	if err != nil {
+		return fmt.Errorf("failed to open file for checksum: %w", err)
+	}
+	defer f.Close()
+
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return fmt.Errorf("failed to compute checksum: %w", err)
+	}
+
+	actualHex := hex.EncodeToString(h.Sum(nil))
+	if actualHex != expectedHex {
+		return fmt.Errorf("SHA256 mismatch: got %s, want %s", actualHex, expectedHex)
+	}
+	return nil
 }
 
 // copyFile copies a file from src to dst, overwriting dst if it exists.

--- a/cmd/madflow/upgrade_test.go
+++ b/cmd/madflow/upgrade_test.go
@@ -1,7 +1,10 @@
 package main
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -144,5 +147,194 @@ func TestDownloadBinary_HTTPError(t *testing.T) {
 	_, err := downloadBinary(ts.URL + "/nonexistent")
 	if err == nil {
 		t.Error("downloadBinary() should return error on HTTP 404")
+	}
+}
+
+func TestDownloadChecksum(t *testing.T) {
+	expectedDigest := "a3f5b2c1d4e6f7890123456789abcdef0123456789abcdef0123456789abcdef"
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintln(w, expectedDigest)
+	}))
+	defer ts.Close()
+
+	got, err := downloadChecksum(ts.URL + "/madflow-linux-amd64.sha256")
+	if err != nil {
+		t.Fatalf("downloadChecksum() error: %v", err)
+	}
+	if got != expectedDigest {
+		t.Errorf("downloadChecksum() = %q, want %q", got, expectedDigest)
+	}
+}
+
+func TestDownloadChecksum_HTTPError(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer ts.Close()
+
+	_, err := downloadChecksum(ts.URL + "/nonexistent.sha256")
+	if err == nil {
+		t.Error("downloadChecksum() should return error on HTTP 404")
+	}
+}
+
+func TestDownloadChecksum_EmptyBody(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		// Empty body
+	}))
+	defer ts.Close()
+
+	_, err := downloadChecksum(ts.URL + "/empty.sha256")
+	if err == nil {
+		t.Error("downloadChecksum() should return error for empty body")
+	}
+}
+
+func TestDownloadChecksum_WrongLength(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintln(w, "tooshort")
+	}))
+	defer ts.Close()
+
+	_, err := downloadChecksum(ts.URL + "/bad.sha256")
+	if err == nil {
+		t.Error("downloadChecksum() should return error for wrong-length digest")
+	}
+}
+
+func TestDownloadChecksum_InvalidChars(t *testing.T) {
+	// 64 chars but contains uppercase (invalid for lowercase hex requirement).
+	invalidDigest := "A3F5B2C1D4E6F7890123456789ABCDEF0123456789ABCDEF0123456789ABCDEF"
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintln(w, invalidDigest)
+	}))
+	defer ts.Close()
+
+	_, err := downloadChecksum(ts.URL + "/bad.sha256")
+	if err == nil {
+		t.Error("downloadChecksum() should return error for non-lowercase-hex digest")
+	}
+}
+
+func TestVerifyChecksum_Match(t *testing.T) {
+	content := []byte("test binary data for checksum verification")
+	h := sha256.Sum256(content)
+	expectedHex := hex.EncodeToString(h[:])
+
+	tmpDir := t.TempDir()
+	filePath := filepath.Join(tmpDir, "testbin")
+	if err := os.WriteFile(filePath, content, 0644); err != nil {
+		t.Fatalf("failed to write test file: %v", err)
+	}
+
+	if err := verifyChecksum(filePath, expectedHex); err != nil {
+		t.Errorf("verifyChecksum() unexpected error: %v", err)
+	}
+}
+
+func TestVerifyChecksum_Mismatch(t *testing.T) {
+	content := []byte("test binary data for checksum verification")
+	wrongHex := strings.Repeat("0", 64)
+
+	tmpDir := t.TempDir()
+	filePath := filepath.Join(tmpDir, "testbin")
+	if err := os.WriteFile(filePath, content, 0644); err != nil {
+		t.Fatalf("failed to write test file: %v", err)
+	}
+
+	err := verifyChecksum(filePath, wrongHex)
+	if err == nil {
+		t.Error("verifyChecksum() should return error on digest mismatch")
+	}
+	if !strings.Contains(err.Error(), "SHA256 mismatch") {
+		t.Errorf("verifyChecksum() error should mention SHA256 mismatch, got: %v", err)
+	}
+}
+
+func TestVerifyChecksum_FileNotFound(t *testing.T) {
+	err := verifyChecksum("/nonexistent/path/to/file", strings.Repeat("0", 64))
+	if err == nil {
+		t.Error("verifyChecksum() should return error for nonexistent file")
+	}
+}
+
+func TestChecksumVerification_TamperedBinary(t *testing.T) {
+	// Integration-style test: binary content differs from what the checksum covers.
+	realContent := []byte("this is the authentic binary content")
+	fakeContent := []byte("this is a tampered binary content!!!")
+
+	h := sha256.Sum256(realContent)
+	correctChecksum := hex.EncodeToString(h[:])
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/binary":
+			// Serve the tampered binary.
+			w.WriteHeader(http.StatusOK)
+			w.Write(fakeContent)
+		case "/checksum":
+			// Serve checksum of the real content.
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprintln(w, correctChecksum)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer ts.Close()
+
+	tmpPath, err := downloadBinary(ts.URL + "/binary")
+	if err != nil {
+		t.Fatalf("downloadBinary() error: %v", err)
+	}
+	defer os.Remove(tmpPath)
+
+	expected, err := downloadChecksum(ts.URL + "/checksum")
+	if err != nil {
+		t.Fatalf("downloadChecksum() error: %v", err)
+	}
+
+	err = verifyChecksum(tmpPath, expected)
+	if err == nil {
+		t.Error("verifyChecksum() should have failed for tampered binary")
+	}
+}
+
+func TestChecksumVerification_HappyPath(t *testing.T) {
+	// Integration-style test: binary content matches published checksum.
+	content := []byte("this is the authentic binary content")
+	h := sha256.Sum256(content)
+	checksumHex := hex.EncodeToString(h[:])
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/binary":
+			w.WriteHeader(http.StatusOK)
+			w.Write(content)
+		case "/checksum":
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprintln(w, checksumHex)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer ts.Close()
+
+	tmpPath, err := downloadBinary(ts.URL + "/binary")
+	if err != nil {
+		t.Fatalf("downloadBinary() error: %v", err)
+	}
+	defer os.Remove(tmpPath)
+
+	expected, err := downloadChecksum(ts.URL + "/checksum")
+	if err != nil {
+		t.Fatalf("downloadChecksum() error: %v", err)
+	}
+
+	if err := verifyChecksum(tmpPath, expected); err != nil {
+		t.Errorf("verifyChecksum() unexpected error for matching checksum: %v", err)
 	}
 }

--- a/cmd/madflow/use.go
+++ b/cmd/madflow/use.go
@@ -42,6 +42,14 @@ var presets = map[string]presetModels{
 		Superintendent: "claude-sonnet-4-6",
 		Engineer:       "gemini-2.5-flash",
 	},
+	"claude-api-standard": {
+		Superintendent: "anthropic/claude-sonnet-4-6",
+		Engineer:       "anthropic/claude-haiku-4-5",
+	},
+	"claude-api-cheap": {
+		Superintendent: "anthropic/claude-haiku-4-5",
+		Engineer:       "anthropic/claude-haiku-4-5",
+	},
 }
 
 // cmdUse switches the active model preset in madflow.toml.
@@ -104,6 +112,7 @@ func updateModelsSection(content, superintendent, engineer string) (string, erro
 func formatPresets() string {
 	names := []string{
 		"claude", "gemini", "claude-cheap", "gemini-cheap", "hybrid", "hybrid-cheap",
+		"claude-api-standard", "claude-api-cheap",
 	}
 	var sb strings.Builder
 	for _, name := range names {

--- a/cmd/madflow/use_test.go
+++ b/cmd/madflow/use_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestPresets_AllDefined(t *testing.T) {
-	expectedPresets := []string{"claude", "gemini", "claude-cheap", "gemini-cheap", "hybrid", "hybrid-cheap"}
+	expectedPresets := []string{"claude", "gemini", "claude-cheap", "gemini-cheap", "hybrid", "hybrid-cheap", "claude-api-standard", "claude-api-cheap"}
 	for _, name := range expectedPresets {
 		if _, ok := presets[name]; !ok {
 			t.Errorf("preset %q is not defined", name)
@@ -26,6 +26,8 @@ func TestPresets_Models(t *testing.T) {
 		{"gemini-cheap", "gemini-2.5-flash", "gemini-2.5-flash"},
 		{"hybrid", "claude-sonnet-4-6", "gemini-2.5-pro"},
 		{"hybrid-cheap", "claude-sonnet-4-6", "gemini-2.5-flash"},
+		{"claude-api-standard", "anthropic/claude-sonnet-4-6", "anthropic/claude-haiku-4-5"},
+		{"claude-api-cheap", "anthropic/claude-haiku-4-5", "anthropic/claude-haiku-4-5"},
 	}
 
 	for _, tt := range tests {
@@ -128,7 +130,7 @@ superintendent = "claude-sonnet-4-6"
 
 func TestFormatPresets(t *testing.T) {
 	out := formatPresets()
-	expectedPresets := []string{"claude", "gemini", "claude-cheap", "gemini-cheap", "hybrid", "hybrid-cheap"}
+	expectedPresets := []string{"claude", "gemini", "claude-cheap", "gemini-cheap", "hybrid", "hybrid-cheap", "claude-api-standard", "claude-api-cheap"}
 	for _, name := range expectedPresets {
 		if !strings.Contains(out, name) {
 			t.Errorf("formatPresets output missing preset %q", name)

--- a/docs/specs/anthropic-api-preset.md
+++ b/docs/specs/anthropic-api-preset.md
@@ -1,0 +1,84 @@
+# Anthropic API Key Preset Specification
+
+## Overview
+
+The `claude-api-standard` and `claude-api-cheap` presets allow MADFLOW to call the
+Anthropic Messages API directly using `ANTHROPIC_API_KEY` instead of the Claude Code CLI.
+
+This is useful when users do not have a Claude Pro/Max subscription and prefer to pay
+per-request using the Anthropic API.
+
+## Presets
+
+| Preset              | Superintendent Model         | Engineer Model               |
+|---------------------|------------------------------|------------------------------|
+| `claude-api-standard` | `anthropic/claude-sonnet-4-6` | `anthropic/claude-haiku-4-5` |
+| `claude-api-cheap`  | `anthropic/claude-haiku-4-5` | `anthropic/claude-haiku-4-5` |
+
+Model strings use the `anthropic/` prefix to distinguish them from Claude CLI models.
+
+## Backend: AnthropicAPIProcess
+
+When a model string starts with `anthropic/`, a new `AnthropicAPIProcess` is created
+instead of the default `ClaudeStreamProcess`.
+
+### API Details
+
+- Endpoint: `https://api.anthropic.com/v1/messages`
+- Auth: `x-api-key: <ANTHROPIC_API_KEY>` header
+- API Version: `anthropic-version: 2023-06-01`
+- Environment variable: `ANTHROPIC_API_KEY`
+
+### Agentic Loop
+
+`AnthropicAPIProcess.Send()` implements an agentic loop similar to `GeminiAPIProcess`:
+
+1. Send the prompt to the API
+2. If the model uses `tool_use` blocks, execute them (bash only)
+3. Feed the results back as `tool_result` user messages
+4. Repeat until no tool calls or `anthropicMaxIter` reached
+
+### Tool
+
+Only the `bash` tool is exposed:
+
+```json
+{
+  "name": "bash",
+  "description": "Execute a bash command and return stdout/stderr.",
+  "input_schema": {
+    "type": "object",
+    "properties": {
+      "command": {"type": "string", "description": "The bash command to execute"}
+    },
+    "required": ["command"]
+  }
+}
+```
+
+### Error Handling
+
+- Missing `ANTHROPIC_API_KEY`: return an error immediately
+- HTTP 429 / rate-limit body: return `*RateLimitError` (triggers dormancy system)
+- Other HTTP 4xx/5xx: return an error
+- `stop_reason == "max_tokens"`: return partial text, no error
+- Max iterations reached: return `*MaxIterationsError`
+
+### Model Name Stripping
+
+The `anthropic/` prefix is stripped before sending to the API.
+Example: `anthropic/claude-sonnet-4-6` → API model `claude-sonnet-4-6`.
+
+## Configuration (use command)
+
+`madflow use claude-api-standard` writes the preset models to `madflow.toml`:
+
+```toml
+[agent.models]
+superintendent = "anthropic/claude-sonnet-4-6"
+engineer       = "anthropic/claude-haiku-4-5"
+```
+
+## formatPresets
+
+The `formatPresets()` function in `use.go` includes both new presets in its output.

--- a/docs/specs/authorized-users-required.md
+++ b/docs/specs/authorized-users-required.md
@@ -1,0 +1,68 @@
+# Spec: authorized_users Required Configuration
+
+## Overview
+
+The `authorized_users` configuration field is **mandatory** when GitHub integration (`[github]` section) is enabled. When not set (or set to an empty list), MADFLOW must refuse to start and print a clear error message.
+
+This prevents a critical security vulnerability where any GitHub user could submit issues to a public repository and have MADFLOW process them, potentially enabling prompt injection attacks that lead to arbitrary command execution.
+
+## Behavior
+
+### Config Validation
+
+When `config.Load()` is called:
+
+1. If `cfg.GitHub != nil` (GitHub integration is enabled) **and** `len(cfg.AuthorizedUsers) == 0` (no authorized users are configured), the function must return an error:
+   ```
+   validate config: authorized_users is required when github integration is enabled; set authorized_users to a list of GitHub logins allowed to interact with MADFLOW
+   ```
+
+2. If `cfg.GitHub == nil` (no GitHub integration), the `authorized_users` field is not required and may remain empty.
+
+3. If `authorized_users` contains at least one entry, validation passes normally.
+
+### `isAuthorized()` Behavior
+
+The `isAuthorized(login string, authorizedUsers []string) bool` function in `internal/github/github.go`:
+
+- **Before** (insecure): When `authorizedUsers` is empty, returns `true` (permit all).
+- **After** (secure): When `authorizedUsers` is empty, returns `false` (deny all).
+
+This change is defense-in-depth; the config validation above should prevent the empty-list case from ever reaching `isAuthorized` in production.
+
+| `authorizedUsers` | `login`       | Result  |
+|-------------------|---------------|---------|
+| empty / nil       | (any)         | `false` |
+| `["alice"]`       | `"alice"`     | `true`  |
+| `["alice"]`       | `"bob"`       | `false` |
+| `["alice", "bob"]`| `"bob"`       | `true`  |
+| `["alice", "bob"]`| `"charlie"`   | `false` |
+
+## Configuration Example
+
+```toml
+# Required when [github] section is present
+authorized_users = ["myusername"]
+
+[github]
+owner = "myorg"
+repos = ["myrepo"]
+```
+
+## Security Context
+
+This change addresses the root attack vector for the following risks documented in `SECURITY_AUDIT_REPORT.md`:
+
+- **MEDIUM** (direct fix): Default all-user trust (`github.go:155-165`)
+- **CRITICAL** (attack path blocked): LLM response arbitrary command execution (`gemini_api.go:405`)
+- **CRITICAL** (attack path blocked): Claude CLI `--dangerously-skip-permissions` compound risk (`claude.go:93`)
+- **HIGH** (attack path blocked): Prompt injection via issue body (`prompt.go:70-74`)
+
+By requiring explicit opt-in for trusted users, MADFLOW will not process issues from unknown users even if the configuration is incomplete.
+
+## Affected Files
+
+- `internal/config/config.go` — validation logic and field comment
+- `internal/github/github.go` — `isAuthorized()` default behavior
+- `internal/config/config_test.go` — updated/new tests for validation
+- `internal/github/github_test.go` — updated test for `isAuthorized()` with empty list

--- a/docs/specs/file-permission-restriction.md
+++ b/docs/specs/file-permission-restriction.md
@@ -1,0 +1,45 @@
+# File Permission Restriction Specification
+
+## Overview
+
+MADFLOW stores sensitive information on disk, including GitHub issue content and LLM conversation logs (chatlog). When these files are created with world-readable permissions (`0755` for directories, `0644` for files), other users on the same host can read them, causing a potential information leak.
+
+This spec defines the restrictive permission policy for all data directories and sensitive files.
+
+## Affected Files
+
+### Data Directories
+
+All data directories managed by MADFLOW must be created with permission `0700` (owner read/write/execute only):
+
+| Package | File | Location |
+|---------|------|----------|
+| `internal/orchestrator` | `orchestrator.go` | `Run()` — sub-directories (issues, memos) |
+| `internal/project` | `project.go` | `Add()` — base dir and sub-directories |
+| `internal/issue` | `issue.go` | `Store.Create()` — issues dir |
+| `internal/reset` | `reset.go` | `SaveMemoWithLang()` — memos dir |
+
+### Sensitive Files
+
+All sensitive files (chatlog, memos) must be created/written with permission `0600` (owner read/write only):
+
+| Package | File | Location |
+|---------|------|----------|
+| `internal/orchestrator` | `orchestrator.go` | `Run()` — chatlog truncate |
+| `internal/chatlog` | `chatlog.go` | `Append()` — chatlog append |
+| `internal/chatlog` | `chatlog.go` | `TruncateOldEntries()` — chatlog tmp write |
+| `internal/agent` | `agent.go` | `rescueChatLogMessages()` — chatlog append |
+| `internal/team` | `team.go` | `appendLine()` — chatlog append |
+| `internal/reset` | `reset.go` | `SaveMemoWithLang()` — memo write |
+
+## Permissions
+
+| Resource Type | Old Permission | New Permission | Rationale |
+|--------------|---------------|---------------|-----------|
+| Data directories | `0755` | `0700` | Prevent other users from listing or accessing directory contents |
+| Sensitive files | `0644` | `0600` | Prevent other users from reading chatlog and memo content |
+
+## Edge Cases
+
+- Existing files/directories are not retroactively `chmod`'d — only newly created files/directories use restrictive permissions. Operators should manually fix permissions on existing deployments.
+- Test files in `_test.go` files are intentionally excluded from this change as they operate on temporary test directories and do not contain real sensitive data.

--- a/docs/specs/gemini-api-key-header-migration.md
+++ b/docs/specs/gemini-api-key-header-migration.md
@@ -1,0 +1,47 @@
+# Spec: Gemini API Key Migration to Authorization Header
+
+## Overview
+
+The Gemini API key must be passed via the `x-goog-api-key` HTTP request header instead of as a URL query parameter (`?key=<apiKey>`).
+
+## Motivation
+
+Passing secrets as URL query parameters exposes them in:
+- Server-side and proxy access logs
+- Browser history
+- Error messages that include the full URL
+
+Using an HTTP header (`x-goog-api-key`) keeps the API key out of the URL and reduces the risk of accidental exposure.
+
+## Behavior
+
+### Before (insecure)
+
+The `callAPIWithURL` function in `internal/agent/gemini_api.go` appends the API key to the request URL:
+
+```
+https://generativelanguage.googleapis.com/v1beta/models/<model>:generateContent?key=<apiKey>
+```
+
+### After (secure)
+
+The `callAPIWithURL` function sends the API key as an HTTP header:
+
+```
+POST https://generativelanguage.googleapis.com/v1beta/models/<model>:generateContent
+x-goog-api-key: <apiKey>
+```
+
+The URL must not contain the `key=` query parameter.
+
+## Implementation
+
+- File: `internal/agent/gemini_api.go`
+- Function: `callAPIWithURL`
+- Change: Remove the query parameter appending logic; add `req.Header.Set("x-goog-api-key", apiKey)` after creating the request.
+
+## Edge Cases
+
+- The URL must not contain `?key=` or `&key=` after the change.
+- The `x-goog-api-key` header must always be set when an API key is present.
+- Tests must verify the header is present and the query parameter is absent.

--- a/docs/specs/github-rate-limit-check.md
+++ b/docs/specs/github-rate-limit-check.md
@@ -1,0 +1,74 @@
+# GitHub API Rate Limit Pre-Check
+
+## Overview
+
+Before making GitHub API calls, the `Syncer` checks the remaining rate limit.
+If the remaining count is at or below a configurable threshold, the Syncer waits
+until the rate limit resets before proceeding, or returns an error to skip the
+current sync cycle.
+
+## Design
+
+### New Fields on `Syncer`
+
+- `rateLimitThreshold int` — minimum remaining API calls required before
+  proceeding. Default: `10`. A value of `0` disables the pre-check.
+
+### New Builder Method
+
+```go
+func (s *Syncer) WithRateLimitThreshold(n int) *Syncer
+```
+
+Sets the rate-limit threshold. Calling with `0` disables the check.
+
+### Rate Limit Structs
+
+```go
+// ghRateLimitResponse is the parsed JSON from `gh api rate_limit`.
+type ghRateLimitResponse struct {
+    Resources struct {
+        Core ghRateLimitResource `json:"core"`
+    } `json:"resources"`
+}
+
+type ghRateLimitResource struct {
+    Limit     int   `json:"limit"`
+    Remaining int   `json:"remaining"`
+    Reset     int64 `json:"reset"` // Unix timestamp
+    Used      int   `json:"used"`
+}
+```
+
+### `checkRateLimit()` Behavior
+
+1. If `rateLimitThreshold == 0`, return `nil` immediately (check disabled).
+2. Execute `gh api rate_limit` to fetch current rate limit state.
+3. Parse the JSON response into `ghRateLimitResponse`.
+4. If `core.Remaining > rateLimitThreshold`, return `nil` (safe to proceed).
+5. If `core.Remaining <= rateLimitThreshold`:
+   - Calculate wait duration: `time.Until(time.Unix(core.Reset, 0)) + 1s buffer`
+   - If wait duration ≤ 0, return `nil` (reset has already passed).
+   - If wait duration > `rateLimitMaxWait` (default 10 minutes), return an
+     error to skip the current sync cycle instead of waiting too long.
+   - Otherwise, log a warning and wait the calculated duration.
+
+### Integration
+
+`checkRateLimit()` is called at the start of:
+- `fetchIssues(repo string)`
+- `fetchComments(repo string, issueNumber int)`
+
+Both functions return an error if `checkRateLimit()` returns an error.
+
+## Constants
+
+- `defaultRateLimitThreshold = 10` — default minimum remaining calls
+- `rateLimitMaxWait = 10 * time.Minute` — maximum time to wait for reset
+
+## Edge Cases
+
+- If `gh api rate_limit` fails (e.g. no network), the pre-check logs a warning
+  and returns `nil` to allow the sync attempt to proceed (fail-open behavior).
+- If the reset time is in the past, proceed immediately.
+- If wait time exceeds `rateLimitMaxWait`, return an error to skip (not block).

--- a/docs/specs/init-authorized-users.md
+++ b/docs/specs/init-authorized-users.md
@@ -1,0 +1,85 @@
+# Spec: madflow init - authorized_users Configuration
+
+## Overview
+
+`madflow init` must prompt users to specify `authorized_users` during project initialization. This ensures that projects using GitHub integration have the required security configuration set from the start.
+
+## Behavior
+
+### CLI Flag
+
+`madflow init` accepts a new flag:
+
+- `--authorized-users <users>` — Comma-separated list of GitHub usernames to authorize (e.g., `--authorized-users alice,bob`).
+
+### Interactive Prompt
+
+If `--authorized-users` is not provided and stdin is a terminal (interactive session), `madflow init` prompts the user:
+
+```
+Enter authorized GitHub usernames (comma-separated, press Enter to skip):
+```
+
+- The user enters a comma-separated list of GitHub usernames (e.g., `alice, bob`).
+- Each username is trimmed of whitespace.
+- Empty strings after trimming are ignored.
+- If the user presses Enter without input, the `authorized_users` field is omitted from the generated config.
+
+### Non-Interactive Mode
+
+If `--authorized-users` is not provided and stdin is NOT a terminal (piped/scripted input), no prompt is shown and `authorized_users` is omitted from the generated config.
+
+### Generated Config
+
+When `authorized_users` are specified (either via flag or interactive prompt):
+
+```toml
+authorized_users = ["alice", "bob"]
+
+[project]
+name = "myproject"
+...
+```
+
+When no users are specified, the `authorized_users` field is omitted from the generated config.
+
+## Examples
+
+### Via CLI Flag
+
+```bash
+madflow init --authorized-users alice,bob
+```
+
+Generated `madflow.toml` includes:
+```toml
+authorized_users = ["alice", "bob"]
+```
+
+### Via Interactive Prompt
+
+```
+$ madflow init
+Enter authorized GitHub usernames (comma-separated, press Enter to skip): alice, bob
+Project 'myproject' initialized.
+```
+
+### Skip (empty input or non-interactive)
+
+```
+$ madflow init
+Enter authorized GitHub usernames (comma-separated, press Enter to skip): [Enter]
+Project 'myproject' initialized.
+```
+
+Config does not include `authorized_users`.
+
+## Notes
+
+- `authorized_users` is only **required** at runtime when the `[github]` section is present (see `authorized-users-required.md`). If not using GitHub integration, users may safely skip this.
+- If `madflow.toml` already exists, `cmdInit` does not overwrite it, so the `authorized_users` prompt behavior only applies when creating a new config file.
+
+## Affected Files
+
+- `cmd/madflow/main.go` — parse `--authorized-users` flag, add interactive prompt, update config template
+- `cmd/madflow/main_test.go` — add tests for new flag and generated config

--- a/docs/specs/log-sanitization.md
+++ b/docs/specs/log-sanitization.md
@@ -1,0 +1,32 @@
+# Log Sanitization Spec
+
+## Overview
+
+Stderr output from subprocesses is logged to assist with diagnostics. However, stderr may contain sensitive information such as API keys, bearer tokens, or other credentials. This spec describes the sanitization applied before any stderr content is logged.
+
+## Patterns to Sanitize
+
+The following patterns are recognized and masked:
+
+| Pattern | Example | Masked Form |
+|---------|---------|-------------|
+| OpenAI / Anthropic-style secret keys (`sk-...`) | `sk-abc123...` | `sk-***` |
+| Bearer tokens in Authorization headers | `Bearer eyJ...` | `Bearer ***` |
+| Google / Gemini API keys (`AIza...`) | `AIzaSy...` | `AIza***` |
+| `key=<value>` query parameters | `?key=myapikey` | `?key=***` |
+| `api_key=<value>` query parameters | `api_key=secret` | `api_key=***` |
+| `token=<value>` query/form parameters | `token=abc` | `token=***` |
+
+## How Sanitization Works
+
+A `SanitizeLog(s string) string` function in `internal/agent/sanitize.go` applies a series of regular expression replacements to an input string. Each regex captures the sensitive portion and replaces it with `***`. The function is applied to:
+
+1. `internal/agent/gemini_api.go` `runBash()`: the stderr content appended to the result string (line 414).
+2. `internal/agent/claude_stream.go` `Send()`: the stderr content passed to `log.Printf` (line 110).
+
+## Edge Cases
+
+- **Multi-line output**: The regexes are applied to the full string; they will match across lines if the pattern spans a line boundary, but in practice each sensitive value appears on a single line.
+- **False positives**: Short words that happen to match (e.g., `token=abc`) will be masked. This is intentional — it is safer to over-mask than to leak credentials.
+- **Already-masked strings**: Applying the sanitizer to an already-sanitized string is idempotent because `***` does not match the sensitive patterns.
+- **Very long values**: The regexes use `[^\s&"']+` to capture the sensitive portion, so they stop at whitespace, `&`, `"`, or `'`. This avoids catastrophic backtracking.

--- a/docs/specs/no-todo-implementation.md
+++ b/docs/specs/no-todo-implementation.md
@@ -1,0 +1,55 @@
+# Spec: TODO実装の抑止 (No TODO Implementation)
+
+## 概要
+
+Goソースコード内に `// TODO` コメント（未実装のプレースホルダー）が含まれていた場合、CIおよびlintチェックで検出し、マージを防止する。
+
+## 背景
+
+`// TODO: implement` のような未実装のプレースホルダーがコードに残ったままマージされることを防ぐ必要がある。
+
+## 対象
+
+- `**/*.go` ファイル内のすべての `// TODO` コメント
+
+## チェック仕様
+
+### 検出対象パターン
+
+以下のパターンをGoソースファイル内で検出する（大文字小文字を区別する）:
+
+- `// TODO`（行コメント形式のTODO）
+- `/* TODO`（ブロックコメント形式のTODO）
+
+### チェック範囲
+
+- プロジェクト内の全Goソースファイル（`*.go`）
+- vendorディレクトリは除外する
+
+### 動作
+
+- TODO コメントが検出された場合: エラーを出力してexit code 1で終了
+- TODO コメントが検出されない場合: 正常終了（exit code 0）
+
+## 実装方法
+
+### 1. Makefile の lint ターゲットに追加
+
+`make lint` 実行時にTODOチェックを行う。
+
+### 2. CI ワークフロー (.github/workflows/ci.yml) に追加
+
+CIパイプラインの lint ステップとしてTODOチェックを追加する。
+
+## エラーメッセージ例
+
+```
+TODO comments found in Go source files:
+internal/foo/bar.go:42: // TODO: implement this
+Please remove or implement all TODO items before merging.
+```
+
+## 除外対象
+
+- テストファイル（`*_test.go`）は除外しない（テストコードにもTODOは残すべきでない）
+- `vendor/` ディレクトリは除外する

--- a/docs/specs/path-traversal-protection.md
+++ b/docs/specs/path-traversal-protection.md
@@ -1,0 +1,43 @@
+# Path Traversal Protection for Branch Names and Issue IDs
+
+## Overview
+
+When `filepath.Join()` is used to compose worktree directory paths from external input (branch names, issue IDs), a crafted value containing `..` or path separators could escape the intended `.worktrees/` directory. This spec defines the validation rules and implementation details for protecting against such path traversal attacks.
+
+## Background
+
+- **Affected code**: `internal/git/git.go` — `PrepareWorktree`, `AddWorktree`, `CleanWorktrees`, `CleanOrphanedWorktrees`
+- **Input source**: Branch names and issue IDs are derived from GitHub issues (external input)
+- **Risk**: A crafted issue ID such as `../../sensitive` could cause worktree operations to target paths outside `.worktrees/`
+- **Reference**: `SECURITY_AUDIT_REPORT.md` section 3.3
+
+## Validation Rules
+
+A safe name (branch name component or issue ID) must satisfy all of the following:
+
+1. **Non-empty**: Empty strings are rejected.
+2. **No `..` sequences**: Strings containing `..` are rejected to prevent directory traversal.
+3. **No path separators**: Strings containing `/` or `\` are rejected.
+4. **No null bytes**: Strings containing `\x00` are rejected.
+
+## Implementation
+
+### Function: `ValidateSafeName(name string) error`
+
+Located in `internal/git/git.go`. Returns a non-nil error if `name` violates any validation rule.
+
+### Integration Points
+
+`PrepareWorktree` validates its `featureBranch` argument using `ValidateSafeName` before proceeding.
+
+Note: `CleanWorktrees` and `CleanOrphanedWorktrees` read directory names via `os.ReadDir`, which cannot return `..` entries; these functions are safe without additional validation. The validation at `PrepareWorktree` covers the write path where external input is used.
+
+## Test Coverage
+
+Tests in `internal/git/git_test.go` cover:
+- Valid names that should pass (alphanumeric, hyphens, dots in non-traversal positions)
+- Strings with `..` (rejected)
+- Strings with `/` or `\` (rejected)
+- Empty string (rejected)
+- Null byte (rejected)
+- Integration: `PrepareWorktree` rejects a crafted traversal branch name

--- a/docs/specs/sha256-checksum-verification.md
+++ b/docs/specs/sha256-checksum-verification.md
@@ -1,0 +1,75 @@
+# SHA256 Checksum Verification for Binary Auto-Update
+
+## Overview
+
+When `madflow upgrade` downloads a binary from GitHub Releases, it must verify the SHA256 checksum of the downloaded file before replacing the current executable. This prevents malicious binary replacement in the event of a GitHub Release compromise or a man-in-the-middle (MITM) attack.
+
+## Related Issue
+
+- Issue: [#200 バイナリ自動更新時にSHA256チェックサム検証を追加する](https://github.com/ytnobody/MADFLOW/issues/200)
+- Security Audit: `SECURITY_AUDIT_REPORT.md` section 3.3
+
+## Design
+
+### Checksum File Format
+
+For each binary release asset, a corresponding SHA256 checksum file is published alongside it. The checksum file name follows the pattern:
+
+```
+{binary-name}.sha256
+```
+
+For example:
+- Binary: `madflow-linux-amd64`
+- Checksum: `madflow-linux-amd64.sha256`
+
+The content of the checksum file is a single line containing the lowercase hex-encoded SHA256 digest of the binary, followed by a newline:
+
+```
+<hex-sha256-digest>
+```
+
+This format is intentionally simple (digest only, no filename), compatible with standard `sha256sum` output when trimmed.
+
+### Verification Flow
+
+1. Fetch the latest release info from the GitHub Releases API.
+2. Locate the binary asset matching the current platform (`madflow-{os}-{arch}`).
+3. Locate the checksum asset for that binary (`madflow-{os}-{arch}.sha256`).
+4. If the checksum asset is not found in the release, abort with an error.
+5. Download the binary to a temporary file.
+6. Download the checksum file (in memory).
+7. Compute the SHA256 digest of the downloaded temporary binary.
+8. Compare the computed digest with the expected digest from the checksum file.
+9. If they do not match, delete the temporary file and abort with an error.
+10. If they match, proceed with replacing the current executable.
+
+### Error Handling
+
+- If the checksum asset is not present in the release, the upgrade is aborted. This makes checksum verification mandatory (fail-closed).
+- If the downloaded checksum content is malformed (empty, unexpected format), the upgrade is aborted.
+- If the checksums do not match, the upgrade is aborted and the temporary binary is deleted.
+
+## Release Workflow Changes
+
+The `.github/workflows/release.yml` workflow is updated to generate and upload checksum files for each binary artifact:
+
+```bash
+cd dist
+for f in madflow-linux-amd64 madflow-linux-arm64 madflow-darwin-amd64 madflow-darwin-arm64 madflow-windows-amd64.exe; do
+  sha256sum "$f" | awk '{print $1}' > "${f}.sha256"
+done
+```
+
+The resulting `.sha256` files are uploaded to the GitHub Release alongside the binary files.
+
+## Security Properties
+
+- **Integrity**: Any modification to the binary after release will cause checksum mismatch and the upgrade will be rejected.
+- **Fail-closed**: If a checksum file is missing from the release, the upgrade is refused rather than proceeding without verification.
+- **No trust-on-first-use**: The checksum file and binary are both fetched from the same GitHub Release; the verification catches corruption or tampering of the binary relative to the published checksum.
+
+## Limitations
+
+- This does not provide cryptographic authenticity (i.e., it does not prove the release was made by the legitimate maintainer). For stronger guarantees, GPG signing of checksums would be needed.
+- Both the binary and checksum file are served from GitHub. A full GitHub Release compromise would affect both. However, this protects against MITM attacks on the download transport and accidental binary corruption.

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -63,6 +63,13 @@ func NewAgent(cfg AgentConfig) *Agent {
 				WorkDir:      cfg.WorkDir,
 				BashTimeout:  cfg.BashTimeout,
 			})
+		case strings.HasPrefix(cfg.Model, "anthropic/"):
+			proc = NewAnthropicAPIProcess(AnthropicAPIOptions{
+				SystemPrompt: cfg.SystemPrompt,
+				Model:        cfg.Model,
+				WorkDir:      cfg.WorkDir,
+				BashTimeout:  cfg.BashTimeout,
+			})
 		default:
 			proc = NewClaudeStreamProcess(ClaudeOptions{
 				SystemPrompt: cfg.SystemPrompt,

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -188,7 +188,7 @@ func buildMessagePrompt(msgs []chatlog.Message, lang string) string {
 // and writes them to the chatlog file. This handles the case where the AI
 // model returns chatlog messages as text output instead of using bash echo.
 func (a *Agent) rescueChatLogMessages(response string) {
-	f, err := os.OpenFile(a.ChatLog.Path(), os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	f, err := os.OpenFile(a.ChatLog.Path(), os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0600)
 	if err != nil {
 		return
 	}

--- a/internal/agent/anthropic_api.go
+++ b/internal/agent/anthropic_api.go
@@ -1,0 +1,337 @@
+package agent
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const (
+	anthropicAPIEndpoint = "https://api.anthropic.com/v1/messages"
+	anthropicVersion     = "2023-06-01"
+	anthropicMaxTokens   = 8096
+	anthropicMaxIter     = 25 // maximum agentic loop iterations
+)
+
+// AnthropicAPIOptions configures the Anthropic API-based agent process.
+type AnthropicAPIOptions struct {
+	SystemPrompt string
+	Model        string
+	WorkDir      string
+	BashTimeout  time.Duration
+}
+
+// AnthropicAPIProcess sends prompts to the Anthropic Messages API using ANTHROPIC_API_KEY.
+// It implements an agentic loop: if the model calls tools (bash), it executes them
+// and feeds the results back until the model finishes.
+type AnthropicAPIProcess struct {
+	opts       AnthropicAPIOptions
+	client     *http.Client
+	testAPIURL string // overrides the endpoint in tests
+}
+
+// NewAnthropicAPIProcess creates a new AnthropicAPIProcess.
+func NewAnthropicAPIProcess(opts AnthropicAPIOptions) *AnthropicAPIProcess {
+	return &AnthropicAPIProcess{
+		opts:   opts,
+		client: &http.Client{Timeout: 300 * time.Second},
+	}
+}
+
+func (a *AnthropicAPIProcess) Reset(ctx context.Context) error { return nil }
+func (a *AnthropicAPIProcess) Close() error                    { return nil }
+
+// apiURL returns the effective API endpoint (test override or production).
+func (a *AnthropicAPIProcess) apiURL() string {
+	if a.testAPIURL != "" {
+		return a.testAPIURL
+	}
+	return anthropicAPIEndpoint
+}
+
+// modelName returns the bare model name with the "anthropic/" prefix stripped.
+func (a *AnthropicAPIProcess) modelName() string {
+	return strings.TrimPrefix(a.opts.Model, "anthropic/")
+}
+
+// --- Anthropic API request/response types ---
+
+type anthropicRequest struct {
+	Model     string             `json:"model"`
+	MaxTokens int                `json:"max_tokens"`
+	System    string             `json:"system,omitempty"`
+	Messages  []anthropicMessage `json:"messages"`
+	Tools     []anthropicTool    `json:"tools,omitempty"`
+}
+
+type anthropicMessage struct {
+	Role    string `json:"role"`
+	Content any    `json:"content"` // string or []anthropicContentBlock
+}
+
+type anthropicContentBlock struct {
+	Type  string          `json:"type"`
+	Text  string          `json:"text,omitempty"`
+	ID    string          `json:"id,omitempty"`
+	Name  string          `json:"name,omitempty"`
+	Input json.RawMessage `json:"input,omitempty"`
+	// For tool_result blocks
+	ToolUseID string `json:"tool_use_id,omitempty"`
+	Content   string `json:"content,omitempty"`
+}
+
+type anthropicTool struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	InputSchema any    `json:"input_schema"`
+}
+
+type anthropicResponse struct {
+	ID         string                  `json:"id"`
+	Type       string                  `json:"type"`
+	Role       string                  `json:"role"`
+	Content    []anthropicContentBlock `json:"content"`
+	StopReason string                  `json:"stop_reason"`
+	Error      *anthropicError         `json:"error,omitempty"`
+}
+
+type anthropicError struct {
+	Type    string `json:"type"`
+	Message string `json:"message"`
+}
+
+// anthropicBashTool is the tool declaration for the bash tool.
+var anthropicBashTool = anthropicTool{
+	Name:        "bash",
+	Description: "Execute a bash command in the working directory and return stdout/stderr. Use this for all file operations, git commands, and shell tasks.",
+	InputSchema: map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"command": map[string]any{
+				"type":        "string",
+				"description": "The bash command to execute",
+			},
+		},
+		"required": []string{"command"},
+	},
+}
+
+// Send implements the Process interface.
+// It calls the Anthropic Messages API with an agentic loop:
+//  1. Send the prompt
+//  2. If the model uses tool_use blocks, execute them and feed results back
+//  3. Repeat until stop_reason is end_turn/max_tokens or max iterations reached
+func (a *AnthropicAPIProcess) Send(ctx context.Context, prompt string) (string, error) {
+	apiKey := os.Getenv("ANTHROPIC_API_KEY")
+	if apiKey == "" {
+		return "", fmt.Errorf("ANTHROPIC_API_KEY is not set; claude-api backend requires an Anthropic API key")
+	}
+
+	messages := []anthropicMessage{
+		{Role: "user", Content: prompt},
+	}
+
+	var lastText string
+	for range anthropicMaxIter {
+		resp, err := a.callAPI(ctx, apiKey, messages)
+		if err != nil {
+			return "", err
+		}
+
+		// Check for API-level error in the response body
+		if resp.Error != nil {
+			errMsg := resp.Error.Message
+			errType := resp.Error.Type
+			if strings.Contains(errType, "rate_limit") || strings.Contains(errType, "overloaded") ||
+				containsRateLimitKeyword(errMsg) {
+				return "", &RateLimitError{Wrapped: fmt.Errorf("anthropic API rate limit: %s", errMsg)}
+			}
+			return "", fmt.Errorf("anthropic API error (%s): %s", errType, errMsg)
+		}
+
+		// Track last text from this response
+		if text := a.extractText(resp.Content); text != "" {
+			lastText = text
+		}
+
+		// Handle stop reasons
+		switch resp.StopReason {
+		case "max_tokens":
+			return lastText, nil
+		case "end_turn":
+			return a.extractText(resp.Content), nil
+		}
+
+		// Check for tool_use blocks
+		toolUses := a.extractToolUses(resp.Content)
+		if len(toolUses) == 0 {
+			// No tool calls, return text
+			return a.extractText(resp.Content), nil
+		}
+
+		// Append assistant message with the full content
+		messages = append(messages, anthropicMessage{
+			Role:    "assistant",
+			Content: resp.Content,
+		})
+
+		// Execute tools and collect results
+		var toolResults []anthropicContentBlock
+		for _, tu := range toolUses {
+			result, _ := a.executeTool(ctx, tu.Name, tu.Input)
+			toolResults = append(toolResults, anthropicContentBlock{
+				Type:      "tool_result",
+				ToolUseID: tu.ID,
+				Content:   result,
+			})
+		}
+
+		// Append tool results as user message
+		messages = append(messages, anthropicMessage{
+			Role:    "user",
+			Content: toolResults,
+		})
+	}
+
+	return "", &MaxIterationsError{PartialResponse: lastText}
+}
+
+// callAPI sends a single request to the Anthropic Messages API.
+func (a *AnthropicAPIProcess) callAPI(ctx context.Context, apiKey string, messages []anthropicMessage) (*anthropicResponse, error) {
+	reqBody := anthropicRequest{
+		Model:     a.modelName(),
+		MaxTokens: anthropicMaxTokens,
+		Messages:  messages,
+		Tools:     []anthropicTool{anthropicBashTool},
+	}
+	if a.opts.SystemPrompt != "" {
+		reqBody.System = a.opts.SystemPrompt
+	}
+
+	data, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("marshal request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, a.apiURL(), bytes.NewReader(data))
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("x-api-key", apiKey)
+	req.Header.Set("anthropic-version", anthropicVersion)
+
+	httpResp, err := a.client.Do(req)
+	if err != nil {
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+		return nil, fmt.Errorf("http request failed: %w", err)
+	}
+	defer httpResp.Body.Close()
+
+	body, err := io.ReadAll(httpResp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read response body: %w", err)
+	}
+
+	// Handle HTTP-level rate limit errors
+	if httpResp.StatusCode == 429 || httpResp.StatusCode == 529 {
+		return nil, &RateLimitError{
+			Wrapped: fmt.Errorf("anthropic API rate limit (HTTP %d): %s", httpResp.StatusCode, strings.TrimSpace(string(body))),
+		}
+	}
+	if httpResp.StatusCode >= 400 {
+		bodyStr := string(body)
+		if containsRateLimitKeyword(bodyStr) || strings.Contains(bodyStr, "overloaded") {
+			return nil, &RateLimitError{
+				Wrapped: fmt.Errorf("anthropic API rate limit (HTTP %d): %s", httpResp.StatusCode, strings.TrimSpace(bodyStr)),
+			}
+		}
+		return nil, fmt.Errorf("anthropic API HTTP %d: %s", httpResp.StatusCode, strings.TrimSpace(bodyStr))
+	}
+
+	var resp anthropicResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return nil, fmt.Errorf("decode response: %w (body: %s)", err, string(body))
+	}
+
+	return &resp, nil
+}
+
+// extractText collects all text blocks from the response content.
+func (a *AnthropicAPIProcess) extractText(content []anthropicContentBlock) string {
+	var texts []string
+	for _, block := range content {
+		if block.Type == "text" && block.Text != "" {
+			texts = append(texts, block.Text)
+		}
+	}
+	return strings.TrimSpace(strings.Join(texts, "\n"))
+}
+
+// extractToolUses returns all tool_use blocks from the response content.
+func (a *AnthropicAPIProcess) extractToolUses(content []anthropicContentBlock) []anthropicContentBlock {
+	var uses []anthropicContentBlock
+	for _, block := range content {
+		if block.Type == "tool_use" {
+			uses = append(uses, block)
+		}
+	}
+	return uses
+}
+
+// executeTool runs the requested tool and returns (output, isError).
+func (a *AnthropicAPIProcess) executeTool(ctx context.Context, toolName string, input json.RawMessage) (string, bool) {
+	switch toolName {
+	case "bash":
+		var params struct {
+			Command string `json:"command"`
+		}
+		if err := json.Unmarshal(input, &params); err != nil {
+			return fmt.Sprintf("failed to parse bash input: %v", err), true
+		}
+		return a.runBash(ctx, params.Command)
+	default:
+		return fmt.Sprintf("unknown tool: %s", toolName), true
+	}
+}
+
+// runBash executes a bash command and returns (output, isError).
+func (a *AnthropicAPIProcess) runBash(ctx context.Context, command string) (string, bool) {
+	if a.opts.BashTimeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, a.opts.BashTimeout)
+		defer cancel()
+	}
+
+	cmd := exec.CommandContext(ctx, "bash", "-c", command)
+	if a.opts.WorkDir != "" {
+		cmd.Dir = a.opts.WorkDir
+	}
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
+	result := strings.TrimSpace(stdout.String())
+	if stderr.Len() > 0 {
+		if result != "" {
+			result += "\n"
+		}
+		result += "STDERR:\n" + strings.TrimSpace(stderr.String())
+	}
+	if result == "" && err != nil {
+		result = fmt.Sprintf("command failed: %v", err)
+	}
+
+	return result, err != nil
+}

--- a/internal/agent/anthropic_api_test.go
+++ b/internal/agent/anthropic_api_test.go
@@ -1,0 +1,315 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestAnthropicAPIProcess_Send_NoAPIKey verifies that missing ANTHROPIC_API_KEY returns an error.
+func TestAnthropicAPIProcess_Send_NoAPIKey(t *testing.T) {
+	prev := os.Getenv("ANTHROPIC_API_KEY")
+	os.Unsetenv("ANTHROPIC_API_KEY")
+	defer func() {
+		if prev != "" {
+			os.Setenv("ANTHROPIC_API_KEY", prev)
+		}
+	}()
+
+	p := NewAnthropicAPIProcess(AnthropicAPIOptions{Model: "anthropic/claude-sonnet-4-6"})
+	_, err := p.Send(context.Background(), "hello")
+	if err == nil {
+		t.Fatal("expected error when ANTHROPIC_API_KEY is not set")
+	}
+	if !strings.Contains(err.Error(), "ANTHROPIC_API_KEY") {
+		t.Errorf("expected ANTHROPIC_API_KEY in error message, got: %v", err)
+	}
+}
+
+// TestAnthropicAPIProcess_Send_EndTurn verifies a successful text response (stop_reason=end_turn).
+func TestAnthropicAPIProcess_Send_EndTurn(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Verify required headers
+		if r.Header.Get("x-api-key") == "" {
+			t.Error("expected x-api-key header")
+		}
+		if r.Header.Get("anthropic-version") == "" {
+			t.Error("expected anthropic-version header")
+		}
+
+		resp := anthropicResponse{
+			Content: []anthropicContentBlock{
+				{Type: "text", Text: "Hello from mock Anthropic API!"},
+			},
+			StopReason: "end_turn",
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	os.Setenv("ANTHROPIC_API_KEY", "test-key")
+	defer os.Unsetenv("ANTHROPIC_API_KEY")
+
+	p := NewAnthropicAPIProcess(AnthropicAPIOptions{Model: "anthropic/claude-sonnet-4-6"})
+	p.client = server.Client()
+	p.testAPIURL = server.URL + "/v1/messages"
+
+	result, err := p.Send(context.Background(), "hello")
+	if err != nil {
+		t.Fatalf("Send failed: %v", err)
+	}
+	if result != "Hello from mock Anthropic API!" {
+		t.Errorf("unexpected result: %q", result)
+	}
+}
+
+// TestAnthropicAPIProcess_Send_RateLimit429 verifies HTTP 429 is detected as a RateLimitError.
+func TestAnthropicAPIProcess_Send_RateLimit429(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(429)
+		w.Write([]byte(`{"type":"error","error":{"type":"rate_limit_error","message":"Too many requests"}}`))
+	}))
+	defer server.Close()
+
+	os.Setenv("ANTHROPIC_API_KEY", "test-key")
+	defer os.Unsetenv("ANTHROPIC_API_KEY")
+
+	p := NewAnthropicAPIProcess(AnthropicAPIOptions{Model: "anthropic/claude-sonnet-4-6"})
+	p.client = server.Client()
+	p.testAPIURL = server.URL + "/v1/messages"
+
+	_, err := p.Send(context.Background(), "hello")
+	if err == nil {
+		t.Fatal("expected error for 429")
+	}
+	if !IsRateLimitError(err) {
+		t.Errorf("expected RateLimitError, got: %v", err)
+	}
+}
+
+// TestAnthropicAPIProcess_Send_ToolUseLoop verifies the agentic tool-use loop.
+func TestAnthropicAPIProcess_Send_ToolUseLoop(t *testing.T) {
+	callCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		w.Header().Set("Content-Type", "application/json")
+		if callCount == 1 {
+			// First call: return tool_use
+			resp := anthropicResponse{
+				Content: []anthropicContentBlock{
+					{
+						Type:  "tool_use",
+						ID:    "tool-1",
+						Name:  "bash",
+						Input: json.RawMessage(`{"command":"echo tool_result"}`),
+					},
+				},
+				StopReason: "tool_use",
+			}
+			json.NewEncoder(w).Encode(resp)
+		} else {
+			// Second call: return text
+			resp := anthropicResponse{
+				Content: []anthropicContentBlock{
+					{Type: "text", Text: "Done after tool use"},
+				},
+				StopReason: "end_turn",
+			}
+			json.NewEncoder(w).Encode(resp)
+		}
+	}))
+	defer server.Close()
+
+	os.Setenv("ANTHROPIC_API_KEY", "test-key")
+	defer os.Unsetenv("ANTHROPIC_API_KEY")
+
+	p := NewAnthropicAPIProcess(AnthropicAPIOptions{Model: "anthropic/claude-sonnet-4-6"})
+	p.client = server.Client()
+	p.testAPIURL = server.URL + "/v1/messages"
+
+	result, err := p.Send(context.Background(), "run a command")
+	if err != nil {
+		t.Fatalf("Send failed: %v", err)
+	}
+	if result != "Done after tool use" {
+		t.Errorf("expected 'Done after tool use', got %q", result)
+	}
+	if callCount != 2 {
+		t.Errorf("expected 2 API calls for tool-use loop, got %d", callCount)
+	}
+}
+
+// TestAnthropicAPIProcess_Send_MaxTokens verifies stop_reason=max_tokens returns partial text without error.
+func TestAnthropicAPIProcess_Send_MaxTokens(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := anthropicResponse{
+			Content: []anthropicContentBlock{
+				{Type: "text", Text: "truncated response text"},
+			},
+			StopReason: "max_tokens",
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	os.Setenv("ANTHROPIC_API_KEY", "test-key")
+	defer os.Unsetenv("ANTHROPIC_API_KEY")
+
+	p := NewAnthropicAPIProcess(AnthropicAPIOptions{Model: "anthropic/claude-sonnet-4-6"})
+	p.client = server.Client()
+	p.testAPIURL = server.URL + "/v1/messages"
+
+	result, err := p.Send(context.Background(), "generate a long response")
+	if err != nil {
+		t.Fatalf("expected no error for max_tokens, got: %v", err)
+	}
+	if result != "truncated response text" {
+		t.Errorf("expected 'truncated response text', got %q", result)
+	}
+}
+
+// TestAnthropicAPIProcess_Send_MaxIterationsError verifies that reaching max iterations returns MaxIterationsError.
+func TestAnthropicAPIProcess_Send_MaxIterationsError(t *testing.T) {
+	// Always return a tool_use so the loop never terminates naturally
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := anthropicResponse{
+			Content: []anthropicContentBlock{
+				{Type: "text", Text: "partial work"},
+				{
+					Type:  "tool_use",
+					ID:    "tool-x",
+					Name:  "bash",
+					Input: json.RawMessage(`{"command":"echo iteration"}`),
+				},
+			},
+			StopReason: "tool_use",
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	os.Setenv("ANTHROPIC_API_KEY", "test-key")
+	defer os.Unsetenv("ANTHROPIC_API_KEY")
+
+	p := NewAnthropicAPIProcess(AnthropicAPIOptions{Model: "anthropic/claude-sonnet-4-6"})
+	p.client = server.Client()
+	p.testAPIURL = server.URL + "/v1/messages"
+
+	_, err := p.Send(context.Background(), "do something complex")
+	if err == nil {
+		t.Fatal("expected error when max iterations reached")
+	}
+
+	var maxIterErr *MaxIterationsError
+	if !errors.As(err, &maxIterErr) {
+		t.Fatalf("expected MaxIterationsError, got: %T: %v", err, err)
+	}
+}
+
+// TestAnthropicAPIProcess_Send_SystemPrompt verifies system prompt is included in the request.
+func TestAnthropicAPIProcess_Send_SystemPrompt(t *testing.T) {
+	var receivedReq anthropicRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewDecoder(r.Body).Decode(&receivedReq)
+		resp := anthropicResponse{
+			Content:    []anthropicContentBlock{{Type: "text", Text: "ok"}},
+			StopReason: "end_turn",
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	os.Setenv("ANTHROPIC_API_KEY", "test-key")
+	defer os.Unsetenv("ANTHROPIC_API_KEY")
+
+	p := NewAnthropicAPIProcess(AnthropicAPIOptions{
+		Model:        "anthropic/claude-sonnet-4-6",
+		SystemPrompt: "You are a helpful assistant",
+	})
+	p.client = server.Client()
+	p.testAPIURL = server.URL + "/v1/messages"
+
+	_, err := p.Send(context.Background(), "hello")
+	if err != nil {
+		t.Fatalf("Send failed: %v", err)
+	}
+
+	if receivedReq.System != "You are a helpful assistant" {
+		t.Errorf("expected system prompt to be set, got: %q", receivedReq.System)
+	}
+}
+
+// TestAnthropicAPIProcess_Send_ModelPrefixStripped verifies anthropic/ prefix is stripped from model name.
+func TestAnthropicAPIProcess_Send_ModelPrefixStripped(t *testing.T) {
+	var receivedReq anthropicRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewDecoder(r.Body).Decode(&receivedReq)
+		resp := anthropicResponse{
+			Content:    []anthropicContentBlock{{Type: "text", Text: "ok"}},
+			StopReason: "end_turn",
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	os.Setenv("ANTHROPIC_API_KEY", "test-key")
+	defer os.Unsetenv("ANTHROPIC_API_KEY")
+
+	p := NewAnthropicAPIProcess(AnthropicAPIOptions{Model: "anthropic/claude-sonnet-4-6"})
+	p.client = server.Client()
+	p.testAPIURL = server.URL + "/v1/messages"
+
+	_, err := p.Send(context.Background(), "hello")
+	if err != nil {
+		t.Fatalf("Send failed: %v", err)
+	}
+
+	if receivedReq.Model != "claude-sonnet-4-6" {
+		t.Errorf("expected model 'claude-sonnet-4-6', got: %q", receivedReq.Model)
+	}
+}
+
+// TestAnthropicAPIProcess_Send_OverloadedError verifies overloaded error is treated as rate limit.
+func TestAnthropicAPIProcess_Send_OverloadedError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(529)
+		w.Write([]byte(`{"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}`))
+	}))
+	defer server.Close()
+
+	os.Setenv("ANTHROPIC_API_KEY", "test-key")
+	defer os.Unsetenv("ANTHROPIC_API_KEY")
+
+	p := NewAnthropicAPIProcess(AnthropicAPIOptions{Model: "anthropic/claude-sonnet-4-6"})
+	p.client = server.Client()
+	p.testAPIURL = server.URL + "/v1/messages"
+
+	_, err := p.Send(context.Background(), "hello")
+	if err == nil {
+		t.Fatal("expected error for overloaded")
+	}
+	if !IsRateLimitError(err) {
+		t.Errorf("expected RateLimitError for overloaded_error, got: %v", err)
+	}
+}
+
+// TestAnthropicAPIProcess_ResetAndClose verifies Reset and Close are no-ops.
+func TestAnthropicAPIProcess_ResetAndClose(t *testing.T) {
+	p := NewAnthropicAPIProcess(AnthropicAPIOptions{Model: "anthropic/claude-sonnet-4-6"})
+	if err := p.Reset(context.Background()); err != nil {
+		t.Errorf("Reset returned error: %v", err)
+	}
+	if err := p.Close(); err != nil {
+		t.Errorf("Close returned error: %v", err)
+	}
+}

--- a/internal/agent/claude_stream.go
+++ b/internal/agent/claude_stream.go
@@ -106,7 +106,7 @@ func (c *ClaudeStreamProcess) Send(ctx context.Context, prompt string) (string, 
 
 	result, err := c.readResult(ctx)
 	if err != nil && c.stderrBuf != nil {
-		if stderrMsg := strings.TrimSpace(c.stderrBuf.String()); stderrMsg != "" {
+		if stderrMsg := SanitizeLog(strings.TrimSpace(c.stderrBuf.String())); stderrMsg != "" {
 			log.Printf("[claude-stream] stderr: %s", stderrMsg)
 		}
 	}

--- a/internal/agent/gemini_api.go
+++ b/internal/agent/gemini_api.go
@@ -304,18 +304,12 @@ func (g *GeminiAPIProcess) callAPIWithURL(ctx context.Context, apiKey string, co
 		return nil, fmt.Errorf("marshal request: %w", err)
 	}
 
-	// Append API key as query parameter
-	sep := "?"
-	if strings.Contains(url, "?") {
-		sep = "&"
-	}
-	fullURL := url + sep + "key=" + apiKey
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, fullURL, bytes.NewReader(data))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(data))
 	if err != nil {
 		return nil, fmt.Errorf("create request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("x-goog-api-key", apiKey)
 
 	httpResp, err := g.client.Do(req)
 	if err != nil {

--- a/internal/agent/gemini_api.go
+++ b/internal/agent/gemini_api.go
@@ -411,7 +411,7 @@ func (g *GeminiAPIProcess) runBash(ctx context.Context, command string) (string,
 		if result != "" {
 			result += "\n"
 		}
-		result += "STDERR:\n" + strings.TrimSpace(stderr.String())
+		result += "STDERR:\n" + SanitizeLog(strings.TrimSpace(stderr.String()))
 	}
 	if result == "" && err != nil {
 		result = fmt.Sprintf("command failed: %v", err)

--- a/internal/agent/gemini_api_test.go
+++ b/internal/agent/gemini_api_test.go
@@ -174,9 +174,12 @@ func TestGeminiAPIProcess_Send_NoAPIKey(t *testing.T) {
 // TestGeminiAPIProcess_Send_EndTurn uses a mock HTTP server to verify a successful response.
 func TestGeminiAPIProcess_Send_EndTurn(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// Verify API key is passed as query parameter
-		if r.URL.Query().Get("key") == "" {
-			t.Error("expected key query parameter")
+		// Verify API key is passed as x-goog-api-key header (not query parameter)
+		if r.Header.Get("x-goog-api-key") == "" {
+			t.Error("expected x-goog-api-key header")
+		}
+		if r.URL.Query().Get("key") != "" {
+			t.Error("API key must not appear as query parameter")
 		}
 
 		resp := geminiResponse{

--- a/internal/agent/sanitize.go
+++ b/internal/agent/sanitize.go
@@ -1,0 +1,35 @@
+package agent
+
+import "regexp"
+
+// sensitivePatterns is the list of regexes used to mask credentials in log output.
+// Each pattern must capture the sensitive value in group 1 so it can be replaced
+// with "***" while keeping the surrounding context intact.
+var sensitivePatterns = []*regexp.Regexp{
+	// OpenAI / Anthropic-style secret keys: sk-<value>
+	regexp.MustCompile(`(?i)(sk-)[^\s"'&]{8,}`),
+	// Google / Gemini API keys: AIza<value>
+	regexp.MustCompile(`(AIza)[^\s"'&]{8,}`),
+	// Bearer tokens in Authorization headers
+	regexp.MustCompile(`(?i)(Bearer\s+)[^\s"'&]{4,}`),
+	// URL query parameters: key=, api_key=, token=, access_token=, secret=
+	regexp.MustCompile(`(?i)(\b(?:key|api[_-]key|token|access[_-]token|secret)=)[^\s"'&]{4,}`),
+}
+
+// SanitizeLog masks known sensitive patterns (API keys, tokens, bearer credentials)
+// in s and returns the sanitized string. It is safe to call on any log message.
+func SanitizeLog(s string) string {
+	for _, re := range sensitivePatterns {
+		s = re.ReplaceAllStringFunc(s, func(match string) string {
+			// Find the prefix (captured group 1 equivalent) by re-matching.
+			sub := re.FindStringSubmatchIndex(match)
+			if len(sub) < 4 {
+				return match
+			}
+			// sub[2]..sub[3] is the position of the first capture group inside match.
+			prefix := match[sub[2]:sub[3]]
+			return prefix + "***"
+		})
+	}
+	return s
+}

--- a/internal/agent/sanitize_test.go
+++ b/internal/agent/sanitize_test.go
@@ -1,0 +1,104 @@
+package agent
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSanitizeLog(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		wantMasked  []string // substrings that must NOT appear in the output
+		wantPresent []string // substrings that must still appear in the output
+	}{
+		{
+			name:        "sk- key is masked",
+			input:       "error: invalid key sk-abc1234567890XYZ",
+			wantMasked:  []string{"sk-abc1234567890XYZ"},
+			wantPresent: []string{"sk-***", "error: invalid key"},
+		},
+		{
+			name:        "AIza key is masked",
+			input:       "using api key AIzaSyD-9tSrke72I6e49zkreH8HsGzABCD1234",
+			wantMasked:  []string{"AIzaSyD-9tSrke72I6e49zkreH8HsGzABCD1234"},
+			wantPresent: []string{"AIza***"},
+		},
+		{
+			name:        "Bearer token is masked",
+			input:       "Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9",
+			wantMasked:  []string{"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9"},
+			wantPresent: []string{"Bearer ***"},
+		},
+		{
+			name:        "bearer token case-insensitive",
+			input:       "header: bearer supersecrettoken12345",
+			wantMasked:  []string{"supersecrettoken12345"},
+			wantPresent: []string{"bearer ***"},
+		},
+		{
+			name:        "key= query parameter is masked",
+			input:       "GET /api?key=mysecretapikey123 HTTP/1.1",
+			wantMasked:  []string{"mysecretapikey123"},
+			wantPresent: []string{"key=***"},
+		},
+		{
+			name:        "api_key= is masked",
+			input:       "request failed: api_key=supersecret123",
+			wantMasked:  []string{"supersecret123"},
+			wantPresent: []string{"api_key=***"},
+		},
+		{
+			name:        "token= is masked",
+			input:       "token=abcdefghij refresh failed",
+			wantMasked:  []string{"abcdefghij"},
+			wantPresent: []string{"token=***"},
+		},
+		{
+			name:        "access_token= is masked",
+			input:       "access_token=longaccesstoken999 expired",
+			wantMasked:  []string{"longaccesstoken999"},
+			wantPresent: []string{"access_token=***"},
+		},
+		{
+			name:        "no sensitive data passes through unchanged",
+			input:       "command failed: exit status 1",
+			wantMasked:  []string{},
+			wantPresent: []string{"command failed: exit status 1"},
+		},
+		{
+			name:        "empty string",
+			input:       "",
+			wantMasked:  []string{},
+			wantPresent: []string{},
+		},
+		{
+			name:        "multiple secrets in one string",
+			input:       "key=secretkey1234 and Bearer tokenvalue5678",
+			wantMasked:  []string{"secretkey1234", "tokenvalue5678"},
+			wantPresent: []string{"key=***", "Bearer ***"},
+		},
+		{
+			name:        "idempotent on already-sanitized output",
+			input:       "sk-*** and key=***",
+			wantMasked:  []string{},
+			wantPresent: []string{"sk-***", "key=***"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := SanitizeLog(tt.input)
+			for _, banned := range tt.wantMasked {
+				if strings.Contains(got, banned) {
+					t.Errorf("SanitizeLog(%q) = %q; still contains sensitive value %q", tt.input, got, banned)
+				}
+			}
+			for _, want := range tt.wantPresent {
+				if !strings.Contains(got, want) {
+					t.Errorf("SanitizeLog(%q) = %q; expected to contain %q", tt.input, got, want)
+				}
+			}
+		})
+	}
+}

--- a/internal/chatlog/chatlog.go
+++ b/internal/chatlog/chatlog.go
@@ -64,7 +64,7 @@ func FormatMessage(recipient, sender, body string) string {
 
 // Append writes a new formatted message to the chatlog file.
 func (c *ChatLog) Append(recipient, sender, body string) error {
-	f, err := os.OpenFile(c.path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	f, err := os.OpenFile(c.path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0600)
 	if err != nil {
 		return fmt.Errorf("open chatlog for append: %w", err)
 	}
@@ -257,7 +257,7 @@ func (c *ChatLog) Truncate(maxLines int) error {
 	newContent := strings.Join(lines, "\n") + "\n"
 
 	tmpPath := c.path + ".tmp"
-	if err := os.WriteFile(tmpPath, []byte(newContent), 0644); err != nil {
+	if err := os.WriteFile(tmpPath, []byte(newContent), 0600); err != nil {
 		return fmt.Errorf("write temp chatlog: %w", err)
 	}
 

--- a/internal/chatlog/chatlog_test.go
+++ b/internal/chatlog/chatlog_test.go
@@ -417,3 +417,53 @@ func TestReadFrom_TruncationPreservesNewMessages(t *testing.T) {
 		t.Errorf("expected body 'TEAM_CREATE 6', got: %s", messages[0].Body)
 	}
 }
+
+// TestAppendCreatesFileWithRestrictedPermissions verifies that Append creates
+// the chatlog file with 0600 permissions (owner read/write only).
+func TestAppendCreatesFileWithRestrictedPermissions(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "chatlog.txt")
+
+	cl := New(path)
+	if err := cl.Append("recipient", "sender", "hello"); err != nil {
+		t.Fatalf("Append failed: %v", err)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat chatlog: %v", err)
+	}
+	got := info.Mode().Perm()
+	want := os.FileMode(0600)
+	if got != want {
+		t.Errorf("chatlog permission: got %04o, want %04o", got, want)
+	}
+}
+
+// TestTruncatePreservesRestrictedPermissions verifies that Truncate writes the
+// temp file with 0600 permissions.
+func TestTruncatePreservesRestrictedPermissions(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "chatlog.txt")
+
+	cl := New(path)
+	for i := 0; i < 5; i++ {
+		if err := cl.Append("recipient", "sender", "line"); err != nil {
+			t.Fatalf("Append failed: %v", err)
+		}
+	}
+
+	if err := cl.Truncate(2); err != nil {
+		t.Fatalf("Truncate failed: %v", err)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat chatlog after truncate: %v", err)
+	}
+	got := info.Mode().Perm()
+	want := os.FileMode(0600)
+	if got != want {
+		t.Errorf("chatlog permission after truncate: got %04o, want %04o", got, want)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -15,8 +15,11 @@ type Config struct {
 	GitHub     *GitHubConfig `toml:"github,omitempty"`
 	PromptsDir string        `toml:"prompts_dir,omitempty"`
 	// AuthorizedUsers is a list of GitHub user logins that are allowed to create
-	// issues, PRs, and comments that MADFLOW will process. When empty (the default),
-	// all users are trusted. When non-empty, only listed users are trusted.
+	// issues, PRs, and comments that MADFLOW will process.
+	// This field is required when [github] integration is enabled.
+	// Leaving it empty while GitHub integration is active is a security risk:
+	// it would allow any GitHub user to interact with MADFLOW, enabling prompt
+	// injection attacks from arbitrary third parties on public repositories.
 	AuthorizedUsers []string `toml:"authorized_users,omitempty"`
 }
 
@@ -228,6 +231,9 @@ func validate(cfg *Config) error {
 		if r.Path == "" {
 			return fmt.Errorf("project.repos[%d].path is required", i)
 		}
+	}
+	if cfg.GitHub != nil && len(cfg.AuthorizedUsers) == 0 {
+		return fmt.Errorf("authorized_users is required when github integration is enabled; set authorized_users to a list of GitHub logins allowed to interact with MADFLOW")
 	}
 	return nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -104,6 +104,8 @@ path = "."
 
 func TestLoadWithGitHub(t *testing.T) {
 	content := `
+authorized_users = ["testuser"]
+
 [project]
 name = "test-app"
 
@@ -140,6 +142,8 @@ sync_interval_minutes = 10
 
 func TestEventPollSecondsDefault(t *testing.T) {
 	content := `
+authorized_users = ["testuser"]
+
 [project]
 name = "test-app"
 
@@ -172,6 +176,8 @@ repos = ["api"]
 
 func TestEventPollSecondsCustom(t *testing.T) {
 	content := `
+authorized_users = ["testuser"]
+
 [project]
 name = "test-app"
 
@@ -398,6 +404,8 @@ extra_prompt = "このプロジェクトはGoで書かれています。コー�
 }
 
 func TestAuthorizedUsersDefault(t *testing.T) {
+	// When GitHub integration is not configured, authorized_users is not required
+	// and defaults to empty.
 	content := `
 [project]
 name = "test-app"
@@ -419,6 +427,33 @@ path = "."
 
 	if len(cfg.AuthorizedUsers) != 0 {
 		t.Errorf("expected empty authorized_users by default, got %v", cfg.AuthorizedUsers)
+	}
+}
+
+func TestLoadGitHubMissingAuthorizedUsers(t *testing.T) {
+	// When GitHub integration is configured but authorized_users is not set,
+	// Load must return an error to prevent the default all-permit behavior.
+	content := `
+[project]
+name = "test-app"
+
+[[project.repos]]
+name = "main"
+path = "."
+
+[github]
+owner = "myorg"
+repos = ["myrepo"]
+`
+	dir := t.TempDir()
+	path := filepath.Join(dir, "madflow.toml")
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := Load(path)
+	if err == nil {
+		t.Fatal("expected error when github is configured without authorized_users, got nil")
 	}
 }
 
@@ -747,6 +782,8 @@ issue_patrol_interval_minutes = -1
 
 func TestGitHubBotCommentPatterns(t *testing.T) {
 	content := `
+authorized_users = ["testuser"]
+
 [project]
 name = "test-app"
 
@@ -837,6 +874,8 @@ language = "ja"
 func TestGitHubBotCommentPatterns_Empty(t *testing.T) {
 	// When bot_comment_patterns is not configured, it should default to nil/empty.
 	content := `
+authorized_users = ["testuser"]
+
 [project]
 name = "test-app"
 

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -194,9 +194,32 @@ func (r *Repo) CleanOrphanedWorktrees(activeTeamDirs map[string]bool) (removed [
 	return removed
 }
 
+// ValidateSafeName validates that name is safe to use as a branch name component
+// or issue ID in file path operations. It rejects empty strings, strings
+// containing ".." (path traversal), path separators ("/" or "\"), and null bytes.
+func ValidateSafeName(name string) error {
+	if name == "" {
+		return fmt.Errorf("name must not be empty")
+	}
+	if strings.Contains(name, "..") {
+		return fmt.Errorf("name %q contains prohibited sequence \"..\"", name)
+	}
+	if strings.ContainsAny(name, "/\\") {
+		return fmt.Errorf("name %q contains prohibited path separator", name)
+	}
+	if strings.ContainsRune(name, '\x00') {
+		return fmt.Errorf("name %q contains null byte", name)
+	}
+	return nil
+}
+
 // PrepareWorktree ensures the develop branch exists (creating from main if needed)
 // and creates a worktree with a new feature branch based on develop.
+// It validates featureBranch to prevent path traversal attacks.
 func (r *Repo) PrepareWorktree(path, featureBranch, developBranch, mainBranch string) error {
+	if err := ValidateSafeName(featureBranch); err != nil {
+		return fmt.Errorf("invalid feature branch name: %w", err)
+	}
 	if err := r.EnsureBranch(developBranch, mainBranch); err != nil {
 		return fmt.Errorf("ensure develop branch: %w", err)
 	}

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -529,3 +529,66 @@ func TestMergeConflict(t *testing.T) {
 	// and the merge was aborted). Both are acceptable.
 	_ = err
 }
+
+func TestValidateSafeName(t *testing.T) {
+	validCases := []string{
+		"feature-issue-123",
+		"gh-121",
+		"local-001",
+		"ytnobody-MADFLOW-201",
+		"abc",
+		"a",
+		"issue.123",
+	}
+	for _, name := range validCases {
+		t.Run("valid/"+name, func(t *testing.T) {
+			if err := ValidateSafeName(name); err != nil {
+				t.Errorf("expected %q to be valid, got error: %v", name, err)
+			}
+		})
+	}
+
+	invalidCases := []struct {
+		name string
+		desc string
+	}{
+		{"", "empty string"},
+		{"..", "double dot alone"},
+		{"foo/../bar", "path traversal with .."},
+		{"../secret", "leading .."},
+		{"foo/bar", "forward slash"},
+		{"foo\\bar", "backslash"},
+		{"/absolute", "absolute path with slash"},
+		{"foo\x00bar", "null byte"},
+	}
+	for _, tc := range invalidCases {
+		t.Run("invalid/"+tc.desc, func(t *testing.T) {
+			if err := ValidateSafeName(tc.name); err == nil {
+				t.Errorf("expected %q (%s) to be invalid, but got no error", tc.name, tc.desc)
+			}
+		})
+	}
+}
+
+func TestPrepareWorktreeRejectsTraversalBranchName(t *testing.T) {
+	repo := initTestRepo(t)
+
+	baseBranch, err := repo.CurrentBranch()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	wtDir := filepath.Join(t.TempDir(), "wt-traversal")
+
+	// A crafted branch name containing ".." should be rejected before any
+	// filesystem or git operation is attempted.
+	err = repo.PrepareWorktree(wtDir, "../../evil", "develop", baseBranch)
+	if err == nil {
+		t.Fatal("expected error for path traversal branch name, got nil")
+	}
+
+	// The worktree directory must not have been created.
+	if _, statErr := os.Stat(wtDir); !os.IsNotExist(statErr) {
+		t.Error("worktree directory must not exist after rejected traversal attempt")
+	}
+}

--- a/internal/github/events_test.go
+++ b/internal/github/events_test.go
@@ -123,7 +123,8 @@ func TestProcessIssueCommentEvent(t *testing.T) {
 		gotComment = c
 	}
 
-	w := NewEventWatcher(store, "owner", []string{"repo"}, time.Minute, cb)
+	w := NewEventWatcher(store, "owner", []string{"repo"}, time.Minute, cb).
+		WithAuthorizedUsers([]string{"alice"})
 
 	payload := ghEventPayloadComment{
 		Action: "created",
@@ -514,7 +515,8 @@ func TestProcessIssueCommentEvent_BotComment(t *testing.T) {
 		gotComment = c
 	}
 
-	w := NewEventWatcher(store, "owner", []string{"repo"}, time.Minute, cb)
+	w := NewEventWatcher(store, "owner", []string{"repo"}, time.Minute, cb).
+		WithAuthorizedUsers([]string{"my-app[bot]"})
 
 	payload := ghEventPayloadComment{
 		Action: "created",
@@ -554,7 +556,8 @@ func TestProcessIssueCommentEvent_BotLoginSuffix(t *testing.T) {
 		gotComment = c
 	}
 
-	w := NewEventWatcher(store, "owner", []string{"repo"}, time.Minute, cb)
+	w := NewEventWatcher(store, "owner", []string{"repo"}, time.Minute, cb).
+		WithAuthorizedUsers([]string{"github-actions[bot]"})
 
 	payload := ghEventPayloadComment{
 		Action: "created",
@@ -593,7 +596,8 @@ func TestProcessIssueCommentEvent_HumanComment(t *testing.T) {
 		gotComment = c
 	}
 
-	w := NewEventWatcher(store, "owner", []string{"repo"}, time.Minute, cb)
+	w := NewEventWatcher(store, "owner", []string{"repo"}, time.Minute, cb).
+		WithAuthorizedUsers([]string{"alice"})
 
 	payload := ghEventPayloadComment{
 		Action: "created",
@@ -641,7 +645,8 @@ func TestProcessIssueCommentEvent_BotPatternDetection(t *testing.T) {
 	}
 
 	w := NewEventWatcher(store, "owner", []string{"repo"}, time.Minute, cb).
-		WithBotCommentPatterns(patterns)
+		WithBotCommentPatterns(patterns).
+		WithAuthorizedUsers([]string{"ytnobody"})
 
 	payload := ghEventPayloadComment{
 		Action: "created",
@@ -683,7 +688,8 @@ func TestEventWatcher_WithBotCommentPatterns_HumanComment(t *testing.T) {
 
 	patterns, _ := CompileBotPatterns([]string{`^\*\*\[`})
 	w := NewEventWatcher(store, "owner", []string{"repo"}, time.Minute, cb).
-		WithBotCommentPatterns(patterns)
+		WithBotCommentPatterns(patterns).
+		WithAuthorizedUsers([]string{"ytnobody"})
 
 	payload := ghEventPayloadComment{
 		Action: "created",

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -101,24 +101,26 @@ type ghLabel struct {
 
 // Syncer synchronizes GitHub Issues to local issue files.
 type Syncer struct {
-	store           *issue.Store
-	owner           string
-	repos           []string
-	interval        time.Duration
-	idleDetector    *IdleDetector    // nil = no adaptive behavior
-	idleInterval    time.Duration    // effective only when idleDetector is set
-	authorizedUsers []string         // empty = all users trusted
-	botPatterns     []*regexp.Regexp // compiled bot comment patterns; nil = no pattern check
-	skipComments    bool             // if true, skip comment sync (for fast startup)
+	store              *issue.Store
+	owner              string
+	repos              []string
+	interval           time.Duration
+	idleDetector       *IdleDetector    // nil = no adaptive behavior
+	idleInterval       time.Duration    // effective only when idleDetector is set
+	authorizedUsers    []string         // empty = all users trusted
+	botPatterns        []*regexp.Regexp // compiled bot comment patterns; nil = no pattern check
+	skipComments       bool             // if true, skip comment sync (for fast startup)
+	rateLimitThreshold int              // minimum remaining API calls before waiting/skipping; 0 disables
 }
 
 // NewSyncer creates a new GitHub issue syncer.
 func NewSyncer(store *issue.Store, owner string, repos []string, interval time.Duration) *Syncer {
 	return &Syncer{
-		store:    store,
-		owner:    owner,
-		repos:    repos,
-		interval: interval,
+		store:              store,
+		owner:              owner,
+		repos:              repos,
+		interval:           interval,
+		rateLimitThreshold: defaultRateLimitThreshold,
 	}
 }
 
@@ -451,6 +453,10 @@ func (s *Syncer) syncComments(repo string, issueNumber int, localID string) {
 
 // fetchComments fetches all comments for a GitHub issue via gh CLI.
 func (s *Syncer) fetchComments(repo string, issueNumber int) ([]ghComment, error) {
+	if err := s.checkRateLimit(); err != nil {
+		return nil, err
+	}
+
 	endpoint := fmt.Sprintf("repos/%s/%s/issues/%d/comments", s.owner, repo, issueNumber)
 	cmd := exec.Command("gh", "api", endpoint, "--paginate")
 
@@ -471,6 +477,10 @@ func (s *Syncer) fetchComments(repo string, issueNumber int) ([]ghComment, error
 }
 
 func (s *Syncer) fetchIssues(repo string) ([]ghIssue, error) {
+	if err := s.checkRateLimit(); err != nil {
+		return nil, err
+	}
+
 	fullRepo := fmt.Sprintf("%s/%s", s.owner, repo)
 	cmd := exec.Command("gh", "issue", "list",
 		"-R", fullRepo,

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -151,10 +151,12 @@ func (s *Syncer) WithSkipComments(skip bool) *Syncer {
 }
 
 // isAuthorized returns true if the given GitHub login is authorized.
-// When authorizedUsers is empty, all users are authorized.
+// When authorizedUsers is empty, no users are authorized (deny-all).
+// This is defense-in-depth: config validation should prevent the empty-list
+// case from reaching production code when GitHub integration is enabled.
 func isAuthorized(login string, authorizedUsers []string) bool {
 	if len(authorizedUsers) == 0 {
-		return true
+		return false
 	}
 	for _, u := range authorizedUsers {
 		if u == login {

--- a/internal/github/github_test.go
+++ b/internal/github/github_test.go
@@ -302,12 +302,15 @@ func TestSyncer_UpdateIdleState_NilDetector(t *testing.T) {
 }
 
 func TestIsAuthorized_EmptyList(t *testing.T) {
-	// Empty authorized users means everyone is authorized.
-	if !isAuthorized("alice", nil) {
-		t.Error("expected alice to be authorized when list is empty")
+	// Empty authorized users means no one is authorized (deny-all for safety).
+	if isAuthorized("alice", nil) {
+		t.Error("expected alice to be unauthorized when list is nil (deny-all)")
 	}
-	if !isAuthorized("", nil) {
-		t.Error("expected empty login to be authorized when list is empty")
+	if isAuthorized("", nil) {
+		t.Error("expected empty login to be unauthorized when list is nil (deny-all)")
+	}
+	if isAuthorized("alice", []string{}) {
+		t.Error("expected alice to be unauthorized when list is empty slice (deny-all)")
 	}
 }
 

--- a/internal/github/ratelimit.go
+++ b/internal/github/ratelimit.go
@@ -1,0 +1,114 @@
+package github
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"os/exec"
+	"time"
+)
+
+const (
+	// defaultRateLimitThreshold is the minimum number of remaining GitHub API
+	// calls required before the Syncer will proceed with an API request.
+	// When remaining <= threshold, the Syncer waits for the rate limit to reset
+	// or skips the current sync cycle if the wait would be too long.
+	defaultRateLimitThreshold = 10
+
+	// rateLimitMaxWait is the maximum duration the Syncer will wait for the
+	// GitHub API rate limit to reset. If the reset time is further away than
+	// this duration, the sync cycle is skipped instead of waiting.
+	rateLimitMaxWait = 10 * time.Minute
+)
+
+// ghRateLimitResponse represents the JSON response from `gh api rate_limit`.
+type ghRateLimitResponse struct {
+	Resources struct {
+		Core ghRateLimitResource `json:"core"`
+	} `json:"resources"`
+}
+
+// ghRateLimitResource holds the rate limit details for a single resource category.
+type ghRateLimitResource struct {
+	Limit     int   `json:"limit"`
+	Remaining int   `json:"remaining"`
+	Reset     int64 `json:"reset"` // Unix timestamp when the rate limit resets
+	Used      int   `json:"used"`
+}
+
+// WithRateLimitThreshold sets the minimum remaining GitHub API calls required
+// before the Syncer will proceed. When the remaining count is at or below this
+// threshold, the Syncer either waits for the rate limit to reset (if the reset
+// is within rateLimitMaxWait) or skips the current sync cycle.
+//
+// Setting threshold to 0 disables the rate limit pre-check entirely.
+func (s *Syncer) WithRateLimitThreshold(n int) *Syncer {
+	s.rateLimitThreshold = n
+	return s
+}
+
+// checkRateLimit fetches the current GitHub API rate limit and waits or returns
+// an error if the remaining count is at or below the configured threshold.
+//
+// If the threshold is 0, the check is disabled and nil is always returned.
+// If the gh CLI call fails, a warning is logged and nil is returned (fail-open).
+func (s *Syncer) checkRateLimit() error {
+	if s.rateLimitThreshold == 0 {
+		return nil
+	}
+
+	out, err := exec.Command("gh", "api", "rate_limit").Output()
+	if err != nil {
+		// Fail open: log a warning but allow the API call to proceed.
+		log.Printf("[github-sync] rate limit check failed (proceeding anyway): %v", err)
+		return nil
+	}
+
+	var resp ghRateLimitResponse
+	if err := json.Unmarshal(out, &resp); err != nil {
+		log.Printf("[github-sync] rate limit parse failed (proceeding anyway): %v", err)
+		return nil
+	}
+
+	return s.checkRateLimitWithData(resp)
+}
+
+// checkRateLimitWithData evaluates the rate limit response and decides whether
+// to wait, skip, or proceed. It is separated from checkRateLimit to allow
+// unit testing without invoking the gh CLI.
+func (s *Syncer) checkRateLimitWithData(resp ghRateLimitResponse) error {
+	if s.rateLimitThreshold == 0 {
+		return nil
+	}
+
+	core := resp.Resources.Core
+	if core.Remaining > s.rateLimitThreshold {
+		return nil
+	}
+
+	resetAt := time.Unix(core.Reset, 0)
+	waitDuration := time.Until(resetAt)
+
+	if waitDuration <= 0 {
+		// Reset has already occurred; proceed immediately.
+		return nil
+	}
+
+	if waitDuration > rateLimitMaxWait {
+		return fmt.Errorf(
+			"github rate limit nearly exhausted (remaining=%d, threshold=%d); "+
+				"reset in %v exceeds max wait %v — skipping sync cycle",
+			core.Remaining, s.rateLimitThreshold, waitDuration.Round(time.Second), rateLimitMaxWait,
+		)
+	}
+
+	// Wait until the rate limit resets, with a small buffer.
+	waitWithBuffer := waitDuration + time.Second
+	log.Printf(
+		"[github-sync] rate limit nearly exhausted (remaining=%d, threshold=%d); "+
+			"waiting %v for reset",
+		core.Remaining, s.rateLimitThreshold, waitWithBuffer.Round(time.Second),
+	)
+	time.Sleep(waitWithBuffer)
+	return nil
+}

--- a/internal/github/ratelimit_test.go
+++ b/internal/github/ratelimit_test.go
@@ -1,0 +1,177 @@
+package github
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+// TestWithRateLimitThreshold verifies that the builder method sets the field correctly.
+func TestWithRateLimitThreshold(t *testing.T) {
+	s := NewSyncer(nil, "owner", []string{"repo"}, time.Minute).
+		WithRateLimitThreshold(20)
+	if s.rateLimitThreshold != 20 {
+		t.Errorf("expected rateLimitThreshold=20, got %d", s.rateLimitThreshold)
+	}
+}
+
+// TestWithRateLimitThreshold_Zero verifies that 0 disables the check.
+func TestWithRateLimitThreshold_Zero(t *testing.T) {
+	s := NewSyncer(nil, "owner", []string{"repo"}, time.Minute).
+		WithRateLimitThreshold(0)
+	if s.rateLimitThreshold != 0 {
+		t.Errorf("expected rateLimitThreshold=0, got %d", s.rateLimitThreshold)
+	}
+}
+
+// TestWithRateLimitThreshold_DefaultValue verifies the default threshold is applied
+// when WithRateLimitThreshold is not called.
+func TestWithRateLimitThreshold_DefaultValue(t *testing.T) {
+	s := NewSyncer(nil, "owner", []string{"repo"}, time.Minute)
+	if s.rateLimitThreshold != defaultRateLimitThreshold {
+		t.Errorf("expected default rateLimitThreshold=%d, got %d", defaultRateLimitThreshold, s.rateLimitThreshold)
+	}
+}
+
+// TestWithRateLimitThreshold_Chaining verifies that the builder method can be chained.
+func TestWithRateLimitThreshold_Chaining(t *testing.T) {
+	s := NewSyncer(nil, "owner", []string{"repo"}, time.Minute).
+		WithRateLimitThreshold(15).
+		WithSkipComments(true)
+	if s.rateLimitThreshold != 15 {
+		t.Errorf("expected rateLimitThreshold=15, got %d", s.rateLimitThreshold)
+	}
+	if !s.skipComments {
+		t.Error("expected skipComments=true after chaining")
+	}
+}
+
+// TestGhRateLimitResponseParsing verifies the JSON parsing of the rate_limit API response.
+func TestGhRateLimitResponseParsing(t *testing.T) {
+	raw := `{
+		"resources": {
+			"core": {
+				"limit": 5000,
+				"remaining": 4998,
+				"reset": 1700000000,
+				"used": 2
+			}
+		}
+	}`
+
+	var resp ghRateLimitResponse
+	if err := json.Unmarshal([]byte(raw), &resp); err != nil {
+		t.Fatalf("unexpected parse error: %v", err)
+	}
+
+	if resp.Resources.Core.Limit != 5000 {
+		t.Errorf("limit: expected 5000, got %d", resp.Resources.Core.Limit)
+	}
+	if resp.Resources.Core.Remaining != 4998 {
+		t.Errorf("remaining: expected 4998, got %d", resp.Resources.Core.Remaining)
+	}
+	if resp.Resources.Core.Reset != 1700000000 {
+		t.Errorf("reset: expected 1700000000, got %d", resp.Resources.Core.Reset)
+	}
+	if resp.Resources.Core.Used != 2 {
+		t.Errorf("used: expected 2, got %d", resp.Resources.Core.Used)
+	}
+}
+
+// TestCheckRateLimit_Disabled verifies that when threshold=0 the check is skipped.
+func TestCheckRateLimit_Disabled(t *testing.T) {
+	s := NewSyncer(nil, "owner", []string{"repo"}, time.Minute).
+		WithRateLimitThreshold(0)
+
+	// Even with a very low (non-existent) rate limit, disabled check should return nil.
+	// We directly test the check-disabled path.
+	if s.rateLimitThreshold != 0 {
+		t.Fatal("precondition: threshold should be 0")
+	}
+
+	// checkRateLimit should short-circuit without calling gh when threshold == 0.
+	// We can verify this by calling it and ensuring no external process error occurs
+	// on a stub that doesn't exist — but since the gh binary may or may not exist,
+	// we test the logic path indirectly by asserting the threshold-zero guard.
+	err := s.checkRateLimitWithData(ghRateLimitResponse{}) // helper with injected data
+	if err != nil {
+		t.Errorf("expected nil error when threshold=0, got: %v", err)
+	}
+}
+
+// TestCheckRateLimit_SufficientRemaining verifies no wait when remaining > threshold.
+func TestCheckRateLimit_SufficientRemaining(t *testing.T) {
+	s := NewSyncer(nil, "owner", []string{"repo"}, time.Minute).
+		WithRateLimitThreshold(10)
+
+	resp := ghRateLimitResponse{}
+	resp.Resources.Core.Limit = 5000
+	resp.Resources.Core.Remaining = 100
+	resp.Resources.Core.Reset = time.Now().Add(time.Hour).Unix()
+
+	err := s.checkRateLimitWithData(resp)
+	if err != nil {
+		t.Errorf("expected nil error when remaining=%d > threshold=%d, got: %v",
+			resp.Resources.Core.Remaining, s.rateLimitThreshold, err)
+	}
+}
+
+// TestCheckRateLimit_ExactlyAtThreshold verifies rate limit is triggered when remaining == threshold.
+func TestCheckRateLimit_ExactlyAtThreshold(t *testing.T) {
+	s := NewSyncer(nil, "owner", []string{"repo"}, time.Minute).
+		WithRateLimitThreshold(10)
+
+	// Reset already passed → should return nil (no wait needed, reset occurred)
+	resp := ghRateLimitResponse{}
+	resp.Resources.Core.Limit = 5000
+	resp.Resources.Core.Remaining = 10                              // exactly at threshold
+	resp.Resources.Core.Reset = time.Now().Add(-time.Second).Unix() // reset in past
+
+	err := s.checkRateLimitWithData(resp)
+	if err != nil {
+		t.Errorf("expected nil error when reset is in the past, got: %v", err)
+	}
+}
+
+// TestCheckRateLimit_BelowThreshold_ResetFarFuture verifies error is returned when
+// remaining <= threshold and reset is too far in the future.
+func TestCheckRateLimit_BelowThreshold_ResetFarFuture(t *testing.T) {
+	s := NewSyncer(nil, "owner", []string{"repo"}, time.Minute).
+		WithRateLimitThreshold(10)
+
+	resp := ghRateLimitResponse{}
+	resp.Resources.Core.Limit = 5000
+	resp.Resources.Core.Remaining = 5                                                 // below threshold
+	resp.Resources.Core.Reset = time.Now().Add(rateLimitMaxWait + time.Minute).Unix() // far future
+
+	err := s.checkRateLimitWithData(resp)
+	if err == nil {
+		t.Error("expected error when remaining < threshold and reset is too far in the future")
+	}
+}
+
+// TestCheckRateLimit_ZeroRemaining_ResetFarFuture verifies error when remaining=0.
+func TestCheckRateLimit_ZeroRemaining_ResetFarFuture(t *testing.T) {
+	s := NewSyncer(nil, "owner", []string{"repo"}, time.Minute).
+		WithRateLimitThreshold(10)
+
+	resp := ghRateLimitResponse{}
+	resp.Resources.Core.Limit = 5000
+	resp.Resources.Core.Remaining = 0
+	resp.Resources.Core.Reset = time.Now().Add(rateLimitMaxWait + time.Minute).Unix()
+
+	err := s.checkRateLimitWithData(resp)
+	if err == nil {
+		t.Error("expected error when remaining=0 and reset is too far in the future")
+	}
+}
+
+// TestRateLimitConstants verifies the expected constant values.
+func TestRateLimitConstants(t *testing.T) {
+	if defaultRateLimitThreshold <= 0 {
+		t.Errorf("defaultRateLimitThreshold should be positive, got %d", defaultRateLimitThreshold)
+	}
+	if rateLimitMaxWait <= 0 {
+		t.Error("rateLimitMaxWait should be positive")
+	}
+}

--- a/internal/issue/issue.go
+++ b/internal/issue/issue.go
@@ -97,7 +97,7 @@ func (s *Store) Dir() string {
 
 // Create creates a new local issue with auto-incremented ID.
 func (s *Store) Create(title, body string) (*Issue, error) {
-	if err := os.MkdirAll(s.dir, 0755); err != nil {
+	if err := os.MkdirAll(s.dir, 0700); err != nil {
 		return nil, fmt.Errorf("create issues dir: %w", err)
 	}
 

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -103,13 +103,13 @@ func (o *Orchestrator) Config() *config.Config {
 func (o *Orchestrator) Run(ctx context.Context) error {
 	// Ensure data directories exist
 	for _, sub := range []string{"issues", "memos"} {
-		os.MkdirAll(filepath.Join(o.dataDir, sub), 0755)
+		os.MkdirAll(filepath.Join(o.dataDir, sub), 0700)
 	}
 
 	// Truncate chatlog to start with a clean slate. Stale messages from
 	// previous runs confuse the superintendent (e.g. referencing engineers
 	// like engineer-4 that no longer exist, causing phantom TEAM_CREATE).
-	os.WriteFile(o.chatLog.Path(), nil, 0644)
+	os.WriteFile(o.chatLog.Path(), nil, 0600)
 
 	log.Println("[orchestrator] starting")
 

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -51,7 +51,7 @@ func Init(name string, paths []string) error {
 		return err
 	}
 
-	if err := os.MkdirAll(base, 0755); err != nil {
+	if err := os.MkdirAll(base, 0700); err != nil {
 		return fmt.Errorf("create base dir: %w", err)
 	}
 
@@ -81,7 +81,7 @@ func Init(name string, paths []string) error {
 
 	dataDir := filepath.Join(base, name)
 	for _, sub := range []string{"issues", "memos"} {
-		if err := os.MkdirAll(filepath.Join(dataDir, sub), 0755); err != nil {
+		if err := os.MkdirAll(filepath.Join(dataDir, sub), 0700); err != nil {
 			return fmt.Errorf("create data dir: %w", err)
 		}
 	}

--- a/internal/project/project_test.go
+++ b/internal/project/project_test.go
@@ -93,3 +93,32 @@ func TestDetectNotFound(t *testing.T) {
 		t.Fatal("expected error for unregistered directory")
 	}
 }
+
+// TestInitCreatesDirectoriesWithRestrictedPermissions verifies that Init creates
+// data directories with 0700 permissions.
+func TestInitCreatesDirectoriesWithRestrictedPermissions(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+
+	projectDir := filepath.Join(tmpHome, "perm-test-app")
+	if err := os.MkdirAll(projectDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := Init("perm-test-app", []string{projectDir}); err != nil {
+		t.Fatal(err)
+	}
+
+	dataDir := filepath.Join(tmpHome, madflowDir, "perm-test-app")
+	for _, sub := range []string{"issues", "memos"} {
+		info, err := os.Stat(filepath.Join(dataDir, sub))
+		if err != nil {
+			t.Fatalf("expected %s dir to exist: %v", sub, err)
+		}
+		got := info.Mode().Perm()
+		want := os.FileMode(0700)
+		if got != want {
+			t.Errorf("data dir %s permission: got %04o, want %04o", sub, got, want)
+		}
+	}
+}

--- a/internal/reset/reset.go
+++ b/internal/reset/reset.go
@@ -24,7 +24,7 @@ func SaveMemo(memosDir string, memo WorkMemo) (string, error) {
 
 // SaveMemoWithLang writes a work memo to the memos directory with localized headers.
 func SaveMemoWithLang(memosDir string, memo WorkMemo, lang string) (string, error) {
-	if err := os.MkdirAll(memosDir, 0755); err != nil {
+	if err := os.MkdirAll(memosDir, 0700); err != nil {
 		return "", fmt.Errorf("create memos dir: %w", err)
 	}
 
@@ -84,7 +84,7 @@ Date: %s
 		)
 	}
 
-	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
 		return "", fmt.Errorf("write memo: %w", err)
 	}
 	return path, nil

--- a/internal/reset/reset_test.go
+++ b/internal/reset/reset_test.go
@@ -94,6 +94,46 @@ func TestLoadLatestMemoDirNotExist(t *testing.T) {
 	}
 }
 
+// TestSaveMemoCreatesFileWithRestrictedPermissions verifies that SaveMemo
+// creates memo files with 0600 permissions and the memos directory with 0700.
+func TestSaveMemoCreatesFileWithRestrictedPermissions(t *testing.T) {
+	dir := t.TempDir()
+	memosDir := filepath.Join(dir, "memos")
+
+	memo := WorkMemo{
+		AgentID:      "engineer-1",
+		Timestamp:    time.Date(2026, 2, 21, 10, 8, 0, 0, time.UTC),
+		CurrentState: "test",
+	}
+
+	path, err := SaveMemo(memosDir, memo)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Check memo file permissions (0600)
+	fileInfo, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat memo file: %v", err)
+	}
+	gotFile := fileInfo.Mode().Perm()
+	wantFile := os.FileMode(0600)
+	if gotFile != wantFile {
+		t.Errorf("memo file permission: got %04o, want %04o", gotFile, wantFile)
+	}
+
+	// Check memos directory permissions (0700)
+	dirInfo, err := os.Stat(memosDir)
+	if err != nil {
+		t.Fatalf("stat memos dir: %v", err)
+	}
+	gotDir := dirInfo.Mode().Perm()
+	wantDir := os.FileMode(0700)
+	if gotDir != wantDir {
+		t.Errorf("memos dir permission: got %04o, want %04o", gotDir, wantDir)
+	}
+}
+
 func TestTimer(t *testing.T) {
 	timer := NewTimer(100 * time.Millisecond)
 

--- a/internal/team/team.go
+++ b/internal/team/team.go
@@ -45,7 +45,7 @@ func announceStart(team *Team) {
 
 // appendLine はチャットログファイルに1行追記する。
 func appendLine(path, line string) {
-	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0600)
 	if err != nil {
 		log.Printf("[team] announce: open %s: %v", path, err)
 		return


### PR DESCRIPTION
Issue: ytnobody-MADFLOW-216

## Summary

- developブランチをmainにマージしてv0.6.0をリリースする
- 前回リリース(v0.5.0)以降の11コミットを含む

## 主な変更内容

- **セキュリティ強化**: SHA256チェックサム検証、パストラバーサル対策、ファイルパーミッション制限、ログの機密情報サニタイズ
- **新機能**: `authorized_users`の必須化、`madflow init`でのauthorized_users指定、GitHubレート制限チェック
- **API改善**: Gemini APIキーのヘッダー移行、Claude APIプリセット追加
- **ドキュメント**: authorized_usersのREADME説明、各機能のスペックドキュメント追加

## Merging from develop

All CI checks pass on the develop branch. Tests pass locally.