### PR TITLE
ytnobody-MADFLOW-230: Superintendentへの教訓注入機能を追加

### DIFF
--- a/docs/specs/lessons.md
+++ b/docs/specs/lessons.md
@@ -1,0 +1,70 @@
+# Lessons Injection Specification
+
+## Overview
+
+The lessons system provides a feedback loop for the Superintendent by:
+1. Scoring issue instruction quality when a PR is merged
+2. Generating lessons from failures and persisting them to `.madflow/lessons.txt`
+3. Maintaining at most 15 lessons (merging/trimming via LLM when exceeded)
+4. Injecting lessons into the Superintendent's patrol prompt so they inform future issue instructions
+
+## Scoring
+
+When a PR is merged, the associated GitHub issue is scored starting from 100 points.
+Deductions are applied for each detected failure:
+
+| Failure | Deduction | Risk Level |
+|---------|-----------|------------|
+| Derived/fix issues created | -30 | 高 (High) |
+| `[Clarification Needed]` comment exists | -20 | 中 (Medium) |
+| Superintendent implemented directly | -20 | 中 (Medium) |
+| 2 or more PRs created | -15 | 低 (Low) |
+
+**Detection methods (using `gh` CLI):**
+- Derived/fix issues: Search GitHub issues referencing the original issue number
+- Clarification Needed: Scan issue comments for the `[Clarification Needed]` tag
+- Direct implementation: Check PR body for "Superintendent implemented directly" or "Superintendentが直接実装"
+- Multiple PRs: Count PRs for the `feature/issue-<issueID>` head branch
+
+Scoring only applies to GitHub-synced issues (those with a `url` field). Local issues (`local-XXX`) are skipped.
+
+## Lesson Generation
+
+If the score is below 70, a lesson is generated using the Anthropic API:
+- The lesson is a single line in Japanese describing what should have been done differently
+- Format: `[危険度] 教訓テキスト` (e.g., `[高] バグ修正Issueは症状への対処だけでなく再発防止策まで含めること`)
+- Risk level is determined by the highest-risk failure detected
+- If `ANTHROPIC_API_KEY` is not set, a template-based fallback lesson is used
+
+## Lesson Storage
+
+- File: `<dataDir>/lessons.txt`
+- Format: One lesson per line, each starting with `[高]`, `[中]`, or `[低]`
+- Lessons are appended when generated
+
+## Lessons Count Management (max 15)
+
+When lessons exceed 15:
+1. **Merge**: Call LLM to merge semantically similar lessons into one
+2. **Trim**: If still over 15 after merging, delete lowest-risk lessons (oldest first for ties)
+
+## Superintendent Prompt Injection
+
+During issue patrol (`runIssuePatrol`), if `lessons.txt` is non-empty, the patrol message prepends all lessons so the Superintendent can reference them when writing issue instructions.
+
+## Data Flow
+
+```
+PR merged
+  → handlePRMerged() [orchestrator]
+    → lessons.Manager.ProcessMergedIssue() [async goroutine]
+      → ScoreIssue() [gh CLI calls]
+      → if score < 70: GenerateLesson() [Anthropic API or fallback]
+      → AppendLesson() [file write]
+      → ManageLessonsCount() [LLM merge/trim if >15]
+
+Issue patrol timer fires
+  → runIssuePatrol()
+    → Manager.InjectLessons() [file read]
+    → prepend lessons to patrol message → superintendent
+```

--- a/internal/lessons/lessons.go
+++ b/internal/lessons/lessons.go
@@ -430,10 +430,10 @@ func fallbackLesson(failures []Failure) Lesson {
 	}
 
 	templates := map[string]string{
-		"派生・修正Issueが発生した":              "Issueの仕様を明確にしてからEngineerに渡し、派生Issueが発生しないようにすること",
+		"派生・修正Issueが発生した":                  "Issueの仕様を明確にしてからEngineerに渡し、派生Issueが発生しないようにすること",
 		"[Clarification Needed] コメントが存在した": "仕様が曖昧なままEngineerに渡さず、先に仕様を人間に確認してから指示すること",
-		"Superintendentが直接実装した":           "EngineerやOrchestratorが応答しない場合の対応手順を見直し、直接実装に頼らないようにすること",
-		"PRが2本以上作成された":                  "重複PRが発生しないようブランチとPR管理を徹底し、作業開始前に既存PRを確認すること",
+		"Superintendentが直接実装した":            "EngineerやOrchestratorが応答しない場合の対応手順を見直し、直接実装に頼らないようにすること",
+		"PRが2本以上作成された":                     "重複PRが発生しないようブランチとPR管理を徹底し、作業開始前に既存PRを確認すること",
 	}
 
 	if text, ok := templates[topFailure.Description]; ok {

--- a/internal/lessons/lessons.go
+++ b/internal/lessons/lessons.go
@@ -1,0 +1,667 @@
+// Package lessons implements the feedback loop that scores issue instruction
+// quality after a PR merge, generates lessons from failures, and injects
+// accumulated lessons into the Superintendent's patrol prompts.
+package lessons
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// RiskLevel represents the severity level of a lesson.
+type RiskLevel string
+
+const (
+	RiskHigh   RiskLevel = "高"
+	RiskMedium RiskLevel = "中"
+	RiskLow    RiskLevel = "低"
+)
+
+// riskOrder maps risk levels to numeric priority (higher = more important to keep).
+var riskOrder = map[RiskLevel]int{
+	RiskHigh:   3,
+	RiskMedium: 2,
+	RiskLow:    1,
+}
+
+// Failure represents a quality failure detected during issue scoring.
+type Failure struct {
+	Description string
+	Risk        RiskLevel
+	Points      int // points deducted
+}
+
+// ScoringResult holds the result of scoring an issue's instruction quality.
+type ScoringResult struct {
+	IssueID  string
+	Score    int
+	Failures []Failure
+}
+
+// Lesson represents a single lesson entry.
+type Lesson struct {
+	Risk RiskLevel
+	Text string
+}
+
+// maxLessons is the maximum number of lessons kept in the file.
+const maxLessons = 15
+
+// lessonsMgmtModel is the Anthropic model used for lesson generation and merging.
+const lessonsMgmtModel = "claude-haiku-4-5"
+
+// anthropicEndpoint is the Anthropic Messages API endpoint.
+const anthropicEndpoint = "https://api.anthropic.com/v1/messages"
+
+// anthropicAPIVersion is the Anthropic API version header value.
+const anthropicAPIVersion = "2023-06-01"
+
+// ParseLesson parses a lesson line in the format "[危険度] text".
+// Returns an error for lines that do not match the expected format.
+func ParseLesson(line string) (Lesson, error) {
+	line = strings.TrimSpace(line)
+	if !strings.HasPrefix(line, "[") {
+		return Lesson{}, fmt.Errorf("invalid lesson format (missing leading '['): %q", line)
+	}
+	end := strings.Index(line, "]")
+	if end == -1 {
+		return Lesson{}, fmt.Errorf("invalid lesson format (missing ']'): %q", line)
+	}
+	risk := RiskLevel(line[1:end])
+	text := strings.TrimSpace(line[end+1:])
+	return Lesson{Risk: risk, Text: text}, nil
+}
+
+// FormatLesson formats a lesson as "[危険度] text".
+func FormatLesson(l Lesson) string {
+	return fmt.Sprintf("[%s] %s", l.Risk, l.Text)
+}
+
+// LoadLessons reads lessons from a file.
+// Returns an empty slice (not an error) when the file does not exist.
+func LoadLessons(path string) ([]Lesson, error) {
+	data, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("read lessons file %s: %w", path, err)
+	}
+
+	var lessons []Lesson
+	scanner := bufio.NewScanner(bytes.NewReader(data))
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		l, err := ParseLesson(line)
+		if err != nil {
+			log.Printf("[lessons] skipping malformed line: %v", err)
+			continue
+		}
+		lessons = append(lessons, l)
+	}
+	return lessons, scanner.Err()
+}
+
+// SaveLessons writes the given lessons to a file, overwriting any existing content.
+func SaveLessons(path string, lessons []Lesson) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+		return fmt.Errorf("mkdir for lessons file: %w", err)
+	}
+	var sb strings.Builder
+	for _, l := range lessons {
+		sb.WriteString(FormatLesson(l))
+		sb.WriteByte('\n')
+	}
+	return os.WriteFile(path, []byte(sb.String()), 0600)
+}
+
+// AppendLesson appends a single lesson to the file.
+func AppendLesson(path string, lesson Lesson) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+		return fmt.Errorf("mkdir for lessons file: %w", err)
+	}
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0600)
+	if err != nil {
+		return fmt.Errorf("open lessons file: %w", err)
+	}
+	defer f.Close()
+	_, err = fmt.Fprintln(f, FormatLesson(lesson))
+	return err
+}
+
+// Manager handles lesson scoring, generation, and management.
+type Manager struct {
+	// DataDir is the MADFLOW data directory (e.g. ~/.madflow/MADFLOW).
+	DataDir string
+	// AnthropicAPIKey is the API key for LLM-based lesson generation and merging.
+	// If empty, template-based fallback is used for generation, and simple
+	// risk-based trimming is used instead of LLM merging.
+	AnthropicAPIKey string
+	// FeaturePrefix is the feature branch prefix (e.g. "feature/issue-").
+	FeaturePrefix string
+}
+
+// LessonsPath returns the absolute path to the lessons file.
+func (m *Manager) LessonsPath() string {
+	return filepath.Join(m.DataDir, "lessons.txt")
+}
+
+// InjectLessons returns a formatted string of all lessons suitable for
+// prepending to the Superintendent's patrol prompt.
+// Returns an empty string when no lessons exist.
+func (m *Manager) InjectLessons() string {
+	lessons, err := LoadLessons(m.LessonsPath())
+	if err != nil {
+		log.Printf("[lessons] InjectLessons: load failed: %v", err)
+		return ""
+	}
+	if len(lessons) == 0 {
+		return ""
+	}
+
+	var sb strings.Builder
+	sb.WriteString("## 過去の失敗から学んだ教訓\n\n")
+	sb.WriteString("以下は過去のIssue指示品質の採点で70点未満だったIssueから生成された教訓です。\n")
+	sb.WriteString("Issueをエンジニアに割り当てる際は必ずこれらの教訓を参照し、同じ失敗を繰り返さないようにしてください：\n\n")
+	for _, l := range lessons {
+		sb.WriteString(FormatLesson(l))
+		sb.WriteByte('\n')
+	}
+	sb.WriteByte('\n')
+	return sb.String()
+}
+
+// ProcessMergedIssue scores the issue, generates a lesson if needed, and
+// manages the lesson count. It is a no-op for local issues (id prefix "local-").
+func (m *Manager) ProcessMergedIssue(issueID, owner, repo string, issueNumber int) error {
+	// Only process GitHub-synced issues
+	if strings.HasPrefix(issueID, "local-") || owner == "" || repo == "" || issueNumber <= 0 {
+		log.Printf("[lessons] skipping local/invalid issue %s", issueID)
+		return nil
+	}
+
+	result, err := ScoreIssue(issueID, owner, repo, issueNumber)
+	if err != nil {
+		return fmt.Errorf("score issue %s: %w", issueID, err)
+	}
+
+	log.Printf("[lessons] issue %s scored %d/100 (failures: %d)", issueID, result.Score, len(result.Failures))
+
+	if result.Score >= 70 || len(result.Failures) == 0 {
+		log.Printf("[lessons] issue %s passed quality threshold (score=%d), no lesson generated", issueID, result.Score)
+		return nil
+	}
+
+	// Generate a lesson
+	lesson, err := m.generateLesson(result)
+	if err != nil {
+		log.Printf("[lessons] lesson generation failed for %s (using fallback): %v", issueID, err)
+		lesson = fallbackLesson(result.Failures)
+	}
+
+	log.Printf("[lessons] generated lesson for %s: %s", issueID, FormatLesson(lesson))
+
+	// Append the lesson to the file
+	if err := AppendLesson(m.LessonsPath(), lesson); err != nil {
+		return fmt.Errorf("append lesson: %w", err)
+	}
+
+	// Manage the 15-lesson limit
+	if err := m.manageLessonsCount(); err != nil {
+		log.Printf("[lessons] manageLessonsCount: %v (continuing)", err)
+	}
+
+	return nil
+}
+
+// ScoreIssue scores the instruction quality of an issue using GitHub API.
+// Returns an error for local issues (owner == "").
+func ScoreIssue(issueID, owner, repo string, issueNumber int) (*ScoringResult, error) {
+	if owner == "" || repo == "" || issueNumber <= 0 {
+		return nil, fmt.Errorf("cannot score local issue %q: missing GitHub coordinates", issueID)
+	}
+
+	result := &ScoringResult{
+		IssueID: issueID,
+		Score:   100,
+	}
+
+	fullRepo := fmt.Sprintf("%s/%s", owner, repo)
+
+	// Check for derived/fix issues (-30, 高)
+	if hasDerivedIssues(fullRepo, issueNumber) {
+		result.Failures = append(result.Failures, Failure{
+			Description: "派生・修正Issueが発生した",
+			Risk:        RiskHigh,
+			Points:      30,
+		})
+		result.Score -= 30
+	}
+
+	// Check for [Clarification Needed] comments (-20, 中)
+	if hasClarificationNeeded(fullRepo, issueNumber) {
+		result.Failures = append(result.Failures, Failure{
+			Description: "[Clarification Needed] コメントが存在した",
+			Risk:        RiskMedium,
+			Points:      20,
+		})
+		result.Score -= 20
+	}
+
+	// Check for Superintendent direct implementation (-20, 中)
+	featureHead := fmt.Sprintf("feature/issue-%s", issueID)
+	if hasSuperintendentDirectImpl(fullRepo, featureHead) {
+		result.Failures = append(result.Failures, Failure{
+			Description: "Superintendentが直接実装した",
+			Risk:        RiskMedium,
+			Points:      20,
+		})
+		result.Score -= 20
+	}
+
+	// Check for multiple PRs (-15, 低)
+	if hasMultiplePRs(fullRepo, featureHead) {
+		result.Failures = append(result.Failures, Failure{
+			Description: "PRが2本以上作成された",
+			Risk:        RiskLow,
+			Points:      15,
+		})
+		result.Score -= 15
+	}
+
+	if result.Score < 0 {
+		result.Score = 0
+	}
+
+	return result, nil
+}
+
+// hasDerivedIssues checks whether any GitHub issues reference the given issue number.
+func hasDerivedIssues(fullRepo string, issueNumber int) bool {
+	query := fmt.Sprintf("%d in:body", issueNumber)
+	cmd := exec.Command("gh", "issue", "list", "-R", fullRepo,
+		"--search", query,
+		"--json", "number",
+		"--limit", "10",
+		"--state", "all",
+	)
+	out, err := cmd.Output()
+	if err != nil {
+		return false
+	}
+	var issues []struct{ Number int }
+	if err := json.Unmarshal(out, &issues); err != nil {
+		return false
+	}
+	// Filter out the original issue itself
+	for _, iss := range issues {
+		if iss.Number != issueNumber {
+			return true
+		}
+	}
+	return false
+}
+
+// hasClarificationNeeded checks whether the issue has a [Clarification Needed] comment.
+func hasClarificationNeeded(fullRepo string, issueNumber int) bool {
+	endpoint := fmt.Sprintf("repos/%s/issues/%d/comments", fullRepo, issueNumber)
+	cmd := exec.Command("gh", "api", endpoint, "--jq", ".[].body")
+	out, err := cmd.Output()
+	if err != nil {
+		return false
+	}
+	return strings.Contains(string(out), "[Clarification Needed]")
+}
+
+// hasSuperintendentDirectImpl checks whether any PR for this branch was
+// implemented directly by the Superintendent (indicated by PR body text).
+func hasSuperintendentDirectImpl(fullRepo, featureHead string) bool {
+	cmd := exec.Command("gh", "pr", "list",
+		"-R", fullRepo,
+		"--search", fmt.Sprintf("head:%s", featureHead),
+		"--json", "body",
+		"--state", "all",
+	)
+	out, err := cmd.Output()
+	if err != nil {
+		return false
+	}
+	body := string(out)
+	return strings.Contains(body, "Superintendent implemented directly") ||
+		strings.Contains(body, "Superintendentが直接実装") ||
+		strings.Contains(body, "The Superintendent implemented directly")
+}
+
+// hasMultiplePRs checks whether 2 or more PRs were created for this feature branch.
+func hasMultiplePRs(fullRepo, featureHead string) bool {
+	cmd := exec.Command("gh", "pr", "list",
+		"-R", fullRepo,
+		"--search", fmt.Sprintf("head:%s", featureHead),
+		"--json", "number",
+		"--state", "all",
+		"--limit", "10",
+	)
+	out, err := cmd.Output()
+	if err != nil {
+		return false
+	}
+	var prs []struct{ Number int }
+	if err := json.Unmarshal(out, &prs); err != nil {
+		return false
+	}
+	return len(prs) >= 2
+}
+
+// generateLesson calls the Anthropic API to generate a 1-line lesson in Japanese.
+// Returns an error when the API key is not available or the call fails.
+func (m *Manager) generateLesson(result *ScoringResult) (Lesson, error) {
+	apiKey := m.AnthropicAPIKey
+	if apiKey == "" {
+		apiKey = os.Getenv("ANTHROPIC_API_KEY")
+	}
+	if apiKey == "" {
+		return Lesson{}, fmt.Errorf("ANTHROPIC_API_KEY not set")
+	}
+
+	// Determine the highest-risk failure
+	highestRisk := RiskLow
+	for _, f := range result.Failures {
+		if riskOrder[f.Risk] > riskOrder[highestRisk] {
+			highestRisk = f.Risk
+		}
+	}
+
+	var failureLines strings.Builder
+	for _, f := range result.Failures {
+		fmt.Fprintf(&failureLines, "- [%s] %s\n", f.Risk, f.Description)
+	}
+
+	prompt := fmt.Sprintf(`あなたはソフトウェア開発プロジェクトの品質改善アドバイザーです。
+
+以下のIssue指示品質の採点結果（%d/100点）を見て、同じ失敗を繰り返さないための教訓を1行の日本語で生成してください。
+
+検出された失敗：
+%s
+条件：
+- 教訓は「次回のIssue指示でどうすればよかったか」を具体的に述べること
+- 1行、50文字以内で簡潔に
+- 「〜すること」「〜を確認すること」などの行動指針の形式で
+- 教訓テキストのみを出力（角括弧や危険度は含めない）
+
+教訓：`, result.Score, failureLines.String())
+
+	text, err := callAnthropicSimple(apiKey, prompt)
+	if err != nil {
+		return Lesson{}, err
+	}
+
+	text = strings.TrimSpace(text)
+	// Remove any accidental "[高]" prefix the model might add
+	if i := strings.Index(text, "] "); i >= 0 && strings.HasPrefix(text, "[") {
+		text = strings.TrimSpace(text[i+2:])
+	}
+
+	return Lesson{Risk: highestRisk, Text: text}, nil
+}
+
+// fallbackLesson returns a template-based lesson when the LLM is unavailable.
+func fallbackLesson(failures []Failure) Lesson {
+	// Use the highest-risk failure to generate the lesson
+	highestRisk := RiskLow
+	var topFailure Failure
+	for _, f := range failures {
+		if riskOrder[f.Risk] > riskOrder[highestRisk] {
+			highestRisk = f.Risk
+			topFailure = f
+		}
+	}
+
+	templates := map[string]string{
+		"派生・修正Issueが発生した":              "Issueの仕様を明確にしてからEngineerに渡し、派生Issueが発生しないようにすること",
+		"[Clarification Needed] コメントが存在した": "仕様が曖昧なままEngineerに渡さず、先に仕様を人間に確認してから指示すること",
+		"Superintendentが直接実装した":           "EngineerやOrchestratorが応答しない場合の対応手順を見直し、直接実装に頼らないようにすること",
+		"PRが2本以上作成された":                  "重複PRが発生しないようブランチとPR管理を徹底し、作業開始前に既存PRを確認すること",
+	}
+
+	if text, ok := templates[topFailure.Description]; ok {
+		return Lesson{Risk: highestRisk, Text: text}
+	}
+	return Lesson{Risk: highestRisk, Text: "Issueの指示品質を向上させ、エンジニアが迷わず実装できるよう仕様を明確にすること"}
+}
+
+// manageLessonsCount ensures there are at most maxLessons lessons.
+// Uses LLM to merge similar lessons first, then falls back to trimming.
+func (m *Manager) manageLessonsCount() error {
+	lessons, err := LoadLessons(m.LessonsPath())
+	if err != nil {
+		return err
+	}
+	if len(lessons) <= maxLessons {
+		return nil
+	}
+
+	log.Printf("[lessons] %d lessons exceed limit of %d, consolidating...", len(lessons), maxLessons)
+
+	// Try LLM-based merging first
+	apiKey := m.AnthropicAPIKey
+	if apiKey == "" {
+		apiKey = os.Getenv("ANTHROPIC_API_KEY")
+	}
+
+	if apiKey != "" {
+		merged, err := mergeLessonsWithLLM(apiKey, lessons)
+		if err != nil {
+			log.Printf("[lessons] LLM merging failed: %v, falling back to trim", err)
+		} else {
+			lessons = merged
+			log.Printf("[lessons] LLM merging resulted in %d lessons", len(lessons))
+		}
+	}
+
+	// If still over limit, trim by risk level
+	if len(lessons) > maxLessons {
+		lessons = trimLessons(lessons)
+		log.Printf("[lessons] trimmed to %d lessons", len(lessons))
+	}
+
+	return SaveLessons(m.LessonsPath(), lessons)
+}
+
+// mergeLessonsWithLLM asks the Anthropic API to merge semantically similar lessons.
+func mergeLessonsWithLLM(apiKey string, lessons []Lesson) ([]Lesson, error) {
+	var sb strings.Builder
+	for i, l := range lessons {
+		fmt.Fprintf(&sb, "%d. %s\n", i+1, FormatLesson(l))
+	}
+
+	prompt := fmt.Sprintf(`以下は%d件の教訓リストです。意味が近い教訓を統合して、できるだけ少ない件数にまとめてください。
+
+元の教訓リスト：
+%s
+ルール：
+- 意味が重複または非常に近い教訓を1行に統合する
+- 統合後も危険度は元のうち最も高いものを使用する
+- 統合により内容が失われないよう、統合後のテキストに重要な要点を含める
+- 出力形式: 各行に "[危険度] 教訓テキスト" の形式で教訓を1件ずつ出力
+- 危険度は「高」「中」「低」のいずれか
+- テキストのみ出力（番号やコメント不要）
+
+統合後の教訓リスト：`, len(lessons), sb.String())
+
+	text, err := callAnthropicSimple(apiKey, prompt)
+	if err != nil {
+		return nil, err
+	}
+
+	var merged []Lesson
+	scanner := bufio.NewScanner(strings.NewReader(text))
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		l, err := ParseLesson(line)
+		if err != nil {
+			log.Printf("[lessons] mergeLessonsWithLLM: skipping unparseable line %q: %v", line, err)
+			continue
+		}
+		merged = append(merged, l)
+	}
+
+	if len(merged) == 0 {
+		return nil, fmt.Errorf("LLM returned no parseable lessons")
+	}
+
+	// Safety check: merged should not exceed original count
+	if len(merged) >= len(lessons) {
+		return nil, fmt.Errorf("LLM did not reduce lesson count (%d -> %d)", len(lessons), len(merged))
+	}
+
+	return merged, nil
+}
+
+// trimLessons removes lowest-risk lessons until at most maxLessons remain.
+// Within the same risk level, earlier (older) lessons are removed first.
+func trimLessons(lessons []Lesson) []Lesson {
+	if len(lessons) <= maxLessons {
+		return lessons
+	}
+
+	// Count how many to remove
+	toRemove := len(lessons) - maxLessons
+
+	// Build a list sorted by risk ascending (lowest risk first = first to remove)
+	// Preserve original order within same risk level.
+	type indexedLesson struct {
+		idx    int
+		lesson Lesson
+	}
+	indexed := make([]indexedLesson, len(lessons))
+	for i, l := range lessons {
+		indexed[i] = indexedLesson{idx: i, lesson: l}
+	}
+
+	// Mark lessons for removal: prefer lowest risk, then oldest (smallest index)
+	removed := make(map[int]bool)
+	for risk := range []RiskLevel{RiskLow, RiskMedium, RiskHigh} {
+		_ = risk // iterate in ascending priority
+	}
+
+	// Simple approach: iterate low→medium→high and mark for removal
+	for _, checkRisk := range []RiskLevel{RiskLow, RiskMedium, RiskHigh} {
+		for _, il := range indexed {
+			if toRemove == 0 {
+				break
+			}
+			if il.lesson.Risk == checkRisk {
+				removed[il.idx] = true
+				toRemove--
+			}
+		}
+		if toRemove == 0 {
+			break
+		}
+	}
+
+	var result []Lesson
+	for i, l := range lessons {
+		if !removed[i] {
+			result = append(result, l)
+		}
+	}
+	return result
+}
+
+// --- Anthropic API helpers ---
+
+type simpleAnthropicRequest struct {
+	Model     string                   `json:"model"`
+	MaxTokens int                      `json:"max_tokens"`
+	Messages  []simpleAnthropicMessage `json:"messages"`
+}
+
+type simpleAnthropicMessage struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+type simpleAnthropicResponse struct {
+	Content []struct {
+		Type string `json:"type"`
+		Text string `json:"text"`
+	} `json:"content"`
+	Error *struct {
+		Type    string `json:"type"`
+		Message string `json:"message"`
+	} `json:"error,omitempty"`
+}
+
+// callAnthropicSimple makes a simple (non-agentic) call to the Anthropic API.
+func callAnthropicSimple(apiKey, prompt string) (string, error) {
+	reqBody := simpleAnthropicRequest{
+		Model:     lessonsMgmtModel,
+		MaxTokens: 1024,
+		Messages: []simpleAnthropicMessage{
+			{Role: "user", Content: prompt},
+		},
+	}
+
+	data, err := json.Marshal(reqBody)
+	if err != nil {
+		return "", fmt.Errorf("marshal anthropic request: %w", err)
+	}
+
+	client := &http.Client{Timeout: 60 * time.Second}
+	req, err := http.NewRequest(http.MethodPost, anthropicEndpoint, bytes.NewReader(data))
+	if err != nil {
+		return "", fmt.Errorf("create anthropic request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("x-api-key", apiKey)
+	req.Header.Set("anthropic-version", anthropicAPIVersion)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("anthropic API call: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("read anthropic response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("anthropic API HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	var apiResp simpleAnthropicResponse
+	if err := json.Unmarshal(body, &apiResp); err != nil {
+		return "", fmt.Errorf("unmarshal anthropic response: %w", err)
+	}
+
+	if apiResp.Error != nil {
+		return "", fmt.Errorf("anthropic API error (%s): %s", apiResp.Error.Type, apiResp.Error.Message)
+	}
+
+	for _, block := range apiResp.Content {
+		if block.Type == "text" && block.Text != "" {
+			return block.Text, nil
+		}
+	}
+
+	return "", fmt.Errorf("no text content in anthropic response")
+}

--- a/internal/lessons/lessons_test.go
+++ b/internal/lessons/lessons_test.go
@@ -1,0 +1,300 @@
+package lessons
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestParseLesson(t *testing.T) {
+	tests := []struct {
+		input   string
+		wantRisk RiskLevel
+		wantText string
+		wantErr  bool
+	}{
+		{"[高] バグ修正Issueは症状への対処だけでなく再発防止策まで含めること", RiskHigh, "バグ修正Issueは症状への対処だけでなく再発防止策まで含めること", false},
+		{"[中] 仕様が曖昧なままEngineerに渡さず、先に人間に確認を取ること", RiskMedium, "仕様が曖昧なままEngineerに渡さず、先に人間に確認を取ること", false},
+		{"[低] PRを複数作成しないようにブランチ管理を徹底すること", RiskLow, "PRを複数作成しないようにブランチ管理を徹底すること", false},
+		{"invalid line", "", "", true},
+		{"", "", "", true},
+		{"[高]", RiskHigh, "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got, err := ParseLesson(tt.input)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("ParseLesson(%q) expected error, got nil", tt.input)
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("ParseLesson(%q) unexpected error: %v", tt.input, err)
+				return
+			}
+			if got.Risk != tt.wantRisk {
+				t.Errorf("ParseLesson(%q).Risk = %q, want %q", tt.input, got.Risk, tt.wantRisk)
+			}
+			if got.Text != tt.wantText {
+				t.Errorf("ParseLesson(%q).Text = %q, want %q", tt.input, got.Text, tt.wantText)
+			}
+		})
+	}
+}
+
+func TestFormatLesson(t *testing.T) {
+	l := Lesson{Risk: RiskHigh, Text: "テスト教訓"}
+	got := FormatLesson(l)
+	want := "[高] テスト教訓"
+	if got != want {
+		t.Errorf("FormatLesson() = %q, want %q", got, want)
+	}
+}
+
+func TestLoadSaveLessons(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "lessons.txt")
+
+	// Load from non-existent file should return empty
+	lessons, err := LoadLessons(path)
+	if err != nil {
+		t.Fatalf("LoadLessons non-existent: %v", err)
+	}
+	if len(lessons) != 0 {
+		t.Errorf("LoadLessons non-existent: got %d lessons, want 0", len(lessons))
+	}
+
+	// Save and reload
+	original := []Lesson{
+		{Risk: RiskHigh, Text: "高い教訓"},
+		{Risk: RiskMedium, Text: "中程度の教訓"},
+		{Risk: RiskLow, Text: "低い教訓"},
+	}
+
+	if err := SaveLessons(path, original); err != nil {
+		t.Fatalf("SaveLessons: %v", err)
+	}
+
+	loaded, err := LoadLessons(path)
+	if err != nil {
+		t.Fatalf("LoadLessons: %v", err)
+	}
+	if len(loaded) != len(original) {
+		t.Fatalf("LoadLessons: got %d lessons, want %d", len(loaded), len(original))
+	}
+	for i, l := range loaded {
+		if l.Risk != original[i].Risk || l.Text != original[i].Text {
+			t.Errorf("LoadLessons[%d]: got %+v, want %+v", i, l, original[i])
+		}
+	}
+}
+
+func TestAppendLesson(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "lessons.txt")
+
+	if err := AppendLesson(path, Lesson{Risk: RiskHigh, Text: "first"}); err != nil {
+		t.Fatalf("AppendLesson: %v", err)
+	}
+	if err := AppendLesson(path, Lesson{Risk: RiskMedium, Text: "second"}); err != nil {
+		t.Fatalf("AppendLesson: %v", err)
+	}
+
+	lessons, err := LoadLessons(path)
+	if err != nil {
+		t.Fatalf("LoadLessons: %v", err)
+	}
+	if len(lessons) != 2 {
+		t.Fatalf("got %d lessons, want 2", len(lessons))
+	}
+	if lessons[0].Text != "first" || lessons[1].Text != "second" {
+		t.Errorf("unexpected lesson order: %v", lessons)
+	}
+}
+
+func TestInjectLessons_Empty(t *testing.T) {
+	dir := t.TempDir()
+	m := &Manager{DataDir: dir}
+
+	result := m.InjectLessons()
+	if result != "" {
+		t.Errorf("InjectLessons with no lessons: got %q, want empty", result)
+	}
+}
+
+func TestInjectLessons_WithLessons(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "lessons.txt")
+
+	lessons := []Lesson{
+		{Risk: RiskHigh, Text: "重要な教訓"},
+		{Risk: RiskMedium, Text: "中程度の教訓"},
+	}
+	if err := SaveLessons(path, lessons); err != nil {
+		t.Fatalf("SaveLessons: %v", err)
+	}
+
+	m := &Manager{DataDir: dir}
+	result := m.InjectLessons()
+
+	if result == "" {
+		t.Error("InjectLessons with lessons: got empty string")
+	}
+	if !strings.Contains(result, "[高] 重要な教訓") {
+		t.Errorf("InjectLessons: missing high-risk lesson: %q", result)
+	}
+	if !strings.Contains(result, "[中] 中程度の教訓") {
+		t.Errorf("InjectLessons: missing medium-risk lesson: %q", result)
+	}
+}
+
+func TestTrimLessons(t *testing.T) {
+	// Create 17 lessons: some high, some medium, some low
+	// We need to remove 2 (17-15=2), and should remove lowest-risk first (oldest low-risk).
+	lessons := []Lesson{
+		{Risk: RiskHigh, Text: "high1"},
+		{Risk: RiskHigh, Text: "high2"},
+		{Risk: RiskHigh, Text: "high3"},
+		{Risk: RiskHigh, Text: "high4"},
+		{Risk: RiskHigh, Text: "high5"},
+		{Risk: RiskMedium, Text: "med1"},
+		{Risk: RiskMedium, Text: "med2"},
+		{Risk: RiskMedium, Text: "med3"},
+		{Risk: RiskMedium, Text: "med4"},
+		{Risk: RiskMedium, Text: "med5"},
+		{Risk: RiskLow, Text: "low1"}, // oldest low-risk → removed first
+		{Risk: RiskLow, Text: "low2"}, // second oldest → removed second
+		{Risk: RiskLow, Text: "low3"},
+		{Risk: RiskLow, Text: "low4"},
+		{Risk: RiskLow, Text: "low5"},
+		{Risk: RiskLow, Text: "low6"},
+		{Risk: RiskLow, Text: "low7"},
+	}
+
+	trimmed := trimLessons(lessons)
+	if len(trimmed) != maxLessons {
+		t.Errorf("trimLessons: got %d lessons, want %d", len(trimmed), maxLessons)
+	}
+
+	// The oldest 2 low-risk lessons (low1, low2) should have been removed.
+	for _, l := range trimmed {
+		if l.Risk == RiskLow && (l.Text == "low1" || l.Text == "low2") {
+			t.Errorf("trimLessons: oldest low-risk lesson should have been removed: %+v", l)
+		}
+	}
+
+	// All high and medium lessons should remain.
+	highCount, medCount := 0, 0
+	for _, l := range trimmed {
+		switch l.Risk {
+		case RiskHigh:
+			highCount++
+		case RiskMedium:
+			medCount++
+		}
+	}
+	if highCount != 5 {
+		t.Errorf("trimLessons: got %d high-risk lessons, want 5", highCount)
+	}
+	if medCount != 5 {
+		t.Errorf("trimLessons: got %d medium-risk lessons, want 5", medCount)
+	}
+}
+
+func TestTrimLessons_ExcessLowRisk(t *testing.T) {
+	// 20 low-risk lessons: trim to 15 (remove oldest 5)
+	lessons := make([]Lesson, 20)
+	for i := range lessons {
+		lessons[i] = Lesson{Risk: RiskLow, Text: fmt.Sprintf("low%d", i+1)}
+	}
+
+	trimmed := trimLessons(lessons)
+	if len(trimmed) != maxLessons {
+		t.Errorf("trimLessons: got %d lessons, want %d", len(trimmed), maxLessons)
+	}
+	// low1..low5 should be removed, low6..low20 remain
+	for _, l := range trimmed {
+		for _, removed := range []string{"low1", "low2", "low3", "low4", "low5"} {
+			if l.Text == removed {
+				t.Errorf("trimLessons: expected %q to be removed", removed)
+			}
+		}
+	}
+}
+
+func TestScoreIssue_LocalIssue(t *testing.T) {
+	// Local issues should not be scored
+	result, err := ScoreIssue("local-001", "", "", 0)
+	if err == nil {
+		t.Errorf("ScoreIssue local issue: expected error, got result=%+v", result)
+	}
+}
+
+func TestFallbackLesson_DerivedIssue(t *testing.T) {
+	failures := []Failure{
+		{Description: "派生・修正Issueが発生", Risk: RiskHigh, Points: 30},
+	}
+	lesson := fallbackLesson(failures)
+	if lesson.Risk != RiskHigh {
+		t.Errorf("fallbackLesson: risk = %q, want 高", lesson.Risk)
+	}
+	if lesson.Text == "" {
+		t.Error("fallbackLesson: empty text")
+	}
+}
+
+func TestFallbackLesson_MultipleFailures(t *testing.T) {
+	failures := []Failure{
+		{Description: "Superintendentが直接実装した", Risk: RiskMedium, Points: 20},
+		{Description: "PRが2本以上作成された", Risk: RiskLow, Points: 15},
+	}
+	lesson := fallbackLesson(failures)
+	// The highest risk failure should determine the lesson risk
+	if lesson.Risk != RiskMedium {
+		t.Errorf("fallbackLesson: risk = %q, want 中", lesson.Risk)
+	}
+}
+
+func TestManagerProcessMergedIssue_LocalIssue(t *testing.T) {
+	dir := t.TempDir()
+	m := &Manager{DataDir: dir}
+
+	// Local issues should be skipped gracefully
+	err := m.ProcessMergedIssue("local-001", "", "", 0)
+	if err != nil {
+		t.Errorf("ProcessMergedIssue local-001: expected nil error, got %v", err)
+	}
+
+	// No lessons file should be created
+	if _, err := os.Stat(filepath.Join(dir, "lessons.txt")); !os.IsNotExist(err) {
+		t.Error("lessons.txt should not be created for local issues")
+	}
+}
+
+func TestManageLessonsCount_Under15(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "lessons.txt")
+	m := &Manager{DataDir: dir}
+
+	lessons := make([]Lesson, 10)
+	for i := range lessons {
+		lessons[i] = Lesson{Risk: RiskMedium, Text: "教訓"}
+	}
+	if err := SaveLessons(path, lessons); err != nil {
+		t.Fatal(err)
+	}
+
+	// Should not error even without API key
+	if err := m.manageLessonsCount(); err != nil {
+		t.Errorf("manageLessonsCount under 15: unexpected error: %v", err)
+	}
+
+	loaded, _ := LoadLessons(path)
+	if len(loaded) != 10 {
+		t.Errorf("manageLessonsCount under 15: got %d lessons, want 10", len(loaded))
+	}
+}

--- a/internal/lessons/lessons_test.go
+++ b/internal/lessons/lessons_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestParseLesson(t *testing.T) {
 	tests := []struct {
-		input   string
+		input    string
 		wantRisk RiskLevel
 		wantText string
 		wantErr  bool

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -19,6 +19,7 @@ import (
 	"github.com/ytnobody/madflow/internal/git"
 	"github.com/ytnobody/madflow/internal/github"
 	"github.com/ytnobody/madflow/internal/issue"
+	"github.com/ytnobody/madflow/internal/lessons"
 	"github.com/ytnobody/madflow/internal/team"
 )
 
@@ -30,13 +31,14 @@ type Orchestrator struct {
 	dataDir    string
 	promptDir  string
 
-	store        *issue.Store
-	chatLog      *chatlog.ChatLog
-	teams        *team.Manager
-	repos        map[string]*git.Repo // name -> repo
-	dormancy     *agent.Dormancy
-	throttle     *agent.Throttle
-	idleDetector *github.IdleDetector // shared idle state for GitHub polling
+	store          *issue.Store
+	chatLog        *chatlog.ChatLog
+	teams          *team.Manager
+	repos          map[string]*git.Repo // name -> repo
+	dormancy       *agent.Dormancy
+	throttle       *agent.Throttle
+	idleDetector   *github.IdleDetector // shared idle state for GitHub polling
+	lessonsManager *lessons.Manager     // manages failure lessons for superintendent
 
 	// patrolResetCh receives a signal when the superintendent reports PATROL_COMPLETE,
 	// allowing runIssuePatrol to reset the interval timer immediately.
@@ -66,6 +68,11 @@ func New(cfg *config.Config, dataDir, promptDir string) *Orchestrator {
 
 	probeInterval := time.Duration(cfg.Agent.DormancyProbeMinutes) * time.Minute
 
+	featurePrefix := cfg.Branches.FeaturePrefix
+	if featurePrefix == "" {
+		featurePrefix = "feature/issue-"
+	}
+
 	orc := &Orchestrator{
 		cfg:           cfg,
 		dataDir:       dataDir,
@@ -77,6 +84,10 @@ func New(cfg *config.Config, dataDir, promptDir string) *Orchestrator {
 		throttle:      agent.NewThrottle(cfg.Agent.GeminiRPM),
 		idleDetector:  idleDetector,
 		patrolResetCh: make(chan struct{}, 1),
+		lessonsManager: &lessons.Manager{
+			DataDir:       dataDir,
+			FeaturePrefix: featurePrefix,
+		},
 	}
 
 	orc.teams = team.NewManager(orc, cfg.Agent.MaxTeams)
@@ -880,10 +891,18 @@ func (o *Orchestrator) handlePRMerged(issueID string) {
 	}
 
 	// Close the GitHub issue via gh CLI (only for GitHub-synced issues with a URL)
+	// Also score the issue and generate a lesson for the Superintendent.
 	if iss.URL != "" {
 		owner, repo, number, err := github.ParseID(issueID)
 		if err == nil {
 			o.closeGitHubIssue(owner, repo, number)
+			// Score instruction quality and generate a lesson asynchronously so
+			// that the gh CLI calls don't block the merge handler.
+			go func() {
+				if err := o.lessonsManager.ProcessMergedIssue(issueID, owner, repo, number); err != nil {
+					log.Printf("[orchestrator] lessons: ProcessMergedIssue(%s) failed: %v", issueID, err)
+				}
+			}()
 		} else {
 			log.Printf("[orchestrator] PR merged: cannot parse issue ID %s for gh close: %v", issueID, err)
 		}
@@ -1258,7 +1277,10 @@ func (o *Orchestrator) runIssuePatrol(ctx context.Context) {
 			}
 
 			log.Println("[issue-patrol] sending issue patrol request to superintendent")
-			o.appendOrLog("superintendent", "orchestrator", issuePatrolPrompt)
+			// Prepend any accumulated lessons so the Superintendent can reference
+			// past failure patterns when writing new issue instructions.
+			patrolMsg := o.lessonsManager.InjectLessons() + issuePatrolPrompt
+			o.appendOrLog("superintendent", "orchestrator", patrolMsg)
 			lastSentFingerprint = current
 			timer.Reset(interval)
 		}


### PR DESCRIPTION
## Summary

- PRマージ時にIssue指示品質を採点し、70点未満の場合に失敗教訓を生成・保存する新しい`internal/lessons`パッケージを追加
- `handlePRMerged`にて非同期で`ProcessMergedIssue`を呼び出し、採点・教訓生成・ファイル保存を実行
- `runIssuePatrol`でpatrol送信前に`InjectLessons`を呼び出し、教訓リストをSuperintendentのプロンプトに注入

## Test plan

- [ ] `go test ./internal/lessons/...` passes
- [ ] `go test ./...` passes (all packages)
- [ ] Build passes with `go build ./...`

Issue: ytnobody-MADFLOW-230