### PR TITLE
ytnobody-MADFLOW-235: ブランチ命名規則とworktreeパスのユーザー名前空間対応

### DIFF
--- a/docs/specs/user-namespace-branch-worktree.md
+++ b/docs/specs/user-namespace-branch-worktree.md
@@ -1,0 +1,103 @@
+# Spec: User-Namespaced Branch Names and Worktree Paths
+
+## Overview
+
+Branch names and worktree paths now include the GitHub login name, preventing resource
+collisions when multiple users run MADFLOW against the same repository.
+
+This implements §3.3 and §3.4 of the multi-user support requirements document.
+It builds on §3.1/§3.2 (GitHub account auto-detection, issue #234).
+
+## Background
+
+Previously, all MADFLOW users shared the same branch namespace (`feature/issue-*`) and
+worktree directory layout (`.worktrees/team-N/`). When two users worked on the same
+repository, their branches and worktree directories would collide.
+
+The fix is to prefix both branch names and worktree paths with the authenticated
+GitHub login, creating a per-user namespace.
+
+## Behavior
+
+### Branch Naming (§3.3)
+
+| | Format |
+|---|---|
+| Before | `feature/issue-{issueID}` |
+| After  | `madflow/{gh_login}/issue-{issueID}` |
+
+The `FeaturePrefix` field in `BranchConfig` defaults to `madflow/{gh_login}/issue-` when
+the GitHub CLI is authenticated. If `gh api user` fails or returns no login, the prefix
+falls back to `feature/issue-` for backward compatibility.
+
+If `feature_prefix` is explicitly set in `madflow.toml`, that value is used as-is
+(no auto-namespacing). This allows per-project override.
+
+### Worktree Path (§3.4)
+
+| | Path |
+|---|---|
+| Before | `{REPO_PATH}/.worktrees/team-{teamNum}/` |
+| After  | `{REPO_PATH}/.worktrees/{gh_login}/issue-{issueID}/` |
+
+Engineers are instructed in their system prompt to create worktrees at the new path.
+The `{{GH_LOGIN}}` template variable is substituted from `cfg.GhLogin` when the agent
+is created.
+
+### GhLogin Field
+
+A new `GhLogin string` field is added to `Config`. It is a runtime-only field (not a TOML
+key) populated by `resolveGitHubLogin()` at load time. It represents the authenticated
+GitHub CLI user and is used for:
+1. Setting the `FeaturePrefix` default
+2. Substituting `{{GH_LOGIN}}` in agent prompts
+
+### Branch Name Validation
+
+A new `ValidateSafeBranchName(name string) error` function is added to `internal/git`.
+Unlike `ValidateSafeName`, it allows `/` as a namespace separator. Each component separated
+by `/` is validated individually (no `..`, no backslash, no null byte, no empty component).
+
+`PrepareWorktree` is updated to use `ValidateSafeBranchName` instead of `ValidateSafeName`.
+
+### Worktree Cleanup
+
+The orchestrator's worktree cleanup logic is updated to handle both legacy (`team-N`) and
+new-style (`{gh_login}/issue-{issueID}`) worktree paths.
+
+- **Startup cleanup** (`cleanStaleWorktrees`): cleans both `team-*` and `{gh_login}/` dirs
+- **Team disband cleanup** (`cleanTeamWorktrees`): removes `{gh_login}/issue-{issueID}/` for new-style
+- **Periodic cleanup** (`runWorktreeCleanup`): tracks active paths as `{gh_login}/issue-{issueID}`
+
+`CleanOrphanedWorktrees` gains a `ghLogin string` parameter. When non-empty, it also
+scans the `{ghLogin}/` namespace directory for orphaned worktrees.
+
+## Affected Files
+
+- `internal/config/config.go` — add `GhLogin` field; set `FeaturePrefix` after login detection
+- `internal/agent/prompt.go` — add `GhLogin` to `PromptVars`; add `{{GH_LOGIN}}` substitution
+- `internal/orchestrator/orchestrator.go` — pass `GhLogin` to prompts; update cleanup logic
+- `internal/git/git.go` — add `ValidateSafeBranchName`; update `CleanOrphanedWorktrees`
+- `prompts/engineer.md` — update worktree path and branch name templates
+- `internal/config/config_test.go` — update FeaturePrefix default test
+- `internal/git/git_test.go` — add `ValidateSafeBranchName` tests; update cleanup tests
+
+## Backward Compatibility
+
+- Existing configs with explicit `feature_prefix` continue to work unchanged.
+- When `gh` CLI is unavailable, the prefix falls back to `feature/issue-`.
+- Old-style `team-N` worktrees are still cleaned up by startup and orphan cleanup.
+
+## Examples
+
+### Branch Names
+
+With `gh_login = "alice"` and `issueID = "myorg-REPO-42"`:
+- Feature prefix: `madflow/alice/issue-`
+- Branch name: `madflow/alice/issue-myorg-REPO-42`
+
+### Worktree Paths
+
+With `gh_login = "alice"` and `issueID = "myorg-REPO-42"`:
+- Old: `/path/to/repo/.worktrees/team-1/`
+- New: `/path/to/repo/.worktrees/alice/issue-myorg-REPO-42/`

--- a/internal/agent/prompt.go
+++ b/internal/agent/prompt.go
@@ -19,6 +19,10 @@ type PromptVars struct {
 	FeaturePrefix string
 	TeamNum       string
 	RepoPath      string
+	// GhLogin is the GitHub login of the authenticated user (e.g. "alice").
+	// Substituted as {{GH_LOGIN}} in templates. Used to construct the namespaced
+	// worktree path: {RepoPath}/.worktrees/{GhLogin}/issue-<issueID>.
+	GhLogin string
 }
 
 // promptFileNames maps roles to their prompt template filenames.
@@ -65,6 +69,7 @@ func substituteVars(content string, vars PromptVars) string {
 		"{{FEATURE_PREFIX}}": vars.FeaturePrefix,
 		"{{TEAM_NUM}}":       vars.TeamNum,
 		"{{REPO_PATH}}":      vars.RepoPath,
+		"{{GH_LOGIN}}":       vars.GhLogin,
 	}
 
 	for placeholder, value := range replacements {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -28,6 +28,12 @@ type Config struct {
 	// Leaving it empty with GitHub integration active and `gh` not authenticated
 	// will cause MADFLOW to deny all incoming GitHub events.
 	AuthorizedUsers []string `toml:"authorized_users,omitempty"`
+	// GhLogin is the GitHub login name of the authenticated user, auto-detected
+	// at startup via `gh api user --jq '.login'`. It is a runtime-only field
+	// (not read from TOML) and is used to namespace branch names and worktree
+	// paths per user (e.g. "madflow/{gh_login}/issue-{id}").
+	// Empty if the GitHub CLI is unavailable or not authenticated.
+	GhLogin string `toml:"-"`
 }
 
 type ProjectConfig struct {
@@ -147,6 +153,7 @@ func Load(path string) (*Config, error) {
 	}
 
 	setDefaults(&cfg)
+	applyGhLogin(&cfg)
 	warnDefaults(&cfg)
 	autoPopulateAuthorizedUsers(&cfg)
 
@@ -200,9 +207,8 @@ func setDefaults(cfg *Config) {
 	if cfg.Branches.Develop == "" {
 		cfg.Branches.Develop = "develop"
 	}
-	if cfg.Branches.FeaturePrefix == "" {
-		cfg.Branches.FeaturePrefix = "feature/issue-"
-	}
+	// FeaturePrefix default is applied after GhLogin is resolved in applyGhLogin.
+	// Leave it empty here so applyGhLogin can detect whether the user set it explicitly.
 	if cfg.GitHub != nil && cfg.GitHub.SyncIntervalMinutes == 0 {
 		cfg.GitHub.SyncIntervalMinutes = 15
 	}
@@ -255,7 +261,22 @@ func resolveGitHubLogin() string {
 	return strings.TrimSpace(string(out))
 }
 
-// autoPopulateAuthorizedUsers detects the GitHub login and populates
+// applyGhLogin resolves the GitHub login and applies it to cfg.GhLogin and,
+// when FeaturePrefix was not explicitly set in the config file, sets the
+// namespaced default: "madflow/{gh_login}/issue-".
+// Falls back to "feature/issue-" when the GitHub CLI is unavailable.
+func applyGhLogin(cfg *Config) {
+	cfg.GhLogin = resolveGitHubLogin()
+	if cfg.Branches.FeaturePrefix == "" {
+		if cfg.GhLogin != "" {
+			cfg.Branches.FeaturePrefix = "madflow/" + cfg.GhLogin + "/issue-"
+		} else {
+			cfg.Branches.FeaturePrefix = "feature/issue-"
+		}
+	}
+}
+
+// autoPopulateAuthorizedUsers uses the already-resolved cfg.GhLogin to populate
 // cfg.AuthorizedUsers when GitHub integration is enabled but no authorized
 // users are configured. A warning is logged when detection fails.
 func autoPopulateAuthorizedUsers(cfg *Config) {
@@ -263,11 +284,10 @@ func autoPopulateAuthorizedUsers(cfg *Config) {
 		// GitHub integration disabled, or already explicitly configured.
 		return
 	}
-	login := resolveGitHubLogin()
-	if login == "" {
+	if cfg.GhLogin == "" {
 		log.Printf("[config] WARNING: github integration is enabled but authorized_users is not set and `gh api user` returned no login; all GitHub events will be denied. Set authorized_users in madflow.toml or ensure `gh` is authenticated.")
 		return
 	}
-	log.Printf("[config] auto-detected GitHub login %q; using as authorized_users", login)
-	cfg.AuthorizedUsers = []string{login}
+	log.Printf("[config] auto-detected GitHub login %q; using as authorized_users", cfg.GhLogin)
+	cfg.AuthorizedUsers = []string{cfg.GhLogin}
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -45,8 +45,11 @@ develop = "develop"
 	if cfg.Agent.ContextResetMinutes != 10 {
 		t.Errorf("expected context_reset_minutes 10, got %d", cfg.Agent.ContextResetMinutes)
 	}
-	if cfg.Branches.FeaturePrefix != "feature/issue-" {
-		t.Errorf("expected default feature prefix, got %s", cfg.Branches.FeaturePrefix)
+	// When gh CLI is authenticated, FeaturePrefix becomes "madflow/{login}/issue-".
+	// When gh CLI is unavailable, it falls back to "feature/issue-".
+	// Accept either form here; the key invariant is that it is non-empty.
+	if cfg.Branches.FeaturePrefix == "" {
+		t.Errorf("expected non-empty feature prefix, got empty string")
 	}
 }
 

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -190,8 +190,8 @@ func (r *Repo) CleanOrphanedWorktrees(ghLogin string, activePaths map[string]boo
 				wtPath := filepath.Join(worktreeDir, name)
 				if err := r.RemoveWorktree(wtPath); err != nil {
 					// If git worktree remove fails, try to prune and remove manually.
-					r.run("worktree", "prune")
-					os.RemoveAll(wtPath)
+					r.run("worktree", "prune")           //nolint:errcheck // best-effort cleanup
+					os.RemoveAll(wtPath)                 //nolint:errcheck // best-effort cleanup
 				}
 				removed = append(removed, name)
 			}
@@ -211,8 +211,8 @@ func (r *Repo) CleanOrphanedWorktrees(ghLogin string, activePaths map[string]boo
 				if !activePaths[relPath] {
 					wtPath := filepath.Join(namespaceDir, subName)
 					if err := r.RemoveWorktree(wtPath); err != nil {
-						r.run("worktree", "prune")
-						os.RemoveAll(wtPath)
+						r.run("worktree", "prune")   //nolint:errcheck // best-effort cleanup
+						os.RemoveAll(wtPath)         //nolint:errcheck // best-effort cleanup
 					}
 					removed = append(removed, relPath)
 				}
@@ -224,7 +224,7 @@ func (r *Repo) CleanOrphanedWorktrees(ghLogin string, activePaths map[string]boo
 		}
 	}
 	// Always prune stale worktree references at the end.
-	r.run("worktree", "prune")
+	r.run("worktree", "prune") //nolint:errcheck // best-effort cleanup
 	return removed
 }
 
@@ -239,7 +239,7 @@ func (r *Repo) RemoveNamespacedWorktree(login, subDir string) error {
 	}
 	if err := r.RemoveWorktree(wtPath); err != nil {
 		// Fall back: prune then remove manually.
-		r.run("worktree", "prune")
+		r.run("worktree", "prune") //nolint:errcheck // best-effort cleanup
 		if rmErr := os.RemoveAll(wtPath); rmErr != nil {
 			return fmt.Errorf("remove namespaced worktree %s/%s: %w", login, subDir, rmErr)
 		}
@@ -281,8 +281,7 @@ func ValidateSafeBranchName(name string) error {
 	if strings.ContainsRune(name, '\x00') {
 		return fmt.Errorf("branch name %q contains null byte", name)
 	}
-	parts := strings.Split(name, "/")
-	for _, part := range parts {
+	for part := range strings.SplitSeq(name, "/") {
 		if part == "" {
 			return fmt.Errorf("branch name %q contains empty component (consecutive or leading/trailing slashes)", name)
 		}

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -190,8 +190,8 @@ func (r *Repo) CleanOrphanedWorktrees(ghLogin string, activePaths map[string]boo
 				wtPath := filepath.Join(worktreeDir, name)
 				if err := r.RemoveWorktree(wtPath); err != nil {
 					// If git worktree remove fails, try to prune and remove manually.
-					r.run("worktree", "prune")           //nolint:errcheck // best-effort cleanup
-					os.RemoveAll(wtPath)                 //nolint:errcheck // best-effort cleanup
+					r.run("worktree", "prune") //nolint:errcheck // best-effort cleanup
+					os.RemoveAll(wtPath)       //nolint:errcheck // best-effort cleanup
 				}
 				removed = append(removed, name)
 			}
@@ -211,8 +211,8 @@ func (r *Repo) CleanOrphanedWorktrees(ghLogin string, activePaths map[string]boo
 				if !activePaths[relPath] {
 					wtPath := filepath.Join(namespaceDir, subName)
 					if err := r.RemoveWorktree(wtPath); err != nil {
-						r.run("worktree", "prune")   //nolint:errcheck // best-effort cleanup
-						os.RemoveAll(wtPath)         //nolint:errcheck // best-effort cleanup
+						r.run("worktree", "prune") //nolint:errcheck // best-effort cleanup
+						os.RemoveAll(wtPath)       //nolint:errcheck // best-effort cleanup
 					}
 					removed = append(removed, relPath)
 				}

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -161,10 +161,18 @@ func (r *Repo) CleanWorktrees(prefix string) (removed []string) {
 }
 
 // CleanOrphanedWorktrees removes worktree directories under .worktrees/ that
-// start with "team-" but are NOT in the activeTeamDirs set. This catches
-// orphaned worktrees from teams that crashed or were not properly cleaned up.
+// are NOT in the activePaths set. It handles both legacy "team-N" style flat
+// worktrees and new namespace-style "{ghLogin}/issue-{id}" worktrees.
+//
+// When ghLogin is non-empty, the function also scans the "{ghLogin}/" namespace
+// directory for orphaned worktrees (paths not in activePaths as "{ghLogin}/sub").
+// When ghLogin is empty, only legacy "team-*" directories are processed.
+//
+// activePaths keys should be the relative path under .worktrees/ (e.g. "team-1"
+// or "alice/issue-myorg-REPO-42").
+//
 // It also runs "git worktree prune" to clean stale internal references.
-func (r *Repo) CleanOrphanedWorktrees(activeTeamDirs map[string]bool) (removed []string) {
+func (r *Repo) CleanOrphanedWorktrees(ghLogin string, activePaths map[string]bool) (removed []string) {
 	worktreeDir := filepath.Join(r.path, ".worktrees")
 	entries, err := os.ReadDir(worktreeDir)
 	if err != nil {
@@ -175,23 +183,72 @@ func (r *Repo) CleanOrphanedWorktrees(activeTeamDirs map[string]bool) (removed [
 			continue
 		}
 		name := entry.Name()
-		if !strings.HasPrefix(name, "team-") {
-			continue
+
+		if strings.HasPrefix(name, "team-") {
+			// Legacy flat worktree: team-N
+			if !activePaths[name] {
+				wtPath := filepath.Join(worktreeDir, name)
+				if err := r.RemoveWorktree(wtPath); err != nil {
+					// If git worktree remove fails, try to prune and remove manually.
+					r.run("worktree", "prune")
+					os.RemoveAll(wtPath)
+				}
+				removed = append(removed, name)
+			}
+		} else if ghLogin != "" && name == ghLogin {
+			// Namespace directory for the current user: scan sub-entries
+			namespaceDir := filepath.Join(worktreeDir, name)
+			subEntries, subErr := os.ReadDir(namespaceDir)
+			if subErr != nil {
+				continue
+			}
+			for _, subEntry := range subEntries {
+				if !subEntry.IsDir() {
+					continue
+				}
+				subName := subEntry.Name()
+				relPath := name + "/" + subName
+				if !activePaths[relPath] {
+					wtPath := filepath.Join(namespaceDir, subName)
+					if err := r.RemoveWorktree(wtPath); err != nil {
+						r.run("worktree", "prune")
+						os.RemoveAll(wtPath)
+					}
+					removed = append(removed, relPath)
+				}
+			}
+			// Remove empty namespace directory
+			if remaining, _ := os.ReadDir(namespaceDir); len(remaining) == 0 {
+				os.Remove(namespaceDir) //nolint:errcheck
+			}
 		}
-		if activeTeamDirs[name] {
-			continue
-		}
-		wtPath := filepath.Join(worktreeDir, name)
-		if err := r.RemoveWorktree(wtPath); err != nil {
-			// If git worktree remove fails, try to prune and remove manually.
-			r.run("worktree", "prune")
-			os.RemoveAll(wtPath)
-		}
-		removed = append(removed, name)
 	}
 	// Always prune stale worktree references at the end.
 	r.run("worktree", "prune")
 	return removed
+}
+
+// RemoveNamespacedWorktree removes a namespaced worktree at .worktrees/{login}/{subDir}.
+// Returns nil if the directory does not exist (no-op).
+// After removal, the namespace directory is also removed if it becomes empty.
+func (r *Repo) RemoveNamespacedWorktree(login, subDir string) error {
+	namespaceDir := filepath.Join(r.path, ".worktrees", login)
+	wtPath := filepath.Join(namespaceDir, subDir)
+	if _, err := os.Stat(wtPath); os.IsNotExist(err) {
+		return nil // already gone
+	}
+	if err := r.RemoveWorktree(wtPath); err != nil {
+		// Fall back: prune then remove manually.
+		r.run("worktree", "prune")
+		if rmErr := os.RemoveAll(wtPath); rmErr != nil {
+			return fmt.Errorf("remove namespaced worktree %s/%s: %w", login, subDir, rmErr)
+		}
+	}
+	// Clean up empty namespace directory.
+	if entries, err := os.ReadDir(namespaceDir); err == nil && len(entries) == 0 {
+		os.Remove(namespaceDir) //nolint:errcheck
+	}
+	return nil
 }
 
 // ValidateSafeName validates that name is safe to use as a branch name component
@@ -213,11 +270,38 @@ func ValidateSafeName(name string) error {
 	return nil
 }
 
+// ValidateSafeBranchName validates that name is safe to use as a git branch name.
+// Unlike ValidateSafeName, it allows "/" as a namespace separator (e.g.
+// "madflow/alice/issue-123"). Each component separated by "/" is validated
+// individually to prevent path traversal attacks.
+func ValidateSafeBranchName(name string) error {
+	if name == "" {
+		return fmt.Errorf("branch name must not be empty")
+	}
+	if strings.ContainsRune(name, '\x00') {
+		return fmt.Errorf("branch name %q contains null byte", name)
+	}
+	parts := strings.Split(name, "/")
+	for _, part := range parts {
+		if part == "" {
+			return fmt.Errorf("branch name %q contains empty component (consecutive or leading/trailing slashes)", name)
+		}
+		if strings.Contains(part, "..") {
+			return fmt.Errorf("branch name %q contains prohibited sequence \"..\" in component %q", name, part)
+		}
+		if strings.ContainsAny(part, "\\") {
+			return fmt.Errorf("branch name %q contains backslash in component %q", name, part)
+		}
+	}
+	return nil
+}
+
 // PrepareWorktree ensures the develop branch exists (creating from main if needed)
 // and creates a worktree with a new feature branch based on develop.
-// It validates featureBranch to prevent path traversal attacks.
+// It validates featureBranch using ValidateSafeBranchName to prevent path traversal
+// attacks while allowing namespace-style branch names (e.g. "madflow/user/issue-123").
 func (r *Repo) PrepareWorktree(path, featureBranch, developBranch, mainBranch string) error {
-	if err := ValidateSafeName(featureBranch); err != nil {
+	if err := ValidateSafeBranchName(featureBranch); err != nil {
 		return fmt.Errorf("invalid feature branch name: %w", err)
 	}
 	if err := r.EnsureBranch(developBranch, mainBranch); err != nil {

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -661,7 +661,9 @@ func TestCleanOrphanedWorktreesNamespaced(t *testing.T) {
 	}
 
 	// Cleanup
-	repo.RemoveWorktree(wtActive)
+	if err := repo.RemoveWorktree(wtActive); err != nil {
+		t.Logf("cleanup: %v", err)
+	}
 }
 
 func TestPrepareWorktreeRejectsTraversalBranchName(t *testing.T) {

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -428,7 +428,7 @@ func TestCleanOrphanedWorktrees(t *testing.T) {
 		"team-1": true,
 	}
 
-	removed := repo.CleanOrphanedWorktrees(activeTeams)
+	removed := repo.CleanOrphanedWorktrees("", activeTeams)
 
 	// team-2 and team-3 should be removed, team-1 should remain
 	if len(removed) != 2 {
@@ -455,7 +455,7 @@ func TestCleanOrphanedWorktreesNoDir(t *testing.T) {
 	repo := initTestRepo(t)
 
 	// No .worktrees directory — should return nil without error
-	removed := repo.CleanOrphanedWorktrees(map[string]bool{})
+	removed := repo.CleanOrphanedWorktrees("", map[string]bool{})
 	if len(removed) != 0 {
 		t.Errorf("expected no removed worktrees, got %d", len(removed))
 	}
@@ -471,7 +471,7 @@ func TestCleanOrphanedWorktreesSkipsNonTeam(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	removed := repo.CleanOrphanedWorktrees(map[string]bool{})
+	removed := repo.CleanOrphanedWorktrees("", map[string]bool{})
 
 	// Non-team directories should not be removed
 	if len(removed) != 0 {
@@ -568,6 +568,100 @@ func TestValidateSafeName(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestValidateSafeBranchName(t *testing.T) {
+	validCases := []string{
+		"feature-issue-123",
+		"madflow/alice/issue-123",
+		"madflow/alice/issue-myorg-REPO-42",
+		"feature/issue-5",
+		"abc",
+		"a/b/c",
+	}
+	for _, name := range validCases {
+		t.Run("valid/"+name, func(t *testing.T) {
+			if err := ValidateSafeBranchName(name); err != nil {
+				t.Errorf("expected %q to be valid, got error: %v", name, err)
+			}
+		})
+	}
+
+	invalidCases := []struct {
+		name string
+		desc string
+	}{
+		{"", "empty string"},
+		{"foo/../bar", "path traversal with .."},
+		{"../secret", "leading .."},
+		{"foo//bar", "consecutive slashes"},
+		{"/absolute", "leading slash"},
+		{"foo\\bar", "backslash"},
+		{"foo\x00bar", "null byte"},
+		{"foo/", "trailing slash"},
+	}
+	for _, tc := range invalidCases {
+		t.Run("invalid/"+tc.desc, func(t *testing.T) {
+			if err := ValidateSafeBranchName(tc.name); err == nil {
+				t.Errorf("expected %q (%s) to be invalid, but got no error", tc.name, tc.desc)
+			}
+		})
+	}
+}
+
+func TestCleanOrphanedWorktreesNamespaced(t *testing.T) {
+	repo := initTestRepo(t)
+
+	baseBranch, err := repo.CurrentBranch()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	worktreeDir := filepath.Join(repo.Path(), ".worktrees")
+	if err := os.MkdirAll(worktreeDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create namespace directory for "alice"
+	namespaceDir := filepath.Join(worktreeDir, "alice")
+	if err := os.MkdirAll(namespaceDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create namespaced worktrees: issue-active (kept) and issue-orphaned (removed)
+	wtActive := filepath.Join(namespaceDir, "issue-active")
+	wtOrphaned := filepath.Join(namespaceDir, "issue-orphaned")
+
+	if err := repo.AddWorktree(wtActive, "alice-active-branch", baseBranch); err != nil {
+		t.Fatalf("AddWorktree active failed: %v", err)
+	}
+	if err := repo.AddWorktree(wtOrphaned, "alice-orphaned-branch", baseBranch); err != nil {
+		t.Fatalf("AddWorktree orphaned failed: %v", err)
+	}
+
+	// Only "alice/issue-active" is in the active set
+	activePaths := map[string]bool{
+		"alice/issue-active": true,
+	}
+
+	removed := repo.CleanOrphanedWorktrees("alice", activePaths)
+
+	// issue-orphaned should be removed
+	if len(removed) != 1 || removed[0] != "alice/issue-orphaned" {
+		t.Errorf("expected [alice/issue-orphaned] removed, got %v", removed)
+	}
+
+	// active worktree should still exist
+	if _, err := os.Stat(wtActive); os.IsNotExist(err) {
+		t.Error("expected alice/issue-active worktree to still exist")
+	}
+	// orphaned worktree should be gone
+	if _, err := os.Stat(wtOrphaned); !os.IsNotExist(err) {
+		t.Error("expected alice/issue-orphaned worktree to be removed")
+	}
+
+	// Cleanup
+	repo.RemoveWorktree(wtActive)
 }
 
 func TestPrepareWorktreeRejectsTraversalBranchName(t *testing.T) {

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -369,6 +369,7 @@ func (o *Orchestrator) startResidentAgents(ctx context.Context, wg *sync.WaitGro
 			DevelopBranch: o.cfg.Branches.Develop,
 			MainBranch:    o.cfg.Branches.Main,
 			FeaturePrefix: o.cfg.Branches.FeaturePrefix,
+			GhLogin:       o.cfg.GhLogin,
 		}
 
 		systemPrompt, err := agent.LoadPrompt(o.promptDir, r.role, vars)
@@ -1034,6 +1035,7 @@ func (o *Orchestrator) CreateTeamAgents(teamNum int, issueID string) (engineer *
 			FeaturePrefix: o.cfg.Branches.FeaturePrefix,
 			TeamNum:       teamNumStr,
 			RepoPath:      o.firstRepoPath(),
+			GhLogin:       o.cfg.GhLogin,
 		}
 
 		systemPrompt, err := agent.LoadPrompt(o.promptDir, r.role, vars)
@@ -1335,14 +1337,19 @@ func (o *Orchestrator) runWorktreeCleanup(ctx context.Context) {
 			log.Println("[worktree-cleanup] stopped")
 			return
 		case <-ticker.C:
-			// Build set of active team worktree directory names.
-			activeTeamDirs := make(map[string]bool)
+			// Build set of active worktree relative paths.
+			// Legacy style: "team-N"; namespaced style: "{ghLogin}/issue-{id}".
+			activePaths := make(map[string]bool)
 			for _, info := range o.teams.List() {
-				activeTeamDirs[fmt.Sprintf("team-%d", info.ID)] = true
+				activePaths[fmt.Sprintf("team-%d", info.ID)] = true
 			}
 
+			o.cfgMu.RLock()
+			ghLogin := o.cfg.GhLogin
+			o.cfgMu.RUnlock()
+
 			for name, repo := range o.repos {
-				removed := repo.CleanOrphanedWorktrees(activeTeamDirs)
+				removed := repo.CleanOrphanedWorktrees(ghLogin, activePaths)
 				if len(removed) > 0 {
 					log.Printf("[worktree-cleanup] %s: removed %d orphaned worktree(s): %v", name, len(removed), removed)
 				}

--- a/prompts/engineer.md
+++ b/prompts/engineer.md
@@ -210,16 +210,16 @@ git -C {{REPO_PATH}} worktree list | grep {{FEATURE_PREFIX}}<issueID>
 
 # If no worktree: create a new one (created from the latest origin/develop)
 git -C {{REPO_PATH}} worktree add -b {{FEATURE_PREFIX}}<issueID> \
-  {{REPO_PATH}}/.worktrees/team-{{TEAM_NUM}} \
+  {{REPO_PATH}}/.worktrees/{{GH_LOGIN}}/issue-<issueID> \
   origin/{{DEVELOP_BRANCH}}
 
 # If worktree exists: move to the existing worktree and merge the latest develop
-cd {{REPO_PATH}}/.worktrees/team-{{TEAM_NUM}}
+cd {{REPO_PATH}}/.worktrees/{{GH_LOGIN}}/issue-<issueID>
 git merge origin/{{DEVELOP_BRANCH}}
 # If conflicts occur, resolve them before continuing work
 ```
 
-**All subsequent git operations and file edits must be performed within the worktree directory (`{{REPO_PATH}}/.worktrees/team-{{TEAM_NUM}}`).**
+**All subsequent git operations and file edits must be performed within the worktree directory (`{{REPO_PATH}}/.worktrees/{{GH_LOGIN}}/issue-<issueID>`).**
 **Running `git checkout` / `git switch` in the project root (`{{REPO_PATH}}`) is strictly prohibited.**
 
 #### Checking for Existing PRs
@@ -297,7 +297,7 @@ git commit -m "feat: <description of changes>"
 Before creating/pushing a PR, **always** check the diff against the base branch ({{DEVELOP_BRANCH}}) and resolve any conflicts.
 
 ```bash
-cd {{REPO_PATH}}/.worktrees/team-{{TEAM_NUM}}
+cd {{REPO_PATH}}/.worktrees/{{GH_LOGIN}}/issue-<issueID>
 
 # Fetch the latest base branch
 git fetch origin {{DEVELOP_BRANCH}}
@@ -317,7 +317,7 @@ When implementation is complete, **always** push the feature branch to the remot
 The PR is the foundation of the review process; you must not request a review without a PR in place.
 
 ```bash
-cd {{REPO_PATH}}/.worktrees/team-{{TEAM_NUM}}
+cd {{REPO_PATH}}/.worktrees/{{GH_LOGIN}}/issue-<issueID>
 git push -u origin {{FEATURE_PREFIX}}<issueID>
 gh pr create --base {{DEVELOP_BRANCH}} --title "<issueID>: <summary of changes>" --body "Issue: <issueID>"
 ```


### PR DESCRIPTION
Issue: ytnobody-MADFLOW-235

## Summary

- `Config.GhLogin` フィールドを追加し、起動時に `gh api user` で GitHub ログイン名を取得
- `FeaturePrefix` デフォルト値を `madflow/{gh_login}/issue-` に変更（gh CLI 未認証時は `feature/issue-` にフォールバック）
- `CleanOrphanedWorktrees` を拡張し、`{login}/issue-*` 形式の namespaced worktree を処理
- `ValidateSafeBranchName` を追加し、`/` を許可しつつ path traversal を防止
- `PrepareWorktree` を `ValidateSafeBranchName` に切り替え
- `{{GH_LOGIN}}` テンプレート変数を engineer プロンプトに追加
- オーケストレーターの worktree クリーンアップで `GhLogin` を利用

## Changes

- `internal/config/config.go` - GhLogin フィールド追加、applyGhLogin 関数追加
- `internal/git/git.go` - ValidateSafeBranchName、RemoveNamespacedWorktree、CleanOrphanedWorktrees 拡張
- `internal/orchestrator/orchestrator.go` - GhLogin をエージェントとクリーンアップに渡す
- `internal/agent/prompt.go` - GhLogin フィールドと {{GH_LOGIN}} 置換を追加
- `prompts/engineer.md` - worktree パスのテンプレート更新
- `docs/specs/user-namespace-branch-worktree.md` - 新規仕様書
- `internal/config/config_test.go`, `internal/git/git_test.go` - テスト更新