### PR TITLE
ytnobody-MADFLOW-249: feat: エージェントで Claude Opus 4.7 を利用可能にする

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ path = "."
 context_reset_minutes = 8
 
 [agent.models]
-superintendent = "claude-opus-4-6"
+superintendent = "claude-opus-4-7"
 engineer = "claude-sonnet-4-6"
 # Gemini models are also supported:
 # superintendent = "gemini-2.0-flash-exp"
@@ -153,6 +153,8 @@ You can switch the models in use with the `madflow use <preset>` command.
 | `hybrid-cheap` | claude-sonnet-4-6 | gemini-2.5-flash | Hybrid low-cost version |
 | `claude-api-standard` | anthropic/claude-sonnet-4-6 | anthropic/claude-haiku-4-5 | **Anthropic API key method** |
 | `claude-api-cheap` | anthropic/claude-haiku-4-5 | anthropic/claude-haiku-4-5 | **Anthropic API key method - cheapest** |
+| `claude-opus` | claude-opus-4-7 | claude-sonnet-4-6 | Claude CLI with Opus 4.7 (1M context, high-complexity tasks) |
+| `claude-api-opus` | anthropic/claude-opus-4-7 | anthropic/claude-sonnet-4-6 | **Anthropic API key method - Opus 4.7** |
 
 ### How to Use the Anthropic API Key Method
 

--- a/cmd/madflow/main.go
+++ b/cmd/madflow/main.go
@@ -136,7 +136,7 @@ path = "%s"
 context_reset_minutes = 8
 
 [agent.models]
-superintendent = "claude-opus-4-6"
+superintendent = "claude-opus-4-7"
 engineer = "claude-sonnet-4-6"
 
 [branches]

--- a/cmd/madflow/use.go
+++ b/cmd/madflow/use.go
@@ -50,6 +50,14 @@ var presets = map[string]presetModels{
 		Superintendent: "anthropic/claude-haiku-4-5",
 		Engineer:       "anthropic/claude-haiku-4-5",
 	},
+	"claude-opus": {
+		Superintendent: "claude-opus-4-7",
+		Engineer:       "claude-sonnet-4-6",
+	},
+	"claude-api-opus": {
+		Superintendent: "anthropic/claude-opus-4-7",
+		Engineer:       "anthropic/claude-sonnet-4-6",
+	},
 }
 
 // cmdUse switches the active model preset in madflow.toml.
@@ -112,7 +120,7 @@ func updateModelsSection(content, superintendent, engineer string) (string, erro
 func formatPresets() string {
 	names := []string{
 		"claude", "gemini", "claude-cheap", "gemini-cheap", "hybrid", "hybrid-cheap",
-		"claude-api-standard", "claude-api-cheap",
+		"claude-api-standard", "claude-api-cheap", "claude-opus", "claude-api-opus",
 	}
 	var sb strings.Builder
 	for _, name := range names {

--- a/cmd/madflow/use_test.go
+++ b/cmd/madflow/use_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestPresets_AllDefined(t *testing.T) {
-	expectedPresets := []string{"claude", "gemini", "claude-cheap", "gemini-cheap", "hybrid", "hybrid-cheap", "claude-api-standard", "claude-api-cheap"}
+	expectedPresets := []string{"claude", "gemini", "claude-cheap", "gemini-cheap", "hybrid", "hybrid-cheap", "claude-api-standard", "claude-api-cheap", "claude-opus", "claude-api-opus"}
 	for _, name := range expectedPresets {
 		if _, ok := presets[name]; !ok {
 			t.Errorf("preset %q is not defined", name)
@@ -28,6 +28,8 @@ func TestPresets_Models(t *testing.T) {
 		{"hybrid-cheap", "claude-sonnet-4-6", "gemini-2.5-flash"},
 		{"claude-api-standard", "anthropic/claude-sonnet-4-6", "anthropic/claude-haiku-4-5"},
 		{"claude-api-cheap", "anthropic/claude-haiku-4-5", "anthropic/claude-haiku-4-5"},
+		{"claude-opus", "claude-opus-4-7", "claude-sonnet-4-6"},
+		{"claude-api-opus", "anthropic/claude-opus-4-7", "anthropic/claude-sonnet-4-6"},
 	}
 
 	for _, tt := range tests {
@@ -106,6 +108,32 @@ main = "main"
 			t.Errorf("engineer not updated: %s", result)
 		}
 	})
+
+	t.Run("switch to claude-opus preset", func(t *testing.T) {
+		result, err := updateModelsSection(input, "claude-opus-4-7", "claude-sonnet-4-6")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !strings.Contains(result, `superintendent = "claude-opus-4-7"`) {
+			t.Errorf("superintendent not updated: %s", result)
+		}
+		if !strings.Contains(result, `engineer = "claude-sonnet-4-6"`) {
+			t.Errorf("engineer not updated: %s", result)
+		}
+	})
+
+	t.Run("switch to claude-api-opus preset", func(t *testing.T) {
+		result, err := updateModelsSection(input, "anthropic/claude-opus-4-7", "anthropic/claude-sonnet-4-6")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !strings.Contains(result, `superintendent = "anthropic/claude-opus-4-7"`) {
+			t.Errorf("superintendent not updated: %s", result)
+		}
+		if !strings.Contains(result, `engineer = "anthropic/claude-sonnet-4-6"`) {
+			t.Errorf("engineer not updated: %s", result)
+		}
+	})
 }
 
 func TestUpdateModelsSection_MissingKeys(t *testing.T) {
@@ -130,7 +158,7 @@ superintendent = "claude-sonnet-4-6"
 
 func TestFormatPresets(t *testing.T) {
 	out := formatPresets()
-	expectedPresets := []string{"claude", "gemini", "claude-cheap", "gemini-cheap", "hybrid", "hybrid-cheap", "claude-api-standard", "claude-api-cheap"}
+	expectedPresets := []string{"claude", "gemini", "claude-cheap", "gemini-cheap", "hybrid", "hybrid-cheap", "claude-api-standard", "claude-api-cheap", "claude-opus", "claude-api-opus"}
 	for _, name := range expectedPresets {
 		if !strings.Contains(out, name) {
 			t.Errorf("formatPresets output missing preset %q", name)

--- a/docs/specs/claude-opus-4-7-preset.md
+++ b/docs/specs/claude-opus-4-7-preset.md
@@ -1,0 +1,45 @@
+# Claude Opus 4.7 Preset Specification
+
+## Overview
+
+Add `claude-opus` and `claude-api-opus` presets to the `madflow use` command, enabling agents to use Claude Opus 4.7 (`claude-opus-4-7`). Also update the default `madflow.toml` template to use Opus 4.7 for the superintendent agent.
+
+## Motivation
+
+Claude Opus 4.7 is the latest Opus model with 1M context support, making it suitable for complex, high-risk tasks handled by the superintendent agent.
+
+## New Presets
+
+### `claude-opus`
+
+Uses Claude Code CLI routing (`claude` command).
+
+| Agent          | Model             |
+|----------------|-------------------|
+| superintendent | `claude-opus-4-7` |
+| engineer       | `claude-sonnet-4-6` |
+
+### `claude-api-opus`
+
+Uses Anthropic API direct routing (`anthropic/` prefix).
+
+| Agent          | Model                        |
+|----------------|------------------------------|
+| superintendent | `anthropic/claude-opus-4-7`  |
+| engineer       | `anthropic/claude-sonnet-4-6` |
+
+## Default Configuration Update
+
+- `madflow.toml` (project root): superintendent updated to `claude-opus-4-7`
+- `cmd/madflow/main.go` init template: superintendent updated to `claude-opus-4-7`
+- `internal/config/config.go` fallback default: unchanged (remains `claude-sonnet-4-6` for cost reasons)
+
+## Routing Logic
+
+- `claude-opus-4-7` is handled by the default Claude Code CLI path in `internal/agent/agent.go` — no routing changes needed.
+- `anthropic/claude-opus-4-7` is handled by the `strings.HasPrefix(cfg.Model, "anthropic/")` branch — no routing changes needed.
+
+## Out of Scope
+
+- `internal/lessons/lessons.go`: `lessonsMgmtModel` remains `claude-haiku-4-5`
+- `agent.context_reset_minutes`: unchanged, to be revisited in a separate issue after observing behavior with 1M context


### PR DESCRIPTION
Issue: ytnobody-MADFLOW-249

## Summary

- `claude-opus` and `claude-api-opus` presets added to `madflow use` command
- Default init template updated to use `claude-opus-4-7` for superintendent
- README preset table updated with new presets

## Changed Files

- `cmd/madflow/use.go`: Added `claude-opus` and `claude-api-opus` presets, updated `formatPresets()`
- `cmd/madflow/main.go`: Updated init template default superintendent to `claude-opus-4-7`
- `cmd/madflow/use_test.go`: Added test cases for new presets
- `docs/specs/claude-opus-4-7-preset.md`: New spec document
- `README.md`: Added new presets to preset table, updated default model reference