### PR TITLE
ytnobody-MADFLOW-238: feat: 旧形式リソース（ブランチ・worktree）の後方互換警告

### DIFF
--- a/cmd/madflow/main.go
+++ b/cmd/madflow/main.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/ytnobody/madflow/internal/chatlog"
 	"github.com/ytnobody/madflow/internal/config"
+	"github.com/ytnobody/madflow/internal/git"
 	"github.com/ytnobody/madflow/internal/orchestrator"
 	"github.com/ytnobody/madflow/internal/project"
 	"github.com/ytnobody/madflow/prompts"
@@ -161,11 +162,37 @@ feature_prefix = "feature/issue-"
 	return nil
 }
 
+// warnLegacyResources checks each configured repository for old-format branches
+// and worktrees and prints a [WARN] message for each one found.
+// Startup continues regardless (warnings are non-fatal).
+func warnLegacyResources(repos []config.RepoConfig) {
+	for _, r := range repos {
+		repo := git.NewRepo(r.Path)
+
+		// Check for legacy worktrees: .madflow/worktrees/issue-{number}/
+		madflowDir := filepath.Join(r.Path, ".madflow")
+		for _, wt := range repo.DetectLegacyWorktrees(madflowDir) {
+			fmt.Fprintf(os.Stderr, "[WARN] Legacy worktree detected: %s\n", wt)
+			fmt.Fprintf(os.Stderr, "       Please migrate manually or remove before continuing.\n")
+		}
+
+		// Check for legacy branches: feature/issue-{number}
+		for _, branch := range repo.DetectLegacyBranches() {
+			fmt.Fprintf(os.Stderr, "[WARN] Legacy branch detected: %s\n", branch)
+			fmt.Fprintf(os.Stderr, "       Please migrate manually or remove before continuing.\n")
+		}
+	}
+}
+
 func cmdStart() error {
 	configPath, cfg, proj, err := loadProjectConfig()
 	if err != nil {
 		return err
 	}
+
+	// Warn about legacy-format resources (old branch/worktree naming convention).
+	// This is a non-fatal check; startup continues after warnings are displayed.
+	warnLegacyResources(cfg.Project.Repos)
 
 	// Determine prompts directory
 	promptDir := findPromptsDir(cfg.PromptsDir)

--- a/docs/specs/legacy-resource-warning.md
+++ b/docs/specs/legacy-resource-warning.md
@@ -1,0 +1,76 @@
+# Legacy Resource Warning Specification
+
+## Overview
+
+When `madflow start` is executed, the system detects old-format branches and worktrees
+and displays a warning message. No automatic migration is performed.
+
+## Background
+
+Issue #235 changed the branch naming convention and worktree path format to include the
+GitHub login name for namespace separation:
+
+| Resource  | Old Format (Legacy)                          | New Format                                       |
+|-----------|----------------------------------------------|--------------------------------------------------|
+| Branch    | `feature/issue-{number}`                     | `madflow/{gh_login}/issue-{number}`              |
+| Worktree  | `.madflow/worktrees/issue-{number}/`         | `.madflow/worktrees/{gh_login}/issue-{number}/`  |
+
+## Detection Targets
+
+### Legacy Worktrees
+
+Directories under `.madflow/worktrees/` whose name matches the pattern `issue-{number}`
+(i.e., a directory named `issue-` followed by one or more digits), and does **not** contain
+a `/` separator (which would indicate the new `{gh_login}/issue-{number}` format).
+
+Pattern: `issue-\d+`
+
+### Legacy Branches
+
+Local git branches whose name matches the pattern `feature/issue-{number}`
+(i.e., `feature/issue-` followed by one or more digits).
+
+Pattern: `feature/issue-\d+`
+
+## Warning Format
+
+### Legacy Worktree Warning
+
+```
+[WARN] Legacy worktree detected: .madflow/worktrees/issue-42/
+       Please migrate manually or remove before continuing.
+```
+
+### Legacy Branch Warning
+
+```
+[WARN] Legacy branch detected: feature/issue-42
+       Please migrate manually or remove before continuing.
+```
+
+## Behavior
+
+- Warnings are printed to stderr during the startup process (`cmdStart`).
+- The startup process **continues** after warnings are displayed (non-fatal).
+- Warnings appear **before** the orchestrator starts.
+- If no legacy resources are present, no warning is displayed.
+- Each detected resource produces its own warning line.
+
+## Implementation
+
+### `internal/git/git.go`
+
+Two new exported functions on `*Repo`:
+
+- `DetectLegacyWorktrees(madflowDir string) []string`
+  - Scans `<madflowDir>/worktrees/` for directories matching `issue-\d+`
+  - Returns a slice of relative paths like `.madflow/worktrees/issue-42/`
+
+- `DetectLegacyBranches() []string`
+  - Lists local branches matching `feature/issue-\d+`
+  - Returns a slice of branch names
+
+### `cmd/madflow/main.go`
+
+- `warnLegacyResources(repos []*git.Repo, madflowDirs []string)` — detects and prints warnings
+- Called from `cmdStart()` before calling `orc.Run(ctx)`

--- a/internal/git/legacy.go
+++ b/internal/git/legacy.go
@@ -1,0 +1,68 @@
+package git
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+// legacyWorktreePattern matches directory names of the old-format worktree:
+// "issue-{number}" (e.g. "issue-42").
+var legacyWorktreePattern = regexp.MustCompile(`^issue-\d+$`)
+
+// legacyBranchPattern matches branch names of the old format:
+// "feature/issue-{number}" (e.g. "feature/issue-42").
+var legacyBranchPattern = regexp.MustCompile(`^feature/issue-\d+$`)
+
+// DetectLegacyWorktrees scans <madflowDir>/worktrees/ for directories whose
+// names match the old-format "issue-{number}" pattern.
+// It returns a slice of relative display paths in the form
+// ".madflow/worktrees/issue-{number}/" for each detected legacy directory.
+// Returns an empty (nil) slice when none are found or the directory does not exist.
+func (r *Repo) DetectLegacyWorktrees(madflowDir string) []string {
+	worktreesDir := filepath.Join(madflowDir, "worktrees")
+	entries, err := os.ReadDir(worktreesDir)
+	if err != nil {
+		// Directory absent or unreadable — nothing to report.
+		return nil
+	}
+
+	var found []string
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		if legacyWorktreePattern.MatchString(entry.Name()) {
+			// Build a human-readable relative path for the warning message.
+			rel, err := filepath.Rel(r.path, filepath.Join(worktreesDir, entry.Name()))
+			if err != nil {
+				rel = filepath.Join(".madflow", "worktrees", entry.Name())
+			}
+			found = append(found, rel+string(filepath.Separator))
+		}
+	}
+	return found
+}
+
+// DetectLegacyBranches lists local branches whose names match the old-format
+// "feature/issue-{number}" pattern.
+// Returns a slice of branch names, or an empty (nil) slice when none are found.
+func (r *Repo) DetectLegacyBranches() []string {
+	out, err := r.run("branch", "--format=%(refname:short)")
+	if err != nil {
+		return nil
+	}
+
+	var found []string
+	for _, line := range strings.Split(out, "\n") {
+		branch := strings.TrimSpace(line)
+		if branch == "" {
+			continue
+		}
+		if legacyBranchPattern.MatchString(branch) {
+			found = append(found, branch)
+		}
+	}
+	return found
+}

--- a/internal/git/legacy.go
+++ b/internal/git/legacy.go
@@ -55,7 +55,7 @@ func (r *Repo) DetectLegacyBranches() []string {
 	}
 
 	var found []string
-	for _, line := range strings.Split(out, "\n") {
+	for line := range strings.SplitSeq(out, "\n") {
 		branch := strings.TrimSpace(line)
 		if branch == "" {
 			continue

--- a/internal/git/legacy_test.go
+++ b/internal/git/legacy_test.go
@@ -1,0 +1,204 @@
+package git
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestDetectLegacyWorktrees_Found verifies that legacy worktree directories
+// (issue-{number} pattern) under .madflow/worktrees/ are detected.
+func TestDetectLegacyWorktrees_Found(t *testing.T) {
+	repo := initTestRepo(t)
+
+	madflowDir := filepath.Join(repo.Path(), ".madflow")
+	worktreesDir := filepath.Join(madflowDir, "worktrees")
+
+	// Create legacy worktree directories.
+	legacyPaths := []string{
+		filepath.Join(worktreesDir, "issue-1"),
+		filepath.Join(worktreesDir, "issue-42"),
+		filepath.Join(worktreesDir, "issue-999"),
+	}
+	for _, p := range legacyPaths {
+		if err := os.MkdirAll(p, 0755); err != nil {
+			t.Fatalf("create legacy worktree dir %s: %v", p, err)
+		}
+	}
+
+	detected := repo.DetectLegacyWorktrees(madflowDir)
+	if len(detected) != 3 {
+		t.Errorf("expected 3 legacy worktrees, got %d: %v", len(detected), detected)
+	}
+
+	// Each entry should follow the .madflow/worktrees/issue-{number}/ form.
+	for _, d := range detected {
+		// Strip trailing separator to get the directory name, then check
+		// that its parent component is "worktrees".
+		clean := strings.TrimSuffix(d, string(filepath.Separator))
+		if filepath.Base(filepath.Dir(clean)) != "worktrees" {
+			t.Errorf("unexpected path format: %s", d)
+		}
+	}
+}
+
+// TestDetectLegacyWorktrees_NewFormatNotDetected verifies that new-format
+// worktrees ({gh_login}/issue-{number}) are NOT detected as legacy.
+func TestDetectLegacyWorktrees_NewFormatNotDetected(t *testing.T) {
+	repo := initTestRepo(t)
+
+	madflowDir := filepath.Join(repo.Path(), ".madflow")
+	worktreesDir := filepath.Join(madflowDir, "worktrees")
+
+	// New format: sub-directory structure.
+	newFormatPath := filepath.Join(worktreesDir, "ytnobody", "issue-1")
+	if err := os.MkdirAll(newFormatPath, 0755); err != nil {
+		t.Fatalf("create new-format worktree dir: %v", err)
+	}
+
+	detected := repo.DetectLegacyWorktrees(madflowDir)
+	if len(detected) != 0 {
+		t.Errorf("expected 0 legacy worktrees, got %d: %v", len(detected), detected)
+	}
+}
+
+// TestDetectLegacyWorktrees_NonNumericNotDetected verifies that directories
+// with names that don't match issue-{number} are not reported as legacy.
+func TestDetectLegacyWorktrees_NonNumericNotDetected(t *testing.T) {
+	repo := initTestRepo(t)
+
+	madflowDir := filepath.Join(repo.Path(), ".madflow")
+	worktreesDir := filepath.Join(madflowDir, "worktrees")
+
+	// These should NOT be detected as legacy.
+	dirs := []string{
+		filepath.Join(worktreesDir, "team-1"),
+		filepath.Join(worktreesDir, "custom"),
+		filepath.Join(worktreesDir, "issue-abc"),
+	}
+	for _, p := range dirs {
+		if err := os.MkdirAll(p, 0755); err != nil {
+			t.Fatalf("create dir %s: %v", p, err)
+		}
+	}
+
+	detected := repo.DetectLegacyWorktrees(madflowDir)
+	if len(detected) != 0 {
+		t.Errorf("expected 0 legacy worktrees, got %d: %v", len(detected), detected)
+	}
+}
+
+// TestDetectLegacyWorktrees_NoWorktreesDir verifies that missing .madflow/worktrees/
+// directory returns an empty slice without error.
+func TestDetectLegacyWorktrees_NoWorktreesDir(t *testing.T) {
+	repo := initTestRepo(t)
+	madflowDir := filepath.Join(repo.Path(), ".madflow")
+
+	// Do not create the worktrees directory.
+	detected := repo.DetectLegacyWorktrees(madflowDir)
+	if len(detected) != 0 {
+		t.Errorf("expected 0 legacy worktrees when dir absent, got %d: %v", len(detected), detected)
+	}
+}
+
+// TestDetectLegacyBranches_Found verifies that local branches matching
+// feature/issue-{number} are detected as legacy.
+func TestDetectLegacyBranches_Found(t *testing.T) {
+	repo := initTestRepo(t)
+
+	baseBranch, err := repo.CurrentBranch()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create legacy branches.
+	legacyBranches := []string{
+		"feature/issue-1",
+		"feature/issue-42",
+		"feature/issue-999",
+	}
+	for _, b := range legacyBranches {
+		run(t, repo.Path(), "git", "branch", b, baseBranch)
+	}
+
+	detected := repo.DetectLegacyBranches()
+	if len(detected) != 3 {
+		t.Errorf("expected 3 legacy branches, got %d: %v", len(detected), detected)
+	}
+}
+
+// TestDetectLegacyBranches_NewFormatNotDetected verifies that new-format branches
+// (madflow/{gh_login}/issue-{number}) are NOT detected as legacy.
+func TestDetectLegacyBranches_NewFormatNotDetected(t *testing.T) {
+	repo := initTestRepo(t)
+
+	baseBranch, err := repo.CurrentBranch()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// New-format branches should NOT be detected.
+	run(t, repo.Path(), "git", "branch", "madflow/ytnobody/issue-1", baseBranch)
+	run(t, repo.Path(), "git", "branch", "madflow/alice/issue-42", baseBranch)
+
+	detected := repo.DetectLegacyBranches()
+	if len(detected) != 0 {
+		t.Errorf("expected 0 legacy branches, got %d: %v", len(detected), detected)
+	}
+}
+
+// TestDetectLegacyBranches_OtherBranchesNotDetected verifies that unrelated
+// branches are not reported as legacy.
+func TestDetectLegacyBranches_OtherBranchesNotDetected(t *testing.T) {
+	repo := initTestRepo(t)
+
+	baseBranch, err := repo.CurrentBranch()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Branches that should not be reported as legacy.
+	run(t, repo.Path(), "git", "branch", "develop", baseBranch)
+	run(t, repo.Path(), "git", "branch", "feature/issue-abc", baseBranch)  // non-numeric
+	run(t, repo.Path(), "git", "branch", "hotfix/issue-1", baseBranch)     // wrong prefix
+
+	detected := repo.DetectLegacyBranches()
+	if len(detected) != 0 {
+		t.Errorf("expected 0 legacy branches, got %d: %v", len(detected), detected)
+	}
+}
+
+// TestDetectLegacyBranches_NoBranches verifies that an empty repo returns
+// an empty slice.
+func TestDetectLegacyBranches_NoBranches(t *testing.T) {
+	repo := initTestRepo(t)
+
+	detected := repo.DetectLegacyBranches()
+	if len(detected) != 0 {
+		t.Errorf("expected 0 legacy branches in fresh repo, got %d: %v", len(detected), detected)
+	}
+}
+
+// TestDetectLegacyBranches_Mixed verifies that only legacy branches are returned
+// when both legacy and non-legacy branches coexist.
+func TestDetectLegacyBranches_Mixed(t *testing.T) {
+	repo := initTestRepo(t)
+
+	baseBranch, err := repo.CurrentBranch()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	run(t, repo.Path(), "git", "branch", "feature/issue-10", baseBranch)        // legacy
+	run(t, repo.Path(), "git", "branch", "madflow/user/issue-10", baseBranch)  // new format
+	run(t, repo.Path(), "git", "branch", "develop", baseBranch)                 // unrelated
+
+	detected := repo.DetectLegacyBranches()
+	if len(detected) != 1 {
+		t.Errorf("expected 1 legacy branch, got %d: %v", len(detected), detected)
+	}
+	if len(detected) > 0 && detected[0] != "feature/issue-10" {
+		t.Errorf("expected 'feature/issue-10', got %q", detected[0])
+	}
+}

--- a/internal/git/legacy_test.go
+++ b/internal/git/legacy_test.go
@@ -160,8 +160,8 @@ func TestDetectLegacyBranches_OtherBranchesNotDetected(t *testing.T) {
 
 	// Branches that should not be reported as legacy.
 	run(t, repo.Path(), "git", "branch", "develop", baseBranch)
-	run(t, repo.Path(), "git", "branch", "feature/issue-abc", baseBranch)  // non-numeric
-	run(t, repo.Path(), "git", "branch", "hotfix/issue-1", baseBranch)     // wrong prefix
+	run(t, repo.Path(), "git", "branch", "feature/issue-abc", baseBranch) // non-numeric
+	run(t, repo.Path(), "git", "branch", "hotfix/issue-1", baseBranch)    // wrong prefix
 
 	detected := repo.DetectLegacyBranches()
 	if len(detected) != 0 {
@@ -190,9 +190,9 @@ func TestDetectLegacyBranches_Mixed(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	run(t, repo.Path(), "git", "branch", "feature/issue-10", baseBranch)        // legacy
-	run(t, repo.Path(), "git", "branch", "madflow/user/issue-10", baseBranch)  // new format
-	run(t, repo.Path(), "git", "branch", "develop", baseBranch)                 // unrelated
+	run(t, repo.Path(), "git", "branch", "feature/issue-10", baseBranch)      // legacy
+	run(t, repo.Path(), "git", "branch", "madflow/user/issue-10", baseBranch) // new format
+	run(t, repo.Path(), "git", "branch", "develop", baseBranch)               // unrelated
 
 	detected := repo.DetectLegacyBranches()
 	if len(detected) != 1 {


### PR DESCRIPTION
Issue: ytnobody-MADFLOW-238

## 概要

旧形式のブランチ・worktreeが存在する場合に起動時に警告を表示する機能を実装しました。

## 変更内容

- `internal/git/legacy.go` (新規): `DetectLegacyWorktrees` および `DetectLegacyBranches` 関数を追加
- `internal/git/legacy_test.go` (新規): 上記関数のテストを追加
- `cmd/madflow/main.go`: `warnLegacyResources` 関数を追加し、`cmdStart` から呼び出すよう変更
- `docs/specs/legacy-resource-warning.md` (新規): 仕様ドキュメントを追加

## 検出対象

- 旧形式worktree: `.madflow/worktrees/issue-{number}/` パターンに一致するディレクトリ
- 旧形式ブランチ: `feature/issue-{number}` パターンに一致するローカルブランチ

## 警告フォーマット

```
[WARN] Legacy worktree detected: .madflow/worktrees/issue-42/
       Please migrate manually or remove before continuing.

[WARN] Legacy branch detected: feature/issue-42
       Please migrate manually or remove before continuing.
```

## 動作仕様

- 自動マイグレーションは行わない（警告表示のみ）
- 起動処理は継続する（エラーではなく警告）
- 新形式のリソースのみ存在する場合は警告が表示されない