### PR TITLE
v0.7.0: Merge develop into main (release v0.7.0)

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,130 @@
+name: Nightly Build
+
+on:
+  schedule:
+    # JST 0:00 = UTC 15:00
+    - cron: "0 15 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  nightly:
+    name: Nightly Build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout develop branch
+        uses: actions/checkout@v4
+        with:
+          ref: develop
+          fetch-depth: 0
+
+      - name: Check if nightly build is needed
+        id: check
+        run: |
+          DEVELOP_SHA=$(git rev-parse HEAD)
+          echo "develop_sha=${DEVELOP_SHA}" >> "$GITHUB_OUTPUT"
+
+          # Check if nightly tag exists
+          if git ls-remote --tags origin refs/tags/nightly | grep -q refs/tags/nightly; then
+            NIGHTLY_SHA=$(git ls-remote --tags origin refs/tags/nightly | awk '{print $1}')
+            # Resolve the tag to a commit SHA (handles annotated tags)
+            NIGHTLY_COMMIT=$(git rev-list -n 1 "${NIGHTLY_SHA}" 2>/dev/null || echo "${NIGHTLY_SHA}")
+            echo "nightly_sha=${NIGHTLY_COMMIT}" >> "$GITHUB_OUTPUT"
+
+            if [ "${DEVELOP_SHA}" = "${NIGHTLY_COMMIT}" ]; then
+              echo "No new commits since last nightly build. Skipping."
+              echo "skip=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "New commits detected. Proceeding with nightly build."
+              echo "skip=false" >> "$GITHUB_OUTPUT"
+            fi
+          else
+            echo "nightly tag does not exist. Proceeding with first nightly build."
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Set up Go
+        if: steps.check.outputs.skip != 'true'
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Build binaries
+        if: steps.check.outputs.skip != 'true'
+        run: |
+          DATE=$(date -u +%Y%m%d)
+          SHORT_SHA=$(git rev-parse --short HEAD)
+          VERSION="nightly-${DATE}-${SHORT_SHA}"
+          LDFLAGS="-X main.version=${VERSION}"
+
+          mkdir -p dist
+
+          GOOS=linux   GOARCH=amd64 go build -ldflags "${LDFLAGS}" -o dist/madflow-linux-amd64   ./cmd/madflow
+          GOOS=linux   GOARCH=arm64 go build -ldflags "${LDFLAGS}" -o dist/madflow-linux-arm64   ./cmd/madflow
+          GOOS=darwin  GOARCH=amd64 go build -ldflags "${LDFLAGS}" -o dist/madflow-darwin-amd64  ./cmd/madflow
+          GOOS=darwin  GOARCH=arm64 go build -ldflags "${LDFLAGS}" -o dist/madflow-darwin-arm64  ./cmd/madflow
+          GOOS=windows GOARCH=amd64 go build -ldflags "${LDFLAGS}" -o dist/madflow-windows-amd64.exe ./cmd/madflow
+
+          echo "VERSION=${VERSION}" >> "$GITHUB_ENV"
+
+      - name: Generate SHA256 checksums
+        if: steps.check.outputs.skip != 'true'
+        run: |
+          cd dist
+          for f in madflow-linux-amd64 madflow-linux-arm64 madflow-darwin-amd64 madflow-darwin-arm64 madflow-windows-amd64.exe; do
+            sha256sum "$f" | awk '{print $1}' > "${f}.sha256"
+          done
+
+      - name: Update nightly tag
+        if: steps.check.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          # Force-push the nightly tag to the current HEAD of develop
+          git tag -f nightly HEAD
+          git push origin nightly --force
+
+      - name: Create or update nightly GitHub Release
+        if: steps.check.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          DATE=$(date -u +%Y%m%d)
+          SHORT_SHA=$(git rev-parse --short HEAD)
+
+          RELEASE_NOTES="## Nightly Build
+
+          **Date**: ${DATE}
+          **Commit**: ${SHORT_SHA}
+          **Branch**: develop
+
+          This is an automated nightly build from the \`develop\` branch.
+          It may be unstable. For stable releases, see the [releases page](https://github.com/${{ github.repository }}/releases)."
+
+          # Delete existing nightly release if it exists, then recreate
+          if gh release view nightly -R ${{ github.repository }} > /dev/null 2>&1; then
+            gh release delete nightly -R ${{ github.repository }} --yes
+          fi
+
+          gh release create nightly -R ${{ github.repository }} \
+            --title "Nightly Build (${DATE}-${SHORT_SHA})" \
+            --notes "${RELEASE_NOTES}" \
+            --prerelease \
+            --target develop \
+            dist/madflow-linux-amd64 \
+            dist/madflow-linux-arm64 \
+            dist/madflow-darwin-amd64 \
+            dist/madflow-darwin-arm64 \
+            dist/madflow-windows-amd64.exe \
+            dist/madflow-linux-amd64.sha256 \
+            dist/madflow-linux-arm64.sha256 \
+            dist/madflow-darwin-amd64.sha256 \
+            dist/madflow-darwin-arm64.sha256 \
+            dist/madflow-windows-amd64.exe.sha256

--- a/cmd/madflow/main.go
+++ b/cmd/madflow/main.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"os/signal"
 	"path/filepath"
 	"strings"
@@ -104,16 +105,62 @@ func parseAuthorizedUsers(raw string) []string {
 }
 
 // buildAuthorizedUsersLine formats the authorized_users TOML line.
-// Returns an empty string when users is nil or empty.
+// Always returns a non-empty string: "authorized_users = []\n\n" when users is nil or empty.
 func buildAuthorizedUsersLine(users []string) string {
 	if len(users) == 0 {
-		return ""
+		return "authorized_users = []\n\n"
 	}
 	var quoted []string
 	for _, u := range users {
 		quoted = append(quoted, fmt.Sprintf("%q", u))
 	}
 	return fmt.Sprintf("authorized_users = [%s]\n\n", strings.Join(quoted, ", "))
+}
+
+// detectGitHubOwner attempts to determine the GitHub repository owner for the
+// given repo path. It first tries to parse the git remote URL, then falls back
+// to the authenticated GitHub CLI user. Returns an empty string on failure.
+func detectGitHubOwner(repoPath string) string {
+	// 1. Try to extract owner from git remote URL.
+	cmd := exec.Command("git", "-C", repoPath, "remote", "get-url", "origin")
+	if out, err := cmd.Output(); err == nil {
+		if owner := extractOwnerFromGitHubURL(strings.TrimSpace(string(out))); owner != "" {
+			return owner
+		}
+	}
+
+	// 2. Fallback: use the authenticated GitHub CLI user.
+	cmd = exec.Command("gh", "api", "user", "--jq", ".login")
+	if out, err := cmd.Output(); err == nil {
+		if login := strings.TrimSpace(string(out)); login != "" {
+			return login
+		}
+	}
+
+	return ""
+}
+
+// extractOwnerFromGitHubURL parses a GitHub remote URL and returns the owner login.
+// Supports HTTPS (https://github.com/owner/repo) and SSH (git@github.com:owner/repo) formats.
+// Returns an empty string for non-GitHub URLs or URLs that cannot be parsed.
+func extractOwnerFromGitHubURL(url string) string {
+	// SSH format: git@github.com:owner/repo[.git]
+	if path, ok := strings.CutPrefix(url, "git@github.com:"); ok {
+		parts := strings.SplitN(path, "/", 2)
+		if len(parts) >= 1 && parts[0] != "" {
+			return parts[0]
+		}
+	}
+	// HTTPS format: https://github.com/owner/repo[.git]
+	for _, prefix := range []string{"https://github.com/", "http://github.com/"} {
+		if path, ok := strings.CutPrefix(url, prefix); ok {
+			parts := strings.SplitN(path, "/", 2)
+			if len(parts) >= 1 && parts[0] != "" {
+				return parts[0]
+			}
+		}
+	}
+	return ""
 }
 
 func cmdInit() error {
@@ -159,16 +206,27 @@ func cmdInit() error {
 		repoPaths = []string{cwd}
 	}
 
-	// If --authorized-users was not given and stdin is a terminal, prompt interactively.
-	if authorizedUsersRaw == "" && isTerminal(os.Stdin) {
-		fmt.Print("Enter authorized GitHub usernames (comma-separated, press Enter to skip): ")
-		scanner := bufio.NewScanner(os.Stdin)
-		if scanner.Scan() {
-			authorizedUsersRaw = scanner.Text()
+	// Determine the list of authorized GitHub users.
+	var authorizedUsers []string
+	if authorizedUsersRaw != "" {
+		// Explicit --authorized-users flag takes priority.
+		authorizedUsers = parseAuthorizedUsers(authorizedUsersRaw)
+	} else {
+		// Try to auto-detect the GitHub repository owner.
+		owner := detectGitHubOwner(repoPaths[0])
+		if owner != "" {
+			authorizedUsers = []string{owner}
+		} else if isTerminal(os.Stdin) {
+			// No owner detected; prompt interactively when stdin is a terminal.
+			fmt.Print("Enter authorized GitHub usernames (comma-separated, press Enter to skip): ")
+			scanner := bufio.NewScanner(os.Stdin)
+			if scanner.Scan() {
+				authorizedUsers = parseAuthorizedUsers(scanner.Text())
+			}
 		}
+		// If nothing was detected and not interactive, authorizedUsers stays nil
+		// and buildAuthorizedUsersLine will emit authorized_users = [].
 	}
-
-	authorizedUsers := parseAuthorizedUsers(authorizedUsersRaw)
 
 	if err := project.Init(name, repoPaths); err != nil {
 		return err

--- a/cmd/madflow/main_test.go
+++ b/cmd/madflow/main_test.go
@@ -227,7 +227,8 @@ func TestCmdInit_AuthorizedUsersFlag_SingleUser(t *testing.T) {
 
 func TestCmdInit_NoAuthorizedUsers_NonInteractive(t *testing.T) {
 	// When no --authorized-users flag is given and stdin is not a terminal,
-	// authorized_users should not appear in the generated config.
+	// authorized_users should always appear in the generated config (as empty array
+	// when no GitHub owner can be auto-detected in test environments).
 	tmpDir := t.TempDir()
 
 	origDir, err := os.Getwd()
@@ -256,10 +257,9 @@ func TestCmdInit_NoAuthorizedUsers_NonInteractive(t *testing.T) {
 
 	content := string(data)
 
-	// In non-interactive mode (tests run without a terminal), authorized_users
-	// should be omitted from the generated config.
-	if strings.Contains(content, "authorized_users") {
-		t.Errorf("generated madflow.toml unexpectedly contains authorized_users in non-interactive mode:\n%s", content)
+	// authorized_users must always be present in the generated config.
+	if !strings.Contains(content, "authorized_users") {
+		t.Errorf("generated madflow.toml is missing authorized_users:\n%s", content)
 	}
 }
 
@@ -295,5 +295,101 @@ func TestCmdInit_AuthorizedUsersFlag_WithSpaces(t *testing.T) {
 
 	if !strings.Contains(content, `authorized_users = ["alice", "bob"]`) {
 		t.Errorf("generated madflow.toml does not contain trimmed authorized_users; got:\n%s", content)
+	}
+}
+
+func TestCmdInit_AlwaysIncludesAuthorizedUsers(t *testing.T) {
+	// authorized_users must always appear in the generated madflow.toml,
+	// even when no flag is provided and stdin is not a terminal.
+	tmpDir := t.TempDir()
+
+	origDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get cwd: %v", err)
+	}
+	defer os.Chdir(origDir) //nolint:errcheck
+
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatalf("failed to chdir: %v", err)
+	}
+
+	origArgs := os.Args
+	os.Args = []string{"madflow", "init", "--name", "testproject", "--repo", tmpDir}
+	defer func() { os.Args = origArgs }()
+
+	if err := cmdInit(); err != nil {
+		t.Fatalf("cmdInit() error: %v", err)
+	}
+
+	configPath := filepath.Join(tmpDir, "madflow.toml")
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("failed to read generated madflow.toml: %v", err)
+	}
+
+	content := string(data)
+
+	if !strings.Contains(content, "authorized_users") {
+		t.Errorf("generated madflow.toml is missing authorized_users field:\n%s", content)
+	}
+}
+
+func TestExtractOwnerFromGitHubURL(t *testing.T) {
+	tests := []struct {
+		name     string
+		url      string
+		expected string
+	}{
+		{
+			name:     "HTTPS URL",
+			url:      "https://github.com/alice/myrepo.git",
+			expected: "alice",
+		},
+		{
+			name:     "HTTPS URL without .git",
+			url:      "https://github.com/bob/project",
+			expected: "bob",
+		},
+		{
+			name:     "SSH URL",
+			url:      "git@github.com:charlie/repo.git",
+			expected: "charlie",
+		},
+		{
+			name:     "non-GitHub URL",
+			url:      "https://gitlab.com/user/repo.git",
+			expected: "",
+		},
+		{
+			name:     "empty URL",
+			url:      "",
+			expected: "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := extractOwnerFromGitHubURL(tc.url)
+			if got != tc.expected {
+				t.Errorf("extractOwnerFromGitHubURL(%q) = %q, want %q", tc.url, got, tc.expected)
+			}
+		})
+	}
+}
+
+func TestBuildAuthorizedUsersLine_AlwaysEmitsField(t *testing.T) {
+	// buildAuthorizedUsersLine must always return a non-empty string,
+	// even for an empty slice (it should emit authorized_users = []).
+	got := buildAuthorizedUsersLine(nil)
+	if got == "" {
+		t.Errorf("buildAuthorizedUsersLine(nil) returned empty string; expected authorized_users = [] line")
+	}
+	if !strings.Contains(got, "authorized_users") {
+		t.Errorf("buildAuthorizedUsersLine(nil) = %q; expected to contain 'authorized_users'", got)
+	}
+
+	got = buildAuthorizedUsersLine([]string{})
+	if got == "" {
+		t.Errorf("buildAuthorizedUsersLine([]) returned empty string; expected authorized_users = [] line")
 	}
 }

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,428 @@
+# MADFLOW 導入ガイド
+
+このドキュメントは、MADFLOW の導入を検討しているエンジニア・チーム向けに、概要・導入手順・利用方法・セキュリティ上の注意点・ベストプラクティスをまとめたものです。
+
+---
+
+## 1. MADFLOW とは何か
+
+MADFLOW（Multi-Agent Development Flow）は、複数の AI エージェントがチームとして協調しながらソフトウェア開発を自律的に進める **開発自動化フレームワーク**です。
+
+### 基本的な仕組み
+
+MADFLOW は **Superintendent（監督）** と **Engineer（エンジニア）** という 2 種類のエージェントで構成されています。
+
+```
+Human（あなた）
+    ↕ GitHub Issue / コメント
+Superintendent（AI）
+    ↕ チャットログ（ローカルファイル）
+Engineer × N（AI）
+    ↕ Git / GitHub
+コードベース
+```
+
+| エージェント | 役割 |
+|---|---|
+| **Superintendent** | PM・アーキテクト・レビュアー・リリースマネージャーを兼務。イシューの割り当てから PR のマージまでを担う |
+| **Engineer** | Superintendent の指示に基づいてコードを実装。仕様書作成→テスト作成→実装のドキュメント駆動開発サイクルに従う |
+
+あなた（Human）は GitHub Issue を通じて要件・バグ・依頼を書き込むだけで、AI エージェントが自律的に実装・レビュー・マージを行います。
+
+---
+
+## 2. 導入するとどうなるか
+
+### できるようになること
+
+- **Issue を書くだけでコードが生成される**: GitHub Issue に要件を記述すると、AI エージェントがブランチ作成・実装・PR 作成・レビュー・マージまでを自律的に実施します
+- **並列開発の自動管理**: 複数の Issue を同時に処理できます（Engineer を複数起動）
+- **ドキュメント駆動開発の自動実践**: 実装前に仕様書・テストを自動生成するため、コード品質が安定します
+- **コンテキストリセットによる品質維持**: 8 分ごとに AI のコンテキストを自動リフレッシュし、性能劣化を防ぎます
+
+### 想定ユースケース
+
+| ユースケース | 説明 |
+|---|---|
+| **個人プロジェクトの加速** | 一人で複数の機能開発を並行して進めたい |
+| **小規模チームの開発支援** | 人手不足を AI エージェントで補い、開発速度を向上させたい |
+| **ルーティン実装の自動化** | CRUD 操作・テスト追加・ドキュメント整備などの定型作業を委任したい |
+| **OSS への貢献支援** | Issue ドリブンで継続的な改善を自動化したい |
+
+---
+
+## 3. 導入するのに必要なもの
+
+### 必須要件
+
+| 要件 | 説明 |
+|---|---|
+| **Go 1.25 以上** | MADFLOW 本体のビルド・実行に必要 |
+| **Git** | ブランチ管理・コミット操作に使用 |
+| **AI バックエンド（いずれか 1 つ）** | 下記の表を参照 |
+
+### AI バックエンド（いずれか 1 つを選択）
+
+| バックエンド | 必要なもの | 費用感 |
+|---|---|---|
+| **Claude CLI**（推奨） | Claude Code（Pro/Max サブスクリプション）、`claude` コマンド | 月額固定（¥15,000 前後） |
+| **Gemini CLI** | `gemini-cli` コマンド（無料枠あり） | 無料〜従量課金 |
+| **Anthropic API キー** | `ANTHROPIC_API_KEY` 環境変数 | 従量課金（¥1,000〜¥8,000/月、使用量による） |
+
+### オプション要件
+
+| 要件 | 説明 |
+|---|---|
+| **GitHub CLI (`gh`)** | GitHub Issue との同期・PR 操作に必要（GitHub 連携を使う場合） |
+| **GitHub アカウント** | Issue/PR の管理に使用（GitHub 連携を使う場合） |
+
+---
+
+## 4. 導入する方法
+
+### ステップ 1: MADFLOW のインストール
+
+**方法 A: `go install` でインストール（推奨）**
+
+```bash
+go install github.com/ytnobody/madflow/cmd/madflow@latest
+```
+
+**方法 B: バイナリを直接ダウンロード**
+
+```bash
+# Linux (amd64) の例
+curl -L https://github.com/ytnobody/madflow/releases/latest/download/madflow-linux-amd64 -o madflow
+chmod +x madflow
+sudo mv madflow /usr/local/bin/
+```
+
+macOS や Windows など他の OS・アーキテクチャは [GitHub Releases](https://github.com/ytnobody/madflow/releases/latest) からダウンロードしてください。
+
+インストール後、以下のコマンドでバージョンを確認できます。
+
+```bash
+madflow version
+```
+
+### ステップ 2: プロジェクトの初期化
+
+MADFLOW で管理したいプロジェクトのディレクトリで `madflow init` を実行します。
+
+```bash
+cd your-project
+madflow init
+```
+
+`madflow.toml` が生成されます。必要に応じて編集してください。
+
+### ステップ 3: 設定ファイルの編集
+
+生成された `madflow.toml` を編集します。以下は基本設定の例です。
+
+```toml
+# プロジェクト名と管理するリポジトリ
+[project]
+name = "my-app"
+
+[[project.repos]]
+name = "main"
+path = "."
+
+# コンテキストリセット間隔（分）
+[agent]
+context_reset_minutes = 8
+
+# 使用するモデル
+[agent.models]
+superintendent = "claude-opus-4-6"
+engineer = "claude-sonnet-4-6"
+
+# ブランチ設定
+[branches]
+main = "main"
+develop = "develop"
+feature_prefix = "feature/issue-"
+
+# GitHub 連携（オプション）
+# authorized_users は GitHub 連携を有効にする場合に必須
+authorized_users = ["your-github-username"]
+
+[github]
+owner = "your-org"
+repos = ["your-repo"]
+sync_interval_minutes = 5
+```
+
+> **重要**: GitHub 連携を有効にする場合は、`authorized_users` を必ず設定してください。詳細は「[6. 導入時のセキュリティチェック](#6-導入時のセキュリティチェック)」を参照してください。
+
+### ステップ 4: AI バックエンドのセットアップ
+
+使用する AI バックエンドに応じて、以下のいずれかを実施してください。
+
+**Claude CLI（Claude Code）を使う場合**
+
+```bash
+# Claude Code がインストール済みであること（https://claude.com/claude-code）
+# 自動的に認証情報が使用されます
+madflow use claude
+```
+
+**Gemini CLI を使う場合**
+
+```bash
+# gemini-cli がインストール済みであること（https://github.com/google-gemini/gemini-cli）
+madflow use gemini
+```
+
+**Anthropic API キーを使う場合**
+
+```bash
+export ANTHROPIC_API_KEY="sk-ant-..."
+madflow use claude-api-standard
+```
+
+### ステップ 5: エージェントの起動
+
+```bash
+madflow start
+```
+
+MADFLOW が起動し、Superintendent と Engineer エージェントが動作を開始します。
+
+---
+
+## 5. 利用方法
+
+### 基本的な使い方
+
+MADFLOW を起動した後は、GitHub Issue（または MADFLOW 内部のイシューファイル）に要件を書き込むことでエージェントに作業を依頼します。
+
+#### GitHub Issue での依頼（推奨）
+
+GitHub Issue を通常どおり作成します。Superintendent が自動的に検知して割り当てを行います。
+
+```
+タイトル: ユーザー登録機能を追加する
+本文: ユーザーのメールアドレスとパスワードで登録できるエンドポイントを追加してください。
+      バリデーション: メールアドレスの形式チェック、パスワードは8文字以上。
+```
+
+#### コマンドリファレンス
+
+| コマンド | 説明 |
+|---|---|
+| `madflow init` | プロジェクトを初期化し、`madflow.toml` を生成する |
+| `madflow start` | Superintendent・Engineer エージェントを起動する |
+| `madflow use <preset>` | 使用するモデルプリセットを切り替える |
+| `madflow version` | 現在のバージョンを表示する |
+| `madflow upgrade` | madflow を最新バージョンにアップグレードする |
+
+#### モデルプリセット一覧
+
+```bash
+# Claude CLI（Pro/Max サブスクリプション必須）
+madflow use claude          # claude-sonnet / claude-sonnet
+madflow use claude-cheap    # claude-sonnet / claude-haiku（低コスト）
+
+# Gemini CLI
+madflow use gemini          # gemini-2.5-pro / gemini-2.5-pro
+madflow use gemini-cheap    # gemini-2.5-flash / gemini-2.5-flash（高速・低コスト）
+
+# ハイブリッド（監督: Claude、エンジニア: Gemini）
+madflow use hybrid
+madflow use hybrid-cheap
+
+# Anthropic API キー直接利用（サブスクリプション不要）
+madflow use claude-api-standard   # sonnet / haiku
+madflow use claude-api-cheap      # haiku / haiku（最安）
+```
+
+#### バージョンアップ
+
+```bash
+madflow upgrade
+```
+
+最新バイナリが自動的にダウンロードされ、インストールされます。
+
+### エージェントとのコミュニケーション
+
+MADFLOW では、チャットログ（`~/.madflow/<project-name>/chatlog.txt`）を通じてエージェント間の通信が行われます。進捗確認はこのファイルを参照してください。
+
+```bash
+# チャットログをリアルタイムで確認
+tail -f ~/.madflow/my-app/chatlog.txt
+```
+
+### イシューの確認
+
+```bash
+# イシューファイルの一覧
+ls ~/.madflow/my-app/issues/
+
+# 特定のイシューの状態確認
+cat ~/.madflow/my-app/issues/<issueID>.toml
+```
+
+---
+
+## 6. 導入時のセキュリティチェック
+
+MADFLOW は AI エージェントが自律的にコマンドを実行するため、セキュリティリスクを理解した上で導入することが重要です。
+
+### チェックリスト
+
+導入前に以下を必ず確認してください。
+
+#### [ ] `authorized_users` を設定する（GitHub 連携使用時は必須）
+
+```toml
+# madflow.toml に必ず設定する
+authorized_users = ["your-github-username", "trusted-collaborator"]
+```
+
+**なぜ必要か**: 未設定の場合、公開リポジトリに対してどの GitHub ユーザーでも Issue を作成・コメントでき、MADFLOW がそれを処理します。悪意のある Issue によってプロンプトインジェクション攻撃を受けるリスクがあります。
+
+#### [ ] プライベートリポジトリでの使用を検討する
+
+公開リポジトリで MADFLOW を使用する場合、`authorized_users` の設定は特に重要です。信頼できるユーザーのみを登録してください。
+
+#### [ ] AI エージェントの実行権限を把握する
+
+MADFLOW のエージェントは、ホストマシン上でコマンドを実行する権限を持ちます（Claude CLI バックエンドでは `--dangerously-skip-permissions` フラグを使用）。以下の点に注意してください。
+
+- エージェントは Git 操作・ファイル編集・ビルドコマンドなどを自律的に実行します
+- 本番環境のサーバーや重要なシステムにアクセスできる環境では直接実行しないことを推奨します
+- 専用の開発環境・CI 環境での実行を推奨します
+
+#### [ ] データディレクトリのパーミッションを確認する
+
+```bash
+# データディレクトリのパーミッションを確認
+ls -la ~/.madflow/
+
+# 推奨: 本人のみアクセス可能に設定
+chmod 700 ~/.madflow/
+chmod 600 ~/.madflow/*/chatlog.txt
+```
+
+デフォルトでは `0755` / `0644` で作成されるため、同一ホストの他ユーザーからチャットログ（Issue 内容・LLM との会話ログ）が読み取れる状態になっています。共有サーバーで使用する場合は特に注意してください。
+
+#### [ ] API キーの管理
+
+```bash
+# API キーは環境変数で渡す（ファイルへの直接記述は避ける）
+export ANTHROPIC_API_KEY="sk-ant-..."
+export GOOGLE_API_KEY="..."  # Gemini 使用時
+
+# .env ファイルを使う場合は .gitignore に追加する
+echo ".env" >> .gitignore
+```
+
+#### [ ] バイナリの整合性確認
+
+`go install` を使わずバイナリを直接ダウンロードした場合は、公式リリースページの SHA256 チェックサムで整合性を確認してください。
+
+```bash
+# ダウンロードしたバイナリのチェックサムを確認
+sha256sum madflow
+```
+
+---
+
+## 7. 実運用におけるベストプラクティス
+
+### Issue の書き方
+
+AI エージェントが正確に実装するために、Issue には以下を含めることを推奨します。
+
+```markdown
+## 概要
+（何を実現したいかを 1〜2 文で）
+
+## 要件
+- 要件 1
+- 要件 2
+
+## 受け入れ条件
+- [ ] 条件 A を満たすこと
+- [ ] 条件 B を満たすこと
+
+## 補足
+（実装方針のヒント・参照すべき既存コードなど）
+```
+
+**避けるべき書き方**:
+- 曖昧な表現（「いい感じにして」「適切に修正する」）
+- スコープが広すぎる Issue（複数の独立した機能を 1 つの Issue に詰め込む）
+- 悪意ある内容・プロンプトインジェクションを誘発するコンテンツ
+
+### ブランチ戦略の維持
+
+MADFLOW は `main` / `develop` / `feature/issue-<ID>` の 3 層ブランチ戦略を前提としています。
+
+```bash
+# develop ブランチを常に最新に保つ
+git checkout develop
+git pull origin develop
+
+# 本番マージは main ← develop のみ（直接 feature → main は避ける）
+```
+
+### コンテキストリセット間隔の調整
+
+デフォルトは 8 分ですが、Issue の複雑さに応じて調整してください。
+
+```toml
+[agent]
+context_reset_minutes = 8   # 複雑な Issue が多い場合は 10〜15 に増やす
+```
+
+### チャットログの定期メンテナンス
+
+チャットログは増加し続けるため、定期的にアーカイブ・削除することを推奨します。
+
+```bash
+# チャットログのサイズ確認
+du -sh ~/.madflow/*/chatlog.txt
+
+# 古いログのアーカイブ（例: 30 日以上前）
+find ~/.madflow/ -name "chatlog.txt" -mtime +30 -exec gzip {} \;
+```
+
+### モデルプリセットの使い分け
+
+| シーン | 推奨プリセット |
+|---|---|
+| 本格的な機能開発 | `claude` / `gemini` |
+| コスト最適化 | `claude-cheap` / `gemini-cheap` |
+| サブスクリプションなし | `claude-api-standard` / `claude-api-cheap` |
+| 無料で試したい | `gemini-cheap`（Gemini Flash は無料枠あり） |
+
+### PR・マージのレビュー習慣
+
+AI が生成したコードも必ず人間がレビューすることを推奨します。
+
+- **自動マージを無効化**: GitHub の Branch Protection Rules でマージに人間の承認を必須にする
+- **差分の確認**: AI が予期しない変更を加えていないか確認する
+- **テストの実行**: CI が通過しているか確認する
+
+### 定期的なアップグレード
+
+```bash
+# MADFLOW 本体のアップグレード
+madflow upgrade
+
+# AI モデルの最新プリセットを確認
+madflow use --list  # 利用可能なプリセット一覧を確認
+```
+
+---
+
+## 参考リンク
+
+- [MADFLOW GitHub リポジトリ](https://github.com/ytnobody/madflow)
+- [SPEC.md（アーキテクチャ仕様）](./SPEC.md)
+- [SECURITY_AUDIT_REPORT.md（セキュリティ調査レポート）](./SECURITY_AUDIT_REPORT.md)
+- [GitHub Releases](https://github.com/ytnobody/madflow/releases)

--- a/docs/integration-plugin-design.md
+++ b/docs/integration-plugin-design.md
@@ -1,0 +1,508 @@
+# GitHubインテグレーション プラグイン化 実装案
+
+## 1. 概要
+
+本ドキュメントは、MADFLOWのGitHubインテグレーション機能をプラグインアーキテクチャへ移行するための実装案を記述する。
+
+### 1.1. 目的
+
+現在のMADFLOWはGitHubを前提としたハードコードされた統合機能を持つ。今後、以下のような異なるバックエンドへの対応を可能にするため、インテグレーション機能をプラグインとして抽象化する。
+
+- **GitLabインテグレーション** — Merge Requestを持つプラットフォーム
+- **Azure DevOpsインテグレーション** — Work ItemsとPull Requestを持つプラットフォーム
+- **Google Spreadsheetによるイシュー管理** — Pull Request相当機能を持たないプラットフォーム
+
+現在のGitHubインテグレーション機能は、**組み込みプラグイン（Built-in Plugin）** として最初から利用可能な状態を維持する。
+
+### 1.2. スコープ
+
+- プラグインインターフェース仕様の定義
+- 組み込みGitHubプラグインの位置づけ
+- Pull Request相当機能が存在しないプラットフォームへの対応方針
+- 設定ファイル（`madflow.toml`）の拡張方針
+- ディレクトリ構成と実装方針
+
+---
+
+## 2. 現状の課題
+
+### 2.1. 現在のアーキテクチャ
+
+```
+internal/
+  github/
+    github.go      — イシュー同期（Syncer）
+    events.go      — イベント監視（EventWatcher）
+    idle.go        — アイドル検出（IdleDetector）
+    ratelimit.go   — レート制限チェック
+  orchestrator/
+    orchestrator.go — GitHub Syncerを直接利用
+```
+
+現在の実装では以下の問題がある。
+
+1. `gh` CLIへの直接依存 — `gh issue list`、`gh api`、`gh issue close` 等をサブプロセス呼び出しで実行
+2. GitHub固有のデータ構造が内部に散在 — `ghIssue`、`ghComment`、`ghEvent` 等
+3. オーケストレーターがGitHub Syncer/EventWatcherを直接生成・管理 — 別プロバイダへの切り替えが困難
+4. IDフォーマットがGitHub前提 — `{owner}-{repo}-{number}` 形式
+
+---
+
+## 3. プラグインインターフェース設計
+
+### 3.1. ディレクトリ構成
+
+```
+internal/
+  integration/
+    plugin.go          — プラグインインターフェース定義
+    registry.go        — プラグイン登録・ファクトリ
+    builtin/
+      github/          — 組み込みGitHubプラグイン（現 internal/github/ を移行）
+        provider.go
+        syncer.go
+        events.go
+        idle.go
+        ratelimit.go
+```
+
+> 現在の `internal/github/` パッケージは `internal/integration/builtin/github/` へ移動し、プラグインインターフェースを実装する形にリファクタリングする。
+
+### 3.2. 共通データ型
+
+プラグイン間で共通して使用するデータ型を `internal/integration/plugin.go` に定義する。
+
+```go
+package integration
+
+import (
+    "context"
+    "time"
+
+    "github.com/ytnobody/madflow/internal/issue"
+)
+
+// ProviderIssue はプロバイダから取得したイシューの共通表現
+type ProviderIssue struct {
+    // プロバイダ固有のID（例: GitHubなら issue number）
+    ExternalID string
+    // MADFLOWシステム内でのID（例: "ytnobody-MADFLOW-219"）
+    SystemID   string
+    Title      string
+    Body       string
+    State      string // "open" or "closed"
+    // プロバイダのURL（GitHub Issue URL等）
+    URL        string
+    // イシューのラベル
+    Labels     []string
+    // 作成者
+    Author     string
+    // リポジトリ名
+    Repo       string
+}
+
+// ProviderComment はプロバイダから取得したコメントの共通表現
+type ProviderComment struct {
+    ExternalID string
+    Body       string
+    Author     string
+    IsBot      bool
+    CreatedAt  time.Time
+    UpdatedAt  time.Time
+}
+
+// ChangeRequest はPull Request / Merge Request相当の概念の共通表現
+type ChangeRequest struct {
+    ExternalID string
+    Title      string
+    Body       string
+    // 対象ブランチ（マージ先）
+    BaseBranch string
+    // マージ済みかどうか
+    Merged     bool
+    // プロバイダのURL
+    URL        string
+    // リポジトリ名
+    Repo       string
+}
+
+// EventType はイベントの種別
+type EventType int
+
+const (
+    EventTypeIssueOpened  EventType = iota
+    EventTypeIssueComment
+    EventTypeChangeRequestMerged
+    EventTypeChangeRequestOpened
+)
+
+// Event はプロバイダから受信したイベントの共通表現
+type Event struct {
+    Type      EventType
+    IssueID   string            // 関連するシステムISSUE ID（あれば）
+    Comment   *ProviderComment  // EventTypeIssueComment の場合に設定
+    ChangeReq *ChangeRequest    // EventTypeChangeRequest* の場合に設定
+}
+
+// EventCallback はイベントを受信した際に呼ばれるコールバック関数
+type EventCallback func(event Event)
+```
+
+### 3.3. IssueProvider インターフェース
+
+イシュー管理操作の抽象インターフェース。すべてのプラグインが実装しなければならない。
+
+```go
+// IssueProvider はイシュー管理バックエンドの基本インターフェース
+type IssueProvider interface {
+    // Name はプラグインの識別子を返す（例: "github", "gitlab"）
+    Name() string
+
+    // ListOpenIssues は指定リポジトリのオープンイシュー一覧を取得する
+    ListOpenIssues(ctx context.Context, repos []string) ([]ProviderIssue, error)
+
+    // FetchComments は指定イシューのコメント一覧を取得する
+    // issueID は ExternalID（プロバイダ固有ID）を使用する
+    FetchComments(ctx context.Context, repo string, issueExternalID string) ([]ProviderComment, error)
+
+    // CloseIssue は指定イシューをクローズする
+    CloseIssue(ctx context.Context, repo string, issueExternalID string) error
+
+    // FormatSystemID はプロバイダ固有情報からMADFLOWシステムIDを生成する
+    // 例 (GitHub): FormatSystemID("ytnobody", "MADFLOW", "219") → "ytnobody-MADFLOW-219"
+    FormatSystemID(owner, repo, externalID string) string
+
+    // ParseSystemID はMADFLOWシステムIDをプロバイダ固有情報に分解する
+    ParseSystemID(systemID string) (owner, repo, externalID string, err error)
+}
+```
+
+### 3.4. ChangeRequestProvider インターフェース（オプション）
+
+Pull RequestやMerge Request相当の機能を持つプラットフォーム向けのオプションインターフェース。このインターフェースを実装しないプラグインは `nil` を返す。
+
+```go
+// ChangeRequestProvider はPR/MR相当の機能を持つプラットフォーム向けのインターフェース
+// 実装はオプション。プラグインがこの機能をサポートしない場合は nil を返す。
+type ChangeRequestProvider interface {
+    // ParseChangeRequestBody はChangeRequestの本文からMADFLOW system IDを抽出する
+    // 例 (GitHub): PR本文中の "Issue: ytnobody-MADFLOW-219" からIDを抽出
+    ParseChangeRequestBody(body string) (systemID string, err error)
+}
+```
+
+### 3.5. EventProvider インターフェース（オプション）
+
+リアルタイムイベント通知をサポートするプラットフォーム向けのオプションインターフェース。
+
+```go
+// EventProvider はリアルタイムイベント監視をサポートするプラットフォーム向けのインターフェース
+// 実装はオプション。サポートしない場合は nil を返す。
+type EventProvider interface {
+    // WatchEvents は指定リポジトリのイベントを監視し、イベント発生時にcallbackを呼び出す
+    // ctx がキャンセルされると監視を停止する
+    WatchEvents(ctx context.Context, repos []string, interval time.Duration, callback EventCallback) error
+}
+```
+
+### 3.6. Plugin 構造体
+
+3つのインターフェースをまとめるプラグイン定義。
+
+```go
+// Plugin はMADFLOWインテグレーションプラグインの定義
+type Plugin struct {
+    // IssueProvider は必須
+    IssueProvider IssueProvider
+
+    // ChangeRequestProvider はオプション（nilの場合はChangeRequest機能を無効化）
+    ChangeRequestProvider ChangeRequestProvider
+
+    // EventProvider はオプション（nilの場合はポーリングのみで動作）
+    EventProvider EventProvider
+}
+
+// SupportsChangeRequests はこのプラグインがChangeRequest機能をサポートするか返す
+func (p *Plugin) SupportsChangeRequests() bool {
+    return p.ChangeRequestProvider != nil
+}
+
+// SupportsEvents はこのプラグインがリアルタイムイベント監視をサポートするか返す
+func (p *Plugin) SupportsEvents() bool {
+    return p.EventProvider != nil
+}
+```
+
+### 3.7. プラグインレジストリ
+
+```go
+// registry.go
+package integration
+
+import "fmt"
+
+var pluginFactories = map[string]PluginFactory{}
+
+// PluginFactory はプラグインインスタンスを生成するファクトリ関数
+type PluginFactory func(config map[string]any) (*Plugin, error)
+
+// Register はプラグインファクトリを登録する
+func Register(name string, factory PluginFactory) {
+    pluginFactories[name] = factory
+}
+
+// New は指定名のプラグインを生成する
+func New(name string, config map[string]any) (*Plugin, error) {
+    factory, ok := pluginFactories[name]
+    if !ok {
+        return nil, fmt.Errorf("unknown integration plugin: %s", name)
+    }
+    return factory(config)
+}
+```
+
+---
+
+## 4. Pull Request相当機能が存在しないプラットフォームへの対応
+
+### 4.1. 問題の整理
+
+現在のMADFLOWのワークフローはPull Requestのマージイベントに強く依存している。
+
+- PRがマージされると → イシューをクローズ → チームを解散
+
+しかし、以下のプラットフォームにはPR相当の概念がない。
+
+| プラットフォーム | PR相当 | 備考 |
+|---|---|---|
+| GitHub | Pull Request | あり |
+| GitLab | Merge Request | あり（機能的には同等） |
+| Azure DevOps | Pull Request | あり（Work Itemsは別途） |
+| Google Spreadsheet | **なし** | スプレッドシート上のセル編集のみ |
+
+### 4.2. 対応方針
+
+オーケストレーターはプラグインの `SupportsChangeRequests()` を確認し、以下のように振る舞いを変更する。
+
+#### ChangeRequest対応プラグインの場合（GitHub / GitLab / Azure DevOps）
+
+現在と同じワークフロー：
+1. エンジニアがコードを実装しPR/MRを作成
+2. EventWatcherまたはポーリングでマージを検知
+3. 対応イシューをクローズ → チーム解散
+
+#### ChangeRequest非対応プラグインの場合（Google Spreadsheet等）
+
+ChangeRequest機能がないため、代替のワークフローを採用する。
+
+**方針A: 手動クローズ**
+- オーケストレーターはPRマージによる自動クローズを行わない
+- Superintendentがイシューを手動でクローズした際にチームを解散
+- チャットログの `ISSUE_CLOSED {issueID}` コマンドで解散トリガー
+
+**方針B: コミットベースクローズ（将来検討）**
+- 特定のコミットメッセージパターン（`Close: {issueID}`等）をトリガーとする
+- Gitフックまたは外部CIとの連携が必要
+
+本実装案では **方針A（手動クローズ）** を採用する。
+
+#### オーケストレーターの制御フロー
+
+```go
+// オーケストレーター内の初期化処理（疑似コード）
+plugin := integration.New(cfg.Integration.Plugin, cfg.Integration.Config)
+
+if plugin.SupportsEvents() {
+    go runEventWatcher(plugin.EventProvider)
+}
+
+if plugin.SupportsChangeRequests() {
+    // PRマージ自動検知フローを有効化
+    enableAutoCloseOnMerge()
+} else {
+    // 手動クローズフローのみ有効化
+    log.Info("ChangeRequest機能なし。手動クローズモードで動作します")
+}
+```
+
+---
+
+## 5. 設定ファイル（madflow.toml）の拡張
+
+### 5.1. 現在の設定構造
+
+```toml
+[github]
+  owner = "ytnobody"
+  repos = ["MADFLOW"]
+  sync_interval_minutes = 5
+  # ...
+```
+
+### 5.2. 拡張後の設定構造
+
+```toml
+[integration]
+  # 使用するプラグイン名。デフォルトは "github"（後方互換性維持）
+  plugin = "github"
+
+[integration.github]
+  owner = "ytnobody"
+  repos = ["MADFLOW"]
+  sync_interval_minutes = 5
+  event_poll_seconds = 30
+  idle_poll_minutes = 60
+  idle_threshold_minutes = 30
+  dormancy_threshold_minutes = 240
+  bot_comment_patterns = []
+  authorized_users = ["ytnobody"]
+
+[integration.gitlab]
+  # GitLab固有の設定（将来実装時）
+  host = "https://gitlab.com"
+  group = "mygroup"
+  repos = ["myproject"]
+  token_env = "GITLAB_TOKEN"
+
+[integration.azure-devops]
+  # Azure DevOps固有の設定（将来実装時）
+  organization = "myorg"
+  project = "myproject"
+  token_env = "AZURE_DEVOPS_TOKEN"
+
+[integration.google-spreadsheet]
+  # Google Spreadsheet固有の設定（将来実装時）
+  spreadsheet_id = "..."
+  credentials_file = "credentials.json"
+```
+
+### 5.3. 後方互換性
+
+既存の `[github]` セクションを持つ `madflow.toml` との後方互換性を維持するため、以下のフォールバック処理を行う。
+
+1. `[integration]` セクションが存在しない場合 → `plugin = "github"` として扱う
+2. `[integration.github]` が未定義かつ `[github]` が存在する場合 → `[github]` の設定を `[integration.github]` として読み込む
+
+---
+
+## 6. 組み込みGitHubプラグインの実装方針
+
+### 6.1. パッケージ移行
+
+現在の `internal/github/` を `internal/integration/builtin/github/` へ移動し、プラグインインターフェースを実装する。
+
+```go
+// internal/integration/builtin/github/provider.go
+package github
+
+import (
+    "github.com/ytnobody/madflow/internal/integration"
+)
+
+// GitHubProvider は組み込みGitHubプラグインのメイン実装
+type GitHubProvider struct {
+    owner  string
+    repos  []string
+    // 現在の Syncer が持つ設定フィールドを引き継ぐ
+    authorizedUsers    []string
+    botCommentPatterns []*regexp.Regexp
+}
+
+// integration.IssueProvider を実装
+var _ integration.IssueProvider = (*GitHubProvider)(nil)
+
+// integration.ChangeRequestProvider を実装
+var _ integration.ChangeRequestProvider = (*GitHubProvider)(nil)
+
+// integration.EventProvider を実装
+var _ integration.EventProvider = (*GitHubProvider)(nil)
+
+func init() {
+    // 起動時に組み込みプラグインを自動登録
+    integration.Register("github", func(config map[string]any) (*integration.Plugin, error) {
+        p := newFromConfig(config)
+        return &integration.Plugin{
+            IssueProvider:         p,
+            ChangeRequestProvider: p,
+            EventProvider:         p,
+        }, nil
+    })
+}
+```
+
+### 6.2. 既存機能との対応
+
+| 現在の関数/メソッド | 対応するインターフェースメソッド |
+|---|---|
+| `Syncer.fetchIssues(repo)` | `IssueProvider.ListOpenIssues()` |
+| `Syncer.fetchComments(repo, num)` | `IssueProvider.FetchComments()` |
+| `orchestrator.handlePRMerged()` 内の `gh issue close` | `IssueProvider.CloseIssue()` |
+| `FormatID(owner, repo, number)` | `IssueProvider.FormatSystemID()` |
+| `ParseID(id)` | `IssueProvider.ParseSystemID()` |
+| `ParsePRBodyIssueID(body)` | `ChangeRequestProvider.ParseChangeRequestBody()` |
+| `EventWatcher.Run()` | `EventProvider.WatchEvents()` |
+
+---
+
+## 7. 将来プラグインの実装要件
+
+### 7.1. GitLabプラグイン
+
+- `IssueProvider` を実装（GitLab Issues API）
+- `ChangeRequestProvider` を実装（GitLab Merge Requests）
+- `EventProvider` を実装（GitLab Webhooks または Events API）
+- SystemIDフォーマット: `{group}-{project}-{issue_iid}`（例: `mygroup-myproject-42`）
+
+### 7.2. Azure DevOpsプラグイン
+
+- `IssueProvider` を実装（Azure DevOps Work Items API）
+- `ChangeRequestProvider` を実装（Azure DevOps Pull Requests）
+- `EventProvider` を実装（Azure DevOps Service Hooks または Webhooks）
+- SystemIDフォーマット: `{org}-{project}-{work_item_id}`
+
+### 7.3. Google Spreadsheetプラグイン
+
+- `IssueProvider` を実装（Sheets API によるセル読み書き）
+- `ChangeRequestProvider` は **実装しない（nil）**
+  - オーケストレーターは自動クローズを行わず、手動クローズモードで動作
+- `EventProvider` は実装しない（ポーリングのみ）
+  - Google Sheets APIはWebhook/Events APIを持たないため
+- スプレッドシートのスキーマ（列定義）:
+  - A列: イシューID（MADFLOWシステムID）
+  - B列: タイトル
+  - C列: ステータス（open / in_progress / closed）
+  - D列: 担当チーム番号
+  - E列: 本文
+  - F列: 最終更新日時
+
+---
+
+## 8. 実装ロードマップ
+
+本イシューのスコープは**設計ドキュメントの作成のみ**であり、以下の各ステップは別途イシューとして管理する。
+
+| フェーズ | 内容 | 依存 |
+|---|---|---|
+| Phase 1 | プラグインインターフェース定義（`internal/integration/plugin.go`）の実装 | なし |
+| Phase 2 | 組み込みGitHubプラグインのリファクタリング（`internal/github/` → `internal/integration/builtin/github/`） | Phase 1 |
+| Phase 3 | オーケストレーターのプラグイン対応リファクタリング | Phase 2 |
+| Phase 4 | `madflow.toml` の設定スキーマ拡張（後方互換性維持） | Phase 3 |
+| Phase 5 | GitLabプラグイン実装 | Phase 4 |
+| Phase 6 | Azure DevOpsプラグイン実装 | Phase 4 |
+| Phase 7 | Google Spreadsheetプラグイン実装 | Phase 4 |
+
+---
+
+## 9. まとめ
+
+本実装案のポイントは以下の通り。
+
+1. **3層のインターフェース分離**: `IssueProvider`（必須）、`ChangeRequestProvider`（オプション）、`EventProvider`（オプション）に分離することで、機能セットの異なるプラットフォームに柔軟に対応できる。
+
+2. **組み込みGitHubプラグインの維持**: 現在のGitHubインテグレーションをそのまま組み込みプラグインとして維持し、既存ユーザーへの影響を最小化する。
+
+3. **Pull Request非対応プラットフォームへの対応**: `ChangeRequestProvider` を実装しないプラグインに対しては、オーケストレーターが手動クローズモードで動作し、ChangeRequest機能への依存なくワークフローを継続できる。
+
+4. **後方互換性の確保**: 既存の `madflow.toml` の `[github]` セクションを自動的に `[integration.github]` として読み込むフォールバック処理により、既存設定ファイルの変更なしに移行できる。
+
+5. **段階的な移行**: フェーズを分けた実装ロードマップにより、現行機能を壊すことなく段階的にプラグインアーキテクチャへ移行できる。

--- a/docs/specs/init-authorized-users.md
+++ b/docs/specs/init-authorized-users.md
@@ -2,50 +2,83 @@
 
 ## Overview
 
-`madflow init` must prompt users to specify `authorized_users` during project initialization. This ensures that projects using GitHub integration have the required security configuration set from the start.
+`madflow init` always includes `authorized_users` in the generated `madflow.toml`. The initial value is
+auto-detected from the GitHub repository owner. If detection fails, an empty array is used.
 
 ## Behavior
 
+### Auto-Detection of GitHub Owner
+
+When `--authorized-users` is not explicitly provided, `madflow init` attempts to determine the
+GitHub repository owner automatically using the following steps (in order):
+
+1. **Parse git remote URL**: Run `git -C <repoPath> remote get-url origin` and extract the owner
+   from a GitHub HTTPS (`https://github.com/owner/repo`) or SSH (`git@github.com:owner/repo`) URL.
+2. **Authenticated GitHub user**: Run `gh api user --jq '.login'` to get the currently
+   authenticated GitHub CLI user as a fallback.
+3. **Empty array**: If neither method succeeds, `authorized_users = []` is written to the config.
+
 ### CLI Flag
 
-`madflow init` accepts a new flag:
+`madflow init` accepts an explicit flag that overrides auto-detection:
 
-- `--authorized-users <users>` — Comma-separated list of GitHub usernames to authorize (e.g., `--authorized-users alice,bob`).
+- `--authorized-users <users>` — Comma-separated list of GitHub usernames (e.g., `--authorized-users alice,bob`).
+
+When `--authorized-users` is provided, auto-detection is skipped entirely.
 
 ### Interactive Prompt
 
-If `--authorized-users` is not provided and stdin is a terminal (interactive session), `madflow init` prompts the user:
+If `--authorized-users` is not provided **and** auto-detection fails **and** stdin is a terminal
+(interactive session), `madflow init` prompts the user:
 
 ```
 Enter authorized GitHub usernames (comma-separated, press Enter to skip):
 ```
 
-- The user enters a comma-separated list of GitHub usernames (e.g., `alice, bob`).
 - Each username is trimmed of whitespace.
 - Empty strings after trimming are ignored.
-- If the user presses Enter without input, the `authorized_users` field is omitted from the generated config.
-
-### Non-Interactive Mode
-
-If `--authorized-users` is not provided and stdin is NOT a terminal (piped/scripted input), no prompt is shown and `authorized_users` is omitted from the generated config.
+- If the user presses Enter without input, `authorized_users = []` is written.
 
 ### Generated Config
 
-When `authorized_users` are specified (either via flag or interactive prompt):
+`authorized_users` is **always** written to the generated `madflow.toml`, regardless of whether
+users were detected, provided, or defaulted to an empty list.
+
+**With detected/provided users:**
 
 ```toml
-authorized_users = ["alice", "bob"]
+authorized_users = ["ytnobody"]
 
 [project]
 name = "myproject"
 ...
 ```
 
-When no users are specified, the `authorized_users` field is omitted from the generated config.
+**With no users detected (empty array):**
+
+```toml
+authorized_users = []
+
+[project]
+name = "myproject"
+...
+```
 
 ## Examples
 
-### Via CLI Flag
+### Auto-Detection from Git Remote
+
+```bash
+cd /path/to/repo  # repo with git remote pointing to github.com/alice/myrepo
+madflow init
+```
+
+Generated `madflow.toml` includes:
+```toml
+authorized_users = ["alice"]
+```
+
+### Via CLI Flag (overrides auto-detection)
 
 ```bash
 madflow init --authorized-users alice,bob
@@ -56,30 +89,27 @@ Generated `madflow.toml` includes:
 authorized_users = ["alice", "bob"]
 ```
 
-### Via Interactive Prompt
+### No Owner Detected (non-interactive, no remote)
 
-```
-$ madflow init
-Enter authorized GitHub usernames (comma-separated, press Enter to skip): alice, bob
-Project 'myproject' initialized.
+```bash
+madflow init  # no git remote, gh CLI not authenticated
 ```
 
-### Skip (empty input or non-interactive)
-
+Generated `madflow.toml` includes:
+```toml
+authorized_users = []
 ```
-$ madflow init
-Enter authorized GitHub usernames (comma-separated, press Enter to skip): [Enter]
-Project 'myproject' initialized.
-```
-
-Config does not include `authorized_users`.
 
 ## Notes
 
-- `authorized_users` is only **required** at runtime when the `[github]` section is present (see `authorized-users-required.md`). If not using GitHub integration, users may safely skip this.
-- If `madflow.toml` already exists, `cmdInit` does not overwrite it, so the `authorized_users` prompt behavior only applies when creating a new config file.
+- `authorized_users` is **required** at runtime when the `[github]` section is present
+  (see `authorized-users-required.md`). Always generating the field makes the config
+  ready for GitHub integration without manual editing.
+- If `madflow.toml` already exists, `cmdInit` does not overwrite it, so this behavior
+  only applies when creating a new config file.
 
 ## Affected Files
 
-- `cmd/madflow/main.go` — parse `--authorized-users` flag, add interactive prompt, update config template
-- `cmd/madflow/main_test.go` — add tests for new flag and generated config
+- `cmd/madflow/main.go` — add `detectGitHubOwner`, `extractOwnerFromGitHubURL`, update
+  `buildAuthorizedUsersLine` to always emit the field, update `cmdInit` logic
+- `cmd/madflow/main_test.go` — update and add tests

--- a/docs/specs/nightly-build.md
+++ b/docs/specs/nightly-build.md
@@ -1,0 +1,58 @@
+# Nightly Build Specification
+
+## Overview
+
+The nightly build workflow automatically creates build artifacts from the `develop` branch
+when new commits exist since the last nightly build.
+
+## Trigger
+
+- **Schedule**: Daily at JST 0:00 (UTC 15:00)
+- **Manual**: Can also be triggered manually via `workflow_dispatch`
+
+## Behavior
+
+1. The workflow checks whether the `nightly` tag exists on GitHub.
+2. If the `nightly` tag exists and points to the same commit as the HEAD of `develop`,
+   the workflow exits early with no-op (no new build is needed).
+3. If the `nightly` tag does not exist, or if it points to a different commit than
+   the HEAD of `develop`, the workflow proceeds to build.
+
+## Build Process
+
+1. Checkout the `develop` branch.
+2. Build binaries for all supported platforms:
+   - `linux/amd64`
+   - `linux/arm64`
+   - `darwin/amd64`
+   - `darwin/arm64`
+   - `windows/amd64`
+3. Generate SHA256 checksums for each binary.
+4. Move or create the `nightly` tag to point to the current HEAD of `develop`.
+5. Create or update the GitHub Release for the `nightly` tag with all artifacts.
+
+## Tag Management
+
+- The `nightly` tag is a **mutable, force-pushed tag** that always points to the
+  latest nightly build commit on `develop`.
+- The release associated with the `nightly` tag is updated (pre-release) with each
+  new nightly build.
+
+## Artifact Naming
+
+Binaries follow the same naming convention as release builds:
+- `madflow-linux-amd64`
+- `madflow-linux-arm64`
+- `madflow-darwin-amd64`
+- `madflow-darwin-arm64`
+- `madflow-windows-amd64.exe`
+- Corresponding `.sha256` checksum files
+
+## Version Embedding
+
+The build version is embedded as:
+```
+nightly-<YYYYMMDD>-<short-SHA>
+```
+
+For example: `nightly-20260412-a1b2c3d`

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -70,6 +70,13 @@ func NewAgent(cfg AgentConfig) *Agent {
 				WorkDir:      cfg.WorkDir,
 				BashTimeout:  cfg.BashTimeout,
 			})
+		case strings.HasPrefix(cfg.Model, "copilot/"):
+			proc = NewCopilotCLIProcess(CopilotCLIOptions{
+				SystemPrompt: cfg.SystemPrompt,
+				Model:        cfg.Model,
+				WorkDir:      cfg.WorkDir,
+				BashTimeout:  cfg.BashTimeout,
+			})
 		default:
 			proc = NewClaudeStreamProcess(ClaudeOptions{
 				SystemPrompt: cfg.SystemPrompt,

--- a/internal/agent/copilot_cli.go
+++ b/internal/agent/copilot_cli.go
@@ -1,0 +1,104 @@
+package agent
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+// CopilotCLIOptions configures the GitHub Copilot CLI backend.
+type CopilotCLIOptions struct {
+	SystemPrompt string
+	Model        string
+	WorkDir      string
+	BashTimeout  time.Duration
+}
+
+// CopilotCLIProcess sends prompts to the GitHub Copilot CLI (`copilot -p`).
+// Each Send() call invokes `copilot -p "<prompt>" --allow-all-tools` as a subprocess.
+type CopilotCLIProcess struct {
+	opts CopilotCLIOptions
+}
+
+// NewCopilotCLIProcess creates a new CopilotCLIProcess.
+func NewCopilotCLIProcess(opts CopilotCLIOptions) *CopilotCLIProcess {
+	return &CopilotCLIProcess{opts: opts}
+}
+
+func (c *CopilotCLIProcess) Reset(ctx context.Context) error { return nil }
+func (c *CopilotCLIProcess) Close() error                    { return nil }
+
+// modelName returns the bare model name with the "copilot/" prefix stripped.
+func (c *CopilotCLIProcess) modelName() string {
+	return strings.TrimPrefix(c.opts.Model, "copilot/")
+}
+
+// Send invokes `copilot -p` with the given prompt and returns the response.
+func (c *CopilotCLIProcess) Send(ctx context.Context, prompt string) (string, error) {
+	// Check for authentication token
+	if os.Getenv("GH_TOKEN") == "" && os.Getenv("GITHUB_TOKEN") == "" {
+		// copilot CLI can also use browser-based auth, so this is only a warning-level check.
+		// We proceed anyway — the CLI will prompt or fail with its own error.
+	}
+
+	if c.opts.BashTimeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, c.opts.BashTimeout)
+		defer cancel()
+	}
+
+	args := c.buildArgs(prompt)
+
+	cmd := exec.CommandContext(ctx, "copilot", args...)
+	if c.opts.WorkDir != "" {
+		cmd.Dir = c.opts.WorkDir
+	}
+
+	// Pass through environment but filter out variables that may conflict.
+	env := filterEnv(os.Environ(), "CLAUDECODE")
+	env = filterEnv(env, "CLAUDE_CODE_ENTRYPOINT")
+	cmd.Env = env
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	if err := cmd.Run(); err != nil {
+		if ctx.Err() != nil {
+			return "", ctx.Err()
+		}
+
+		stderrStr := stderr.String()
+		// Check for rate limit indicators in stderr
+		if containsRateLimitKeyword(stderrStr) {
+			return "", &RateLimitError{
+				Wrapped: fmt.Errorf("copilot CLI rate limit: %s", strings.TrimSpace(stderrStr)),
+			}
+		}
+
+		return "", fmt.Errorf("copilot CLI process failed: %w\nstderr: %s", err, stderrStr)
+	}
+
+	return strings.TrimSpace(stdout.String()), nil
+}
+
+// buildArgs constructs the command-line arguments for the copilot CLI.
+func (c *CopilotCLIProcess) buildArgs(prompt string) []string {
+	args := []string{
+		"-p", prompt,
+		"--allow-all-tools",
+		"--allow-all-paths",
+		"--no-color",
+	}
+
+	model := c.modelName()
+	if model != "" {
+		args = append(args, "--model", model)
+	}
+
+	return args
+}

--- a/internal/agent/copilot_cli_test.go
+++ b/internal/agent/copilot_cli_test.go
@@ -1,0 +1,119 @@
+package agent
+
+import (
+	"testing"
+)
+
+func TestCopilotCLIProcess_ModelName(t *testing.T) {
+	tests := []struct {
+		model    string
+		expected string
+	}{
+		{"copilot/claude-sonnet-4", "claude-sonnet-4"},
+		{"copilot/gpt-5", "gpt-5"},
+		{"copilot/claude-sonnet-4.5", "claude-sonnet-4.5"},
+		{"copilot/claude-haiku-4.5", "claude-haiku-4.5"},
+		{"copilot/", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.model, func(t *testing.T) {
+			p := NewCopilotCLIProcess(CopilotCLIOptions{Model: tt.model})
+			got := p.modelName()
+			if got != tt.expected {
+				t.Errorf("modelName() = %q, want %q", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestCopilotCLIProcess_BuildArgs(t *testing.T) {
+	p := NewCopilotCLIProcess(CopilotCLIOptions{
+		Model: "copilot/gpt-5",
+	})
+
+	args := p.buildArgs("test prompt")
+
+	// Verify -p flag with prompt
+	found := false
+	for i, arg := range args {
+		if arg == "-p" && i+1 < len(args) && args[i+1] == "test prompt" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected -p 'test prompt' in args: %v", args)
+	}
+
+	// Verify --allow-all-tools
+	hasAllowAll := false
+	for _, arg := range args {
+		if arg == "--allow-all-tools" {
+			hasAllowAll = true
+			break
+		}
+	}
+	if !hasAllowAll {
+		t.Errorf("expected --allow-all-tools in args: %v", args)
+	}
+
+	// Verify --model
+	hasModel := false
+	for i, arg := range args {
+		if arg == "--model" && i+1 < len(args) && args[i+1] == "gpt-5" {
+			hasModel = true
+			break
+		}
+	}
+	if !hasModel {
+		t.Errorf("expected --model gpt-5 in args: %v", args)
+	}
+
+	// Verify --no-color
+	hasNoColor := false
+	for _, arg := range args {
+		if arg == "--no-color" {
+			hasNoColor = true
+			break
+		}
+	}
+	if !hasNoColor {
+		t.Errorf("expected --no-color in args: %v", args)
+	}
+
+	// Verify --allow-all-paths
+	hasAllowPaths := false
+	for _, arg := range args {
+		if arg == "--allow-all-paths" {
+			hasAllowPaths = true
+			break
+		}
+	}
+	if !hasAllowPaths {
+		t.Errorf("expected --allow-all-paths in args: %v", args)
+	}
+}
+
+func TestCopilotCLIProcess_ResetAndClose(t *testing.T) {
+	p := NewCopilotCLIProcess(CopilotCLIOptions{Model: "copilot/gpt-5"})
+
+	if err := p.Reset(nil); err != nil {
+		t.Errorf("Reset() returned error: %v", err)
+	}
+	if err := p.Close(); err != nil {
+		t.Errorf("Close() returned error: %v", err)
+	}
+}
+
+func TestNewAgent_CopilotPrefix(t *testing.T) {
+	agent := NewAgent(AgentConfig{
+		ID:          AgentID{Role: RoleEngineer, TeamNum: 99},
+		Model:       "copilot/gpt-5",
+		ChatLogPath: "/dev/null",
+	})
+
+	if _, ok := agent.Process.(*CopilotCLIProcess); !ok {
+		t.Errorf("expected CopilotCLIProcess for model 'copilot/gpt-5', got %T", agent.Process)
+	}
+}


### PR DESCRIPTION
## Summary
Merge develop branch into main for v0.7.0 release.

### Changes since v0.6.0
- ytnobody-MADFLOW-218: `madflow init`時に作られるtomlファイルに`authorized_users`を最初から含める (#220)
- docs: GitHubインテグレーションのプラグイン化実装案ドキュメントを追加 (#221)
- docs: add getting-started guide for potential adopters (#223)
- ytnobody-MADFLOW-224: developブランチのnightlyビルドワークフローを追加 (#225)
- ytnobody-MADFLOW-226: Add GitHub Copilot CLI backend engine (#227)

Closes #228