### PR TITLE
ytnobody-MADFLOW-218: madflow init時に作られるtomlファイルにauthorized_usersを最初から含める

### DIFF
--- a/cmd/madflow/main.go
+++ b/cmd/madflow/main.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"os/signal"
 	"path/filepath"
 	"strings"
@@ -104,16 +105,62 @@ func parseAuthorizedUsers(raw string) []string {
 }
 
 // buildAuthorizedUsersLine formats the authorized_users TOML line.
-// Returns an empty string when users is nil or empty.
+// Always returns a non-empty string: "authorized_users = []\n\n" when users is nil or empty.
 func buildAuthorizedUsersLine(users []string) string {
 	if len(users) == 0 {
-		return ""
+		return "authorized_users = []\n\n"
 	}
 	var quoted []string
 	for _, u := range users {
 		quoted = append(quoted, fmt.Sprintf("%q", u))
 	}
 	return fmt.Sprintf("authorized_users = [%s]\n\n", strings.Join(quoted, ", "))
+}
+
+// detectGitHubOwner attempts to determine the GitHub repository owner for the
+// given repo path. It first tries to parse the git remote URL, then falls back
+// to the authenticated GitHub CLI user. Returns an empty string on failure.
+func detectGitHubOwner(repoPath string) string {
+	// 1. Try to extract owner from git remote URL.
+	cmd := exec.Command("git", "-C", repoPath, "remote", "get-url", "origin")
+	if out, err := cmd.Output(); err == nil {
+		if owner := extractOwnerFromGitHubURL(strings.TrimSpace(string(out))); owner != "" {
+			return owner
+		}
+	}
+
+	// 2. Fallback: use the authenticated GitHub CLI user.
+	cmd = exec.Command("gh", "api", "user", "--jq", ".login")
+	if out, err := cmd.Output(); err == nil {
+		if login := strings.TrimSpace(string(out)); login != "" {
+			return login
+		}
+	}
+
+	return ""
+}
+
+// extractOwnerFromGitHubURL parses a GitHub remote URL and returns the owner login.
+// Supports HTTPS (https://github.com/owner/repo) and SSH (git@github.com:owner/repo) formats.
+// Returns an empty string for non-GitHub URLs or URLs that cannot be parsed.
+func extractOwnerFromGitHubURL(url string) string {
+	// SSH format: git@github.com:owner/repo[.git]
+	if path, ok := strings.CutPrefix(url, "git@github.com:"); ok {
+		parts := strings.SplitN(path, "/", 2)
+		if len(parts) >= 1 && parts[0] != "" {
+			return parts[0]
+		}
+	}
+	// HTTPS format: https://github.com/owner/repo[.git]
+	for _, prefix := range []string{"https://github.com/", "http://github.com/"} {
+		if path, ok := strings.CutPrefix(url, prefix); ok {
+			parts := strings.SplitN(path, "/", 2)
+			if len(parts) >= 1 && parts[0] != "" {
+				return parts[0]
+			}
+		}
+	}
+	return ""
 }
 
 func cmdInit() error {
@@ -159,16 +206,27 @@ func cmdInit() error {
 		repoPaths = []string{cwd}
 	}
 
-	// If --authorized-users was not given and stdin is a terminal, prompt interactively.
-	if authorizedUsersRaw == "" && isTerminal(os.Stdin) {
-		fmt.Print("Enter authorized GitHub usernames (comma-separated, press Enter to skip): ")
-		scanner := bufio.NewScanner(os.Stdin)
-		if scanner.Scan() {
-			authorizedUsersRaw = scanner.Text()
+	// Determine the list of authorized GitHub users.
+	var authorizedUsers []string
+	if authorizedUsersRaw != "" {
+		// Explicit --authorized-users flag takes priority.
+		authorizedUsers = parseAuthorizedUsers(authorizedUsersRaw)
+	} else {
+		// Try to auto-detect the GitHub repository owner.
+		owner := detectGitHubOwner(repoPaths[0])
+		if owner != "" {
+			authorizedUsers = []string{owner}
+		} else if isTerminal(os.Stdin) {
+			// No owner detected; prompt interactively when stdin is a terminal.
+			fmt.Print("Enter authorized GitHub usernames (comma-separated, press Enter to skip): ")
+			scanner := bufio.NewScanner(os.Stdin)
+			if scanner.Scan() {
+				authorizedUsers = parseAuthorizedUsers(scanner.Text())
+			}
 		}
+		// If nothing was detected and not interactive, authorizedUsers stays nil
+		// and buildAuthorizedUsersLine will emit authorized_users = [].
 	}
-
-	authorizedUsers := parseAuthorizedUsers(authorizedUsersRaw)
 
 	if err := project.Init(name, repoPaths); err != nil {
 		return err

--- a/cmd/madflow/main_test.go
+++ b/cmd/madflow/main_test.go
@@ -227,7 +227,8 @@ func TestCmdInit_AuthorizedUsersFlag_SingleUser(t *testing.T) {
 
 func TestCmdInit_NoAuthorizedUsers_NonInteractive(t *testing.T) {
 	// When no --authorized-users flag is given and stdin is not a terminal,
-	// authorized_users should not appear in the generated config.
+	// authorized_users should always appear in the generated config (as empty array
+	// when no GitHub owner can be auto-detected in test environments).
 	tmpDir := t.TempDir()
 
 	origDir, err := os.Getwd()
@@ -256,10 +257,9 @@ func TestCmdInit_NoAuthorizedUsers_NonInteractive(t *testing.T) {
 
 	content := string(data)
 
-	// In non-interactive mode (tests run without a terminal), authorized_users
-	// should be omitted from the generated config.
-	if strings.Contains(content, "authorized_users") {
-		t.Errorf("generated madflow.toml unexpectedly contains authorized_users in non-interactive mode:\n%s", content)
+	// authorized_users must always be present in the generated config.
+	if !strings.Contains(content, "authorized_users") {
+		t.Errorf("generated madflow.toml is missing authorized_users:\n%s", content)
 	}
 }
 
@@ -297,3 +297,99 @@ func TestCmdInit_AuthorizedUsersFlag_WithSpaces(t *testing.T) {
 		t.Errorf("generated madflow.toml does not contain trimmed authorized_users; got:\n%s", content)
 	}
 }
+
+func TestCmdInit_AlwaysIncludesAuthorizedUsers(t *testing.T) {
+	// authorized_users must always appear in the generated madflow.toml,
+	// even when no flag is provided and stdin is not a terminal.
+	tmpDir := t.TempDir()
+
+	origDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get cwd: %v", err)
+	}
+	defer os.Chdir(origDir) //nolint:errcheck
+
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatalf("failed to chdir: %v", err)
+	}
+
+	origArgs := os.Args
+	os.Args = []string{"madflow", "init", "--name", "testproject", "--repo", tmpDir}
+	defer func() { os.Args = origArgs }()
+
+	if err := cmdInit(); err != nil {
+		t.Fatalf("cmdInit() error: %v", err)
+	}
+
+	configPath := filepath.Join(tmpDir, "madflow.toml")
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("failed to read generated madflow.toml: %v", err)
+	}
+
+	content := string(data)
+
+	if !strings.Contains(content, "authorized_users") {
+		t.Errorf("generated madflow.toml is missing authorized_users field:\n%s", content)
+	}
+}
+
+func TestExtractOwnerFromGitHubURL(t *testing.T) {
+	tests := []struct {
+		name     string
+		url      string
+		expected string
+	}{
+		{
+			name:     "HTTPS URL",
+			url:      "https://github.com/alice/myrepo.git",
+			expected: "alice",
+		},
+		{
+			name:     "HTTPS URL without .git",
+			url:      "https://github.com/bob/project",
+			expected: "bob",
+		},
+		{
+			name:     "SSH URL",
+			url:      "git@github.com:charlie/repo.git",
+			expected: "charlie",
+		},
+		{
+			name:     "non-GitHub URL",
+			url:      "https://gitlab.com/user/repo.git",
+			expected: "",
+		},
+		{
+			name:     "empty URL",
+			url:      "",
+			expected: "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := extractOwnerFromGitHubURL(tc.url)
+			if got != tc.expected {
+				t.Errorf("extractOwnerFromGitHubURL(%q) = %q, want %q", tc.url, got, tc.expected)
+			}
+		})
+	}
+}
+
+func TestBuildAuthorizedUsersLine_AlwaysEmitsField(t *testing.T) {
+	// buildAuthorizedUsersLine must always return a non-empty string,
+	// even for an empty slice (it should emit authorized_users = []).
+	got := buildAuthorizedUsersLine(nil)
+	if got == "" {
+		t.Errorf("buildAuthorizedUsersLine(nil) returned empty string; expected authorized_users = [] line")
+	}
+	if !strings.Contains(got, "authorized_users") {
+		t.Errorf("buildAuthorizedUsersLine(nil) = %q; expected to contain 'authorized_users'", got)
+	}
+
+	got = buildAuthorizedUsersLine([]string{})
+	if got == "" {
+		t.Errorf("buildAuthorizedUsersLine([]) returned empty string; expected authorized_users = [] line")
+	}
+}}

--- a/cmd/madflow/main_test.go
+++ b/cmd/madflow/main_test.go
@@ -392,4 +392,4 @@ func TestBuildAuthorizedUsersLine_AlwaysEmitsField(t *testing.T) {
 	if got == "" {
 		t.Errorf("buildAuthorizedUsersLine([]) returned empty string; expected authorized_users = [] line")
 	}
-}}
+}

--- a/docs/specs/init-authorized-users.md
+++ b/docs/specs/init-authorized-users.md
@@ -2,50 +2,83 @@
 
 ## Overview
 
-`madflow init` must prompt users to specify `authorized_users` during project initialization. This ensures that projects using GitHub integration have the required security configuration set from the start.
+`madflow init` always includes `authorized_users` in the generated `madflow.toml`. The initial value is
+auto-detected from the GitHub repository owner. If detection fails, an empty array is used.
 
 ## Behavior
 
+### Auto-Detection of GitHub Owner
+
+When `--authorized-users` is not explicitly provided, `madflow init` attempts to determine the
+GitHub repository owner automatically using the following steps (in order):
+
+1. **Parse git remote URL**: Run `git -C <repoPath> remote get-url origin` and extract the owner
+   from a GitHub HTTPS (`https://github.com/owner/repo`) or SSH (`git@github.com:owner/repo`) URL.
+2. **Authenticated GitHub user**: Run `gh api user --jq '.login'` to get the currently
+   authenticated GitHub CLI user as a fallback.
+3. **Empty array**: If neither method succeeds, `authorized_users = []` is written to the config.
+
 ### CLI Flag
 
-`madflow init` accepts a new flag:
+`madflow init` accepts an explicit flag that overrides auto-detection:
 
-- `--authorized-users <users>` — Comma-separated list of GitHub usernames to authorize (e.g., `--authorized-users alice,bob`).
+- `--authorized-users <users>` — Comma-separated list of GitHub usernames (e.g., `--authorized-users alice,bob`).
+
+When `--authorized-users` is provided, auto-detection is skipped entirely.
 
 ### Interactive Prompt
 
-If `--authorized-users` is not provided and stdin is a terminal (interactive session), `madflow init` prompts the user:
+If `--authorized-users` is not provided **and** auto-detection fails **and** stdin is a terminal
+(interactive session), `madflow init` prompts the user:
 
 ```
 Enter authorized GitHub usernames (comma-separated, press Enter to skip):
 ```
 
-- The user enters a comma-separated list of GitHub usernames (e.g., `alice, bob`).
 - Each username is trimmed of whitespace.
 - Empty strings after trimming are ignored.
-- If the user presses Enter without input, the `authorized_users` field is omitted from the generated config.
-
-### Non-Interactive Mode
-
-If `--authorized-users` is not provided and stdin is NOT a terminal (piped/scripted input), no prompt is shown and `authorized_users` is omitted from the generated config.
+- If the user presses Enter without input, `authorized_users = []` is written.
 
 ### Generated Config
 
-When `authorized_users` are specified (either via flag or interactive prompt):
+`authorized_users` is **always** written to the generated `madflow.toml`, regardless of whether
+users were detected, provided, or defaulted to an empty list.
+
+**With detected/provided users:**
 
 ```toml
-authorized_users = ["alice", "bob"]
+authorized_users = ["ytnobody"]
 
 [project]
 name = "myproject"
 ...
 ```
 
-When no users are specified, the `authorized_users` field is omitted from the generated config.
+**With no users detected (empty array):**
+
+```toml
+authorized_users = []
+
+[project]
+name = "myproject"
+...
+```
 
 ## Examples
 
-### Via CLI Flag
+### Auto-Detection from Git Remote
+
+```bash
+cd /path/to/repo  # repo with git remote pointing to github.com/alice/myrepo
+madflow init
+```
+
+Generated `madflow.toml` includes:
+```toml
+authorized_users = ["alice"]
+```
+
+### Via CLI Flag (overrides auto-detection)
 
 ```bash
 madflow init --authorized-users alice,bob
@@ -56,30 +89,27 @@ Generated `madflow.toml` includes:
 authorized_users = ["alice", "bob"]
 ```
 
-### Via Interactive Prompt
+### No Owner Detected (non-interactive, no remote)
 
-```
-$ madflow init
-Enter authorized GitHub usernames (comma-separated, press Enter to skip): alice, bob
-Project 'myproject' initialized.
+```bash
+madflow init  # no git remote, gh CLI not authenticated
 ```
 
-### Skip (empty input or non-interactive)
-
+Generated `madflow.toml` includes:
+```toml
+authorized_users = []
 ```
-$ madflow init
-Enter authorized GitHub usernames (comma-separated, press Enter to skip): [Enter]
-Project 'myproject' initialized.
-```
-
-Config does not include `authorized_users`.
 
 ## Notes
 
-- `authorized_users` is only **required** at runtime when the `[github]` section is present (see `authorized-users-required.md`). If not using GitHub integration, users may safely skip this.
-- If `madflow.toml` already exists, `cmdInit` does not overwrite it, so the `authorized_users` prompt behavior only applies when creating a new config file.
+- `authorized_users` is **required** at runtime when the `[github]` section is present
+  (see `authorized-users-required.md`). Always generating the field makes the config
+  ready for GitHub integration without manual editing.
+- If `madflow.toml` already exists, `cmdInit` does not overwrite it, so this behavior
+  only applies when creating a new config file.
 
 ## Affected Files
 
-- `cmd/madflow/main.go` — parse `--authorized-users` flag, add interactive prompt, update config template
-- `cmd/madflow/main_test.go` — add tests for new flag and generated config
+- `cmd/madflow/main.go` — add `detectGitHubOwner`, `extractOwnerFromGitHubURL`, update
+  `buildAuthorizedUsersLine` to always emit the field, update `cmdInit` logic
+- `cmd/madflow/main_test.go` — update and add tests


### PR DESCRIPTION
Issue: ytnobody-MADFLOW-218

## Changes

- `buildAuthorizedUsersLine` now always emits the `authorized_users` field (empty array when no users)
- Added `detectGitHubOwner(repoPath)`: auto-detects owner from git remote URL, falls back to `gh api user`
- Added `extractOwnerFromGitHubURL(url)`: parses HTTPS and SSH GitHub remote URLs
- `cmdInit` now uses auto-detection when `--authorized-users` flag is not provided
- Interactive prompt is only shown when auto-detection fails and stdin is a terminal

## Behavior

1. `--authorized-users alice,bob` → `authorized_users = ["alice", "bob"]` (explicit flag, unchanged)
2. git remote points to `github.com/alice/repo` → `authorized_users = ["alice"]` (auto-detected from remote)
3. No remote, gh CLI authenticated → `authorized_users = ["authenticated-user"]` (fallback)
4. No remote, not authenticated, non-interactive → `authorized_users = []` (always present)