### PR TITLE
feat: add Claude Opus 4.7 presets

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ path = "."
 context_reset_minutes = 8
 
 [agent.models]
-superintendent = "claude-opus-4-6"
+superintendent = "claude-opus-4-7"
 engineer = "claude-sonnet-4-6"
 # Gemini models are also supported:
 # superintendent = "gemini-2.0-flash-exp"
@@ -146,12 +146,14 @@ You can switch the models in use with the `madflow use <preset>` command.
 | Preset | superintendent | engineer | Notes |
 |--------|---------------|----------|-------|
 | `claude` | claude-sonnet-4-6 | claude-sonnet-4-6 | Claude CLI (requires Pro/Max) |
+| `claude-opus` | claude-opus-4-7 | claude-sonnet-4-6 | Claude CLI with Opus 4.7 superintendent |
 | `claude-cheap` | claude-sonnet-4-6 | claude-haiku-4-5 | Claude CLI cost-reduced version |
 | `gemini` | gemini-2.5-pro | gemini-2.5-pro | Gemini CLI (requires gemini-cli) |
 | `gemini-cheap` | gemini-2.5-flash | gemini-2.5-flash | Gemini fast & low-cost version |
 | `hybrid` | claude-sonnet-4-6 | gemini-2.5-pro | Hybrid configuration |
 | `hybrid-cheap` | claude-sonnet-4-6 | gemini-2.5-flash | Hybrid low-cost version |
 | `claude-api-standard` | anthropic/claude-sonnet-4-6 | anthropic/claude-haiku-4-5 | **Anthropic API key method** |
+| `claude-api-opus` | anthropic/claude-opus-4-7 | anthropic/claude-sonnet-4-6 | **Anthropic API - Opus 4.7 superintendent** |
 | `claude-api-cheap` | anthropic/claude-haiku-4-5 | anthropic/claude-haiku-4-5 | **Anthropic API key method - cheapest** |
 
 ### How to Use the Anthropic API Key Method

--- a/cmd/madflow/main.go
+++ b/cmd/madflow/main.go
@@ -136,7 +136,7 @@ path = "%s"
 context_reset_minutes = 8
 
 [agent.models]
-superintendent = "claude-opus-4-6"
+superintendent = "claude-opus-4-7"
 engineer = "claude-sonnet-4-6"
 
 [branches]

--- a/cmd/madflow/use.go
+++ b/cmd/madflow/use.go
@@ -50,6 +50,14 @@ var presets = map[string]presetModels{
 		Superintendent: "anthropic/claude-haiku-4-5",
 		Engineer:       "anthropic/claude-haiku-4-5",
 	},
+	"claude-opus": {
+		Superintendent: "claude-opus-4-7",
+		Engineer:       "claude-sonnet-4-6",
+	},
+	"claude-api-opus": {
+		Superintendent: "anthropic/claude-opus-4-7",
+		Engineer:       "anthropic/claude-sonnet-4-6",
+	},
 }
 
 // cmdUse switches the active model preset in madflow.toml.
@@ -111,8 +119,8 @@ func updateModelsSection(content, superintendent, engineer string) (string, erro
 // formatPresets returns a human-readable list of available presets.
 func formatPresets() string {
 	names := []string{
-		"claude", "gemini", "claude-cheap", "gemini-cheap", "hybrid", "hybrid-cheap",
-		"claude-api-standard", "claude-api-cheap",
+		"claude", "claude-opus", "gemini", "claude-cheap", "gemini-cheap", "hybrid", "hybrid-cheap",
+		"claude-api-standard", "claude-api-opus", "claude-api-cheap",
 	}
 	var sb strings.Builder
 	for _, name := range names {

--- a/cmd/madflow/use_test.go
+++ b/cmd/madflow/use_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestPresets_AllDefined(t *testing.T) {
-	expectedPresets := []string{"claude", "gemini", "claude-cheap", "gemini-cheap", "hybrid", "hybrid-cheap", "claude-api-standard", "claude-api-cheap"}
+	expectedPresets := []string{"claude", "claude-opus", "gemini", "claude-cheap", "gemini-cheap", "hybrid", "hybrid-cheap", "claude-api-standard", "claude-api-opus", "claude-api-cheap"}
 	for _, name := range expectedPresets {
 		if _, ok := presets[name]; !ok {
 			t.Errorf("preset %q is not defined", name)
@@ -28,6 +28,8 @@ func TestPresets_Models(t *testing.T) {
 		{"hybrid-cheap", "claude-sonnet-4-6", "gemini-2.5-flash"},
 		{"claude-api-standard", "anthropic/claude-sonnet-4-6", "anthropic/claude-haiku-4-5"},
 		{"claude-api-cheap", "anthropic/claude-haiku-4-5", "anthropic/claude-haiku-4-5"},
+		{"claude-opus", "claude-opus-4-7", "claude-sonnet-4-6"},
+		{"claude-api-opus", "anthropic/claude-opus-4-7", "anthropic/claude-sonnet-4-6"},
 	}
 
 	for _, tt := range tests {
@@ -54,7 +56,7 @@ name = "test"
 context_reset_minutes = 8
 
 [agent.models]
-superintendent = "claude-opus-4-6"
+superintendent = "claude-opus-4-7"
 engineer = "claude-sonnet-4-6"
 
 [branches]
@@ -130,7 +132,7 @@ superintendent = "claude-sonnet-4-6"
 
 func TestFormatPresets(t *testing.T) {
 	out := formatPresets()
-	expectedPresets := []string{"claude", "gemini", "claude-cheap", "gemini-cheap", "hybrid", "hybrid-cheap", "claude-api-standard", "claude-api-cheap"}
+	expectedPresets := []string{"claude", "claude-opus", "gemini", "claude-cheap", "gemini-cheap", "hybrid", "hybrid-cheap", "claude-api-standard", "claude-api-opus", "claude-api-cheap"}
 	for _, name := range expectedPresets {
 		if !strings.Contains(out, name) {
 			t.Errorf("formatPresets output missing preset %q", name)

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -135,7 +135,7 @@ context_reset_minutes = 8
 
 # 使用するモデル
 [agent.models]
-superintendent = "claude-opus-4-6"
+superintendent = "claude-opus-4-7"
 engineer = "claude-sonnet-4-6"
 
 # ブランチ設定


### PR DESCRIPTION
## Summary

- Add `claude-opus` and `claude-api-opus` presets to `madflow use` command
- Update default superintendent model from `claude-opus-4-6` to `claude-opus-4-7` in init template and docs
- Keep `config.go` fallback defaults unchanged (cost consideration)

Closes #249

**Note**: The Superintendent implemented directly due to orchestrator being unresponsive to TEAM_CREATE requests (3 attempts rejected with false "active team exists" error while teams.toml had no active teams).

## Changes

| File | Change |
|------|--------|
| `cmd/madflow/use.go` | Add `claude-opus` and `claude-api-opus` presets, update `formatPresets()` |
| `cmd/madflow/use_test.go` | Add test cases for new presets |
| `cmd/madflow/main.go` | Update init template default to `claude-opus-4-7` |
| `README.md` | Update preset table and example config |
| `docs/getting-started.md` | Update example config |

## Test plan

- [x] All existing tests pass (`go test ./...`)
- [x] New preset test cases added and passing
- [x] `formatPresets()` output includes new presets
- [x] No routing changes needed (Opus 4.7 uses default Claude CLI path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)