### PR TITLE
252: refactor: Orchestrator pure/effect分離 — Command sum type & DecideTeamAssignment

### DIFF
--- a/docs/specs/orchestrator-pure-effect-separation.md
+++ b/docs/specs/orchestrator-pure-effect-separation.md
@@ -1,0 +1,118 @@
+# Orchestrator Pure/Effect Separation
+
+## Overview
+
+Refactor `internal/orchestrator` to separate pure domain logic from effectful I/O and LLM calls.
+The goal is to improve testability by making decision logic independently testable without needing
+to mock the entire orchestrator infrastructure.
+
+## Command Sum Type
+
+### Problem
+
+`handleCommand` uses `strings.HasPrefix` to dispatch on command strings:
+
+```go
+switch {
+case strings.HasPrefix(body, "TEAM_CREATE"):
+    o.handleTeamCreate(ctx, body)
+case strings.HasPrefix(body, "TEAM_DISBAND"):
+    ...
+}
+```
+
+This is error-prone (prefix matching can be ambiguous) and hard to test without a full orchestrator.
+
+### Solution
+
+Introduce `type CommandType int` with `iota` constants and `ParseCommand(body string) Command`
+to centralize command parsing.
+
+```go
+type CommandType int
+
+const (
+    CommandTeamCreate   CommandType = iota
+    CommandTeamDisband
+    CommandRelease
+    CommandWakeGitHub
+    CommandPatrolComplete
+    CommandUnknown
+)
+
+type Command struct {
+    Type CommandType
+    Args []string
+}
+
+func ParseCommand(body string) Command
+```
+
+**Invariants**:
+- `ParseCommand` is a pure function with no side effects
+- If the body is empty or unrecognized, `Command{Type: CommandUnknown}` is returned
+- `Args` contains all whitespace-separated tokens after the command keyword
+- `CommandType.String()` returns a human-readable name for logging
+
+## Team Assignment Decision
+
+### Problem
+
+`handleTeamCreate` (150+ lines) mixes issue validation, decision logic, and effects
+(store updates, LLM team creation, chatlog writes) in one function. The rejection/assignment
+decision logic cannot be tested without a running orchestrator.
+
+### Solution
+
+Extract the pure decision logic into `DecideTeamAssignment`:
+
+```go
+type TeamAssignDecisionType int
+
+const (
+    AssignDecisionReject    TeamAssignDecisionType = iota // issue ineligible
+    AssignDecisionReuseIdle                               // assign to existing idle team
+    AssignDecisionCreate                                  // create new team
+    AssignDecisionDefer                                   // at capacity, retry later
+)
+
+type TeamAssignResult struct {
+    Decision TeamAssignDecisionType
+    Reason   string // human-readable explanation
+}
+
+func DecideTeamAssignment(iss issue.Issue, hasActiveTeam bool, hasIdleTeam bool, atCapacity bool) TeamAssignResult
+```
+
+**Decision matrix**:
+
+| Condition                             | Decision        |
+|---------------------------------------|-----------------|
+| issue status is terminal              | Reject          |
+| issue already has AssignedTeam > 0   | Reject          |
+| active/pending team exists for issue  | Reject          |
+| idle team available                   | ReuseIdle       |
+| at max_teams capacity                 | Defer           |
+| otherwise                             | Create          |
+
+**Invariants**:
+- `DecideTeamAssignment` is a pure function with no side effects
+- The orchestrator is responsible for executing effects based on the returned decision
+- Rejection reasons are human-readable for chatlog messages
+
+## Impact
+
+- `internal/orchestrator/command.go` (new file)
+- `internal/orchestrator/command_test.go` (new file)
+- `internal/orchestrator/decision.go` (new file)
+- `internal/orchestrator/decision_test.go` (new file)
+- `internal/orchestrator/orchestrator.go` (simplify handleCommand, handleTeamCreate)
+
+## Acceptance Criteria
+
+- `ParseCommand` correctly parses all recognized command strings
+- `DecideTeamAssignment` returns correct decisions for all input combinations
+- `handleCommand` uses `ParseCommand` instead of `strings.HasPrefix` switches
+- `handleTeamCreate` uses `DecideTeamAssignment` for decision logic
+- All existing tests pass
+- `orchestrator.go` line count decreases from 1468

--- a/internal/orchestrator/command.go
+++ b/internal/orchestrator/command.go
@@ -1,0 +1,81 @@
+package orchestrator
+
+import "strings"
+
+// CommandType is a sum type representing the set of valid orchestrator commands.
+// Using iota instead of raw strings prevents invalid command values from being constructed.
+type CommandType int
+
+const (
+	// CommandTeamCreate requests creation of a new team for an issue.
+	CommandTeamCreate CommandType = iota
+	// CommandTeamDisband requests disbanding an existing team.
+	CommandTeamDisband
+	// CommandRelease requests a new release.
+	CommandRelease
+	// CommandWakeGitHub wakes the GitHub polling subsystem from dormancy.
+	CommandWakeGitHub
+	// CommandPatrolComplete signals that an issue patrol cycle has completed.
+	CommandPatrolComplete
+	// CommandUnknown represents an unrecognized command.
+	CommandUnknown
+)
+
+// String returns the canonical command keyword for ct.
+func (ct CommandType) String() string {
+	switch ct {
+	case CommandTeamCreate:
+		return "TEAM_CREATE"
+	case CommandTeamDisband:
+		return "TEAM_DISBAND"
+	case CommandRelease:
+		return "RELEASE"
+	case CommandWakeGitHub:
+		return "WAKE_GITHUB"
+	case CommandPatrolComplete:
+		return "PATROL_COMPLETE"
+	default:
+		return "UNKNOWN"
+	}
+}
+
+// Command is a parsed orchestrator command with its type and arguments.
+type Command struct {
+	// Type identifies the kind of command.
+	Type CommandType
+	// Args contains the whitespace-separated tokens following the command keyword.
+	// For CommandUnknown, Args is nil.
+	Args []string
+}
+
+// ParseCommand parses a chatlog message body into a Command.
+// It is a pure function with no side effects.
+// If body is empty, whitespace-only, or begins with an unrecognized keyword,
+// a Command with Type == CommandUnknown is returned.
+func ParseCommand(body string) Command {
+	body = strings.TrimSpace(body)
+	if body == "" {
+		return Command{Type: CommandUnknown}
+	}
+	fields := strings.Fields(body)
+	keyword := fields[0]
+	args := fields[1:]
+
+	var cmdType CommandType
+	switch keyword {
+	case "TEAM_CREATE":
+		cmdType = CommandTeamCreate
+	case "TEAM_DISBAND":
+		cmdType = CommandTeamDisband
+	case "RELEASE":
+		cmdType = CommandRelease
+	case "WAKE_GITHUB":
+		cmdType = CommandWakeGitHub
+	case "PATROL_COMPLETE":
+		cmdType = CommandPatrolComplete
+	default:
+		return Command{Type: CommandUnknown}
+	}
+
+	return Command{Type: cmdType, Args: args}
+}

--- a/internal/orchestrator/command_test.go
+++ b/internal/orchestrator/command_test.go
@@ -1,0 +1,127 @@
+package orchestrator
+
+import (
+	"testing"
+)
+
+func TestParseCommand(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		wantType CommandType
+		wantArgs []string
+	}{
+		{
+			name:     "TEAM_CREATE with issue ID",
+			input:    "TEAM_CREATE gh-123",
+			wantType: CommandTeamCreate,
+			wantArgs: []string{"gh-123"},
+		},
+		{
+			name:     "TEAM_CREATE with extra text",
+			input:    "TEAM_CREATE gh-123（2回目）",
+			wantType: CommandTeamCreate,
+			wantArgs: []string{"gh-123（2回目）"},
+		},
+		{
+			name:     "TEAM_CREATE no args",
+			input:    "TEAM_CREATE",
+			wantType: CommandTeamCreate,
+			wantArgs: []string{},
+		},
+		{
+			name:     "TEAM_DISBAND with team number",
+			input:    "TEAM_DISBAND 2",
+			wantType: CommandTeamDisband,
+			wantArgs: []string{"2"},
+		},
+		{
+			name:     "RELEASE command",
+			input:    "RELEASE v1.2.3",
+			wantType: CommandRelease,
+			wantArgs: []string{"v1.2.3"},
+		},
+		{
+			name:     "WAKE_GITHUB no args",
+			input:    "WAKE_GITHUB",
+			wantType: CommandWakeGitHub,
+			wantArgs: []string{},
+		},
+		{
+			name:     "PATROL_COMPLETE no args",
+			input:    "PATROL_COMPLETE",
+			wantType: CommandPatrolComplete,
+			wantArgs: []string{},
+		},
+		{
+			name:     "unknown command",
+			input:    "UNKNOWN_CMD foo",
+			wantType: CommandUnknown,
+			wantArgs: nil,
+		},
+		{
+			name:     "empty body",
+			input:    "",
+			wantType: CommandUnknown,
+			wantArgs: nil,
+		},
+		{
+			name:     "whitespace only",
+			input:    "   ",
+			wantType: CommandUnknown,
+			wantArgs: nil,
+		},
+		{
+			name:     "leading whitespace trimmed",
+			input:    "  TEAM_CREATE gh-42",
+			wantType: CommandTeamCreate,
+			wantArgs: []string{"gh-42"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ParseCommand(tt.input)
+			if got.Type != tt.wantType {
+				t.Errorf("ParseCommand(%q).Type = %v, want %v", tt.input, got.Type, tt.wantType)
+			}
+			if tt.wantArgs == nil {
+				if len(got.Args) != 0 {
+					t.Errorf("ParseCommand(%q).Args = %v, want nil/empty", tt.input, got.Args)
+				}
+			} else {
+				if len(got.Args) != len(tt.wantArgs) {
+					t.Errorf("ParseCommand(%q).Args = %v, want %v", tt.input, got.Args, tt.wantArgs)
+				} else {
+					for i, arg := range got.Args {
+						if arg != tt.wantArgs[i] {
+							t.Errorf("ParseCommand(%q).Args[%d] = %q, want %q", tt.input, i, arg, tt.wantArgs[i])
+						}
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestCommandTypeString(t *testing.T) {
+	tests := []struct {
+		ct   CommandType
+		want string
+	}{
+		{CommandTeamCreate, "TEAM_CREATE"},
+		{CommandTeamDisband, "TEAM_DISBAND"},
+		{CommandRelease, "RELEASE"},
+		{CommandWakeGitHub, "WAKE_GITHUB"},
+		{CommandPatrolComplete, "PATROL_COMPLETE"},
+		{CommandUnknown, "UNKNOWN"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.want, func(t *testing.T) {
+			got := tt.ct.String()
+			if got != tt.want {
+				t.Errorf("CommandType(%d).String() = %q, want %q", tt.ct, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/orchestrator/decision.go
+++ b/internal/orchestrator/decision.go
@@ -1,0 +1,109 @@
+package orchestrator
+
+import (
+	"fmt"
+
+	"github.com/ytnobody/madflow/internal/issue"
+)
+
+// TeamAssignDecisionType is a sum type representing the possible outcomes
+// of a team assignment decision.
+type TeamAssignDecisionType int
+
+const (
+	// AssignDecisionReject means the issue is ineligible for team assignment.
+	AssignDecisionReject TeamAssignDecisionType = iota
+	// AssignDecisionReuseIdle means an existing idle standby team should be reused.
+	AssignDecisionReuseIdle
+	// AssignDecisionCreate means a new team should be created for the issue.
+	AssignDecisionCreate
+	// AssignDecisionDefer means team creation is deferred because max capacity is reached.
+	AssignDecisionDefer
+)
+
+// String returns a human-readable label for the decision type.
+func (d TeamAssignDecisionType) String() string {
+	switch d {
+	case AssignDecisionReject:
+		return "Reject"
+	case AssignDecisionReuseIdle:
+		return "ReuseIdle"
+	case AssignDecisionCreate:
+		return "Create"
+	case AssignDecisionDefer:
+		return "Defer"
+	default:
+		return fmt.Sprintf("TeamAssignDecisionType(%d)", int(d))
+	}
+}
+
+// TeamAssignResult holds the outcome of a team assignment decision.
+type TeamAssignResult struct {
+	// Decision is the action to take.
+	Decision TeamAssignDecisionType
+	// Reason is a human-readable explanation, suitable for chatlog or log output.
+	Reason string
+}
+
+// DecideTeamAssignment is a pure function that determines the correct team
+// assignment action for an issue given the current state of the team manager.
+//
+// Parameters:
+//   - iss:           the issue requesting a team
+//   - hasActiveTeam: true if an active or pending team already exists for the issue
+//   - hasIdleTeam:   true if an idle standby team is available for reuse
+//   - atCapacity:    true if the team manager is at max_teams capacity
+//
+// Decision priority (highest to lowest):
+//  1. Terminal status or already-assigned → Reject
+//  2. Active/pending team exists → Reject
+//  3. Idle team available → ReuseIdle
+//  4. At capacity → Defer
+//  5. Otherwise → Create
+func DecideTeamAssignment(iss issue.Issue, hasActiveTeam bool, hasIdleTeam bool, atCapacity bool) TeamAssignResult {
+	// Reject terminal issues.
+	if iss.Status.IsTerminal() {
+		return TeamAssignResult{
+			Decision: AssignDecisionReject,
+			Reason:   fmt.Sprintf("issue status is %s", iss.Status),
+		}
+	}
+
+	// Reject issues already assigned to a team.
+	if iss.AssignedTeam > 0 {
+		return TeamAssignResult{
+			Decision: AssignDecisionReject,
+			Reason:   fmt.Sprintf("アサイン済みです (チーム %d)", iss.AssignedTeam),
+		}
+	}
+
+	// Reject if an active or pending team already exists (duplicate prevention).
+	if hasActiveTeam {
+		return TeamAssignResult{
+			Decision: AssignDecisionReject,
+			Reason:   "アクティブなチームが既に存在します",
+		}
+	}
+
+	// Prefer reusing an idle standby team over creating a new one.
+	if hasIdleTeam {
+		return TeamAssignResult{
+			Decision: AssignDecisionReuseIdle,
+			Reason:   "idle standby team available for reuse",
+		}
+	}
+
+	// If at capacity, defer until a slot becomes available.
+	if atCapacity {
+		return TeamAssignResult{
+			Decision: AssignDecisionDefer,
+			Reason:   "team manager is at max_teams capacity",
+		}
+	}
+
+	// All checks passed: create a new team.
+	return TeamAssignResult{
+		Decision: AssignDecisionCreate,
+		Reason:   "new team will be created for the issue",
+	}
+}

--- a/internal/orchestrator/decision_test.go
+++ b/internal/orchestrator/decision_test.go
@@ -1,0 +1,144 @@
+package orchestrator
+
+import (
+	"testing"
+
+	"github.com/ytnobody/madflow/internal/issue"
+)
+
+func TestDecideTeamAssignment(t *testing.T) {
+	openIssue := issue.Issue{
+		ID:           "gh-100",
+		Title:        "test issue",
+		Status:       issue.StatusOpen,
+		AssignedTeam: 0,
+	}
+	inProgressIssue := issue.Issue{
+		ID:           "gh-101",
+		Title:        "test issue",
+		Status:       issue.StatusInProgress,
+		AssignedTeam: 0,
+	}
+	assignedIssue := issue.Issue{
+		ID:           "gh-102",
+		Title:        "test issue",
+		Status:       issue.StatusInProgress,
+		AssignedTeam: 3,
+	}
+	resolvedIssue := issue.Issue{
+		ID:     "gh-103",
+		Title:  "test issue",
+		Status: issue.StatusResolved,
+	}
+	closedIssue := issue.Issue{
+		ID:     "gh-104",
+		Title:  "test issue",
+		Status: issue.StatusClosed,
+	}
+
+	tests := []struct {
+		name          string
+		iss           issue.Issue
+		hasActiveTeam bool
+		hasIdleTeam   bool
+		atCapacity    bool
+		wantDecision  TeamAssignDecisionType
+	}{
+		{
+			name:         "resolved issue is rejected",
+			iss:          resolvedIssue,
+			wantDecision: AssignDecisionReject,
+		},
+		{
+			name:         "closed issue is rejected",
+			iss:          closedIssue,
+			wantDecision: AssignDecisionReject,
+		},
+		{
+			name:         "already assigned issue is rejected",
+			iss:          assignedIssue,
+			wantDecision: AssignDecisionReject,
+		},
+		{
+			name:          "issue with active team is rejected",
+			iss:           openIssue,
+			hasActiveTeam: true,
+			wantDecision:  AssignDecisionReject,
+		},
+		{
+			name:         "open issue with idle team reuses idle",
+			iss:          openIssue,
+			hasIdleTeam:  true,
+			wantDecision: AssignDecisionReuseIdle,
+		},
+		{
+			name:         "in_progress issue with idle team reuses idle",
+			iss:          inProgressIssue,
+			hasIdleTeam:  true,
+			wantDecision: AssignDecisionReuseIdle,
+		},
+		{
+			name:         "open issue at capacity is deferred",
+			iss:          openIssue,
+			atCapacity:   true,
+			wantDecision: AssignDecisionDefer,
+		},
+		{
+			name:         "open issue with no idle and no capacity creates new team",
+			iss:          openIssue,
+			wantDecision: AssignDecisionCreate,
+		},
+		{
+			name:         "in_progress issue with no assignment creates new team",
+			iss:          inProgressIssue,
+			wantDecision: AssignDecisionCreate,
+		},
+		{
+			name:          "active team check takes priority over idle team",
+			iss:           openIssue,
+			hasActiveTeam: true,
+			hasIdleTeam:   true,
+			wantDecision:  AssignDecisionReject,
+		},
+		{
+			name:         "idle team takes priority over capacity",
+			iss:          openIssue,
+			hasIdleTeam:  true,
+			atCapacity:   true,
+			wantDecision: AssignDecisionReuseIdle,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := DecideTeamAssignment(tt.iss, tt.hasActiveTeam, tt.hasIdleTeam, tt.atCapacity)
+			if result.Decision != tt.wantDecision {
+				t.Errorf("DecideTeamAssignment() Decision = %v, want %v (reason: %s)",
+					result.Decision, tt.wantDecision, result.Reason)
+			}
+			if result.Reason == "" {
+				t.Errorf("DecideTeamAssignment() returned empty Reason")
+			}
+		})
+	}
+}
+
+func TestTeamAssignDecisionTypeString(t *testing.T) {
+	tests := []struct {
+		d    TeamAssignDecisionType
+		want string
+	}{
+		{AssignDecisionReject, "Reject"},
+		{AssignDecisionReuseIdle, "ReuseIdle"},
+		{AssignDecisionCreate, "Create"},
+		{AssignDecisionDefer, "Defer"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.want, func(t *testing.T) {
+			got := tt.d.String()
+			if got != tt.want {
+				t.Errorf("TeamAssignDecisionType(%d).String() = %q, want %q", tt.d, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -559,21 +559,20 @@ func (o *Orchestrator) watchCommands(ctx context.Context) {
 
 // handleCommand processes orchestrator commands from the chatlog.
 func (o *Orchestrator) handleCommand(ctx context.Context, msg chatlog.Message) {
-	body := strings.TrimSpace(msg.Body)
-
-	switch {
-	case strings.HasPrefix(body, "TEAM_CREATE"):
-		o.handleTeamCreate(ctx, body)
-	case strings.HasPrefix(body, "TEAM_DISBAND"):
-		o.handleTeamDisband(body)
-	case strings.HasPrefix(body, "RELEASE"):
-		o.handleRelease(body)
-	case strings.HasPrefix(body, "WAKE_GITHUB"):
+	cmd := ParseCommand(msg.Body)
+	switch cmd.Type {
+	case CommandTeamCreate:
+		o.handleTeamCreate(ctx, cmd)
+	case CommandTeamDisband:
+		o.handleTeamDisband(cmd)
+	case CommandRelease:
+		o.handleRelease(cmd)
+	case CommandWakeGitHub:
 		o.handleWakeGitHub()
-	case strings.HasPrefix(body, "PATROL_COMPLETE"):
+	case CommandPatrolComplete:
 		o.handlePatrolComplete()
 	default:
-		log.Printf("[orchestrator] unknown command from %s: %s", msg.Sender, body)
+		log.Printf("[orchestrator] unknown command from %s: %s", msg.Sender, strings.TrimSpace(msg.Body))
 	}
 }
 
@@ -622,9 +621,8 @@ func normalizeIssueID(s string) string {
 // The expensive Create call is run in a goroutine so the watchCommands loop
 // is not blocked while waiting for the LLM to respond (which can take 10+ min).
 // Pre-validation checks are synchronous and fast.
-func (o *Orchestrator) handleTeamCreate(ctx context.Context, body string) {
-	parts := strings.Fields(body)
-	if len(parts) < 2 {
+func (o *Orchestrator) handleTeamCreate(ctx context.Context, cmd Command) {
+	if len(cmd.Args) == 0 {
 		log.Printf("[orchestrator] TEAM_CREATE missing issue ID")
 		return
 	}
@@ -632,15 +630,16 @@ func (o *Orchestrator) handleTeamCreate(ctx context.Context, body string) {
 	// Normalize the issue ID: strip any non-ID characters that the superintendent
 	// may append when retrying (e.g. "gh-121（2回目の要求）。チームアサインをお願いします。").
 	// Issue IDs consist solely of ASCII alphanumeric characters and hyphens.
-	issueID := normalizeIssueID(parts[1])
+	rawID := cmd.Args[0]
+	issueID := normalizeIssueID(rawID)
 	if issueID == "" {
-		log.Printf("[orchestrator] TEAM_CREATE: could not extract valid issue ID from %q", parts[1])
+		log.Printf("[orchestrator] TEAM_CREATE: could not extract valid issue ID from %q", rawID)
 		o.appendOrLog("superintendent", "orchestrator",
-			fmt.Sprintf("TEAM_CREATE は拒否されました: 有効なイシューIDを抽出できませんでした (%q)", parts[1]))
+			fmt.Sprintf("TEAM_CREATE は拒否されました: 有効なイシューIDを抽出できませんでした (%q)", rawID))
 		return
 	}
-	if issueID != parts[1] {
-		log.Printf("[orchestrator] TEAM_CREATE: normalized issue ID %q -> %q (stripped extra text)", parts[1], issueID)
+	if issueID != rawID {
+		log.Printf("[orchestrator] TEAM_CREATE: normalized issue ID %q -> %q (stripped extra text)", rawID, issueID)
 	}
 
 	existingIss, err := o.store.Get(issueID)
@@ -651,73 +650,72 @@ func (o *Orchestrator) handleTeamCreate(ctx context.Context, body string) {
 		return
 	}
 
-	// Reject team creation for issues that are already closed or resolved.
-	if existingIss.Status == issue.StatusClosed || existingIss.Status == issue.StatusResolved {
-		log.Printf("[orchestrator] TEAM_CREATE rejected: issue %s is %s", issueID, existingIss.Status)
+	// Determine the correct action using the pure decision function.
+	// This separates the decision logic from the effectful I/O operations below.
+	decision := DecideTeamAssignment(
+		*existingIss,
+		o.teams.HasIssue(issueID),
+		o.teams.HasIdle(),
+		o.teams.Full(),
+	)
+
+	switch decision.Decision {
+	case AssignDecisionReject:
+		log.Printf("[orchestrator] TEAM_CREATE rejected: issue %s: %s", issueID, decision.Reason)
 		o.appendOrLog("superintendent", "orchestrator",
-			fmt.Sprintf("TEAM_CREATE %s は拒否されました: イシューのステータスが %s です", issueID, existingIss.Status))
+			fmt.Sprintf("TEAM_CREATE %s は拒否されました: %s", issueID, decision.Reason))
 		return
-	}
 
-	// Reject if issue is already assigned to a team.
-	if existingIss.AssignedTeam > 0 {
-		log.Printf("[orchestrator] TEAM_CREATE rejected: issue %s already assigned to team %d", issueID, existingIss.AssignedTeam)
-		o.appendOrLog("superintendent", "orchestrator",
-			fmt.Sprintf("TEAM_CREATE %s は拒否されました: 既にチーム %d にアサイン済みです", issueID, existingIss.AssignedTeam))
+	case AssignDecisionReuseIdle:
+		o.executeReuseIdle(issueID, existingIss)
 		return
-	}
 
-	// Reject if an active or pending team is already working on this issue
-	// (covers both the race window where AssignedTeam is not yet updated
-	// and the window where Create() is still in progress).
-	if o.teams.HasIssue(issueID) {
-		log.Printf("[orchestrator] TEAM_CREATE rejected: active/pending team already exists for issue %s", issueID)
-		o.appendOrLog("superintendent", "orchestrator",
-			fmt.Sprintf("TEAM_CREATE %s は拒否されました: 既にアクティブまたは作成中のチームが存在します", issueID))
-		return
-	}
-
-	issueTitle := existingIss.Title
-
-	// Before creating a new team, try to reuse an existing idle standby team.
-	// When all maxTeams slots are occupied by standby teams (IssueID == ""),
-	// calling Create() would fail with "maximum teams reached". Instead, we
-	// assign the issue directly to one of the idle teams and notify its engineer.
-	if idleTeam, ok := o.teams.AssignIdle(issueID, issueTitle); ok {
-		log.Printf("[orchestrator] TEAM_CREATE %s: reusing idle team %d", issueID, idleTeam.ID)
-
-		// Update the issue to reflect the new assignment.
-		existingIss.AssignedTeam = idleTeam.ID
-		existingIss.Status = issue.StatusInProgress
-		if updErr := o.store.Update(existingIss); updErr != nil {
-			log.Printf("[orchestrator] TEAM_CREATE: failed to update issue %s assignment: %v", issueID, updErr)
-		}
-
-		// Notify the idle team's engineer about the new assignment via chatlog.
-		engineerID := idleTeam.Engineer.ID.String()
-		o.appendOrLog(engineerID, "superintendent",
-			fmt.Sprintf("イシュー %s の実装をお願いします。あなたにアサインしました。", issueID))
-
-		// Notify superintendent that the assignment was completed.
-		o.appendOrLog("superintendent", "orchestrator",
-			fmt.Sprintf("TEAM_CREATE %s: アイドルチーム %d (%s) にアサインしました", issueID, idleTeam.ID, engineerID))
-		return
-	}
-
-	// No idle team available.
-	// Check if we are already at the maximum team capacity.  If so, we cannot
-	// create a new team and must wait until an existing team is disbanded.
-	// Reject early (before marking in_progress) so the issue stays open and
-	// the superintendent can retry after a team slot becomes available.
-	if o.teams.Full() {
-		log.Printf("[orchestrator] TEAM_CREATE %s: rejected — at max_teams capacity (%d)", issueID, o.teams.Cap())
+	case AssignDecisionDefer:
+		log.Printf("[orchestrator] TEAM_CREATE %s: deferred — at max_teams capacity (%d)", issueID, o.teams.Cap())
 		o.appendOrLog("superintendent", "orchestrator",
 			fmt.Sprintf("TEAM_CREATE %s は保留されました: チームが上限 (max_teams=%d) に達しています。既存チームが解放されるまで待機してください。",
 				issueID, o.teams.Cap()))
 		return
+
+	case AssignDecisionCreate:
+		o.executeCreateTeam(ctx, issueID, existingIss)
+	}
+}
+
+// executeReuseIdle assigns an idle standby team to the given issue.
+// This is the effectful part of the ReuseIdle decision.
+func (o *Orchestrator) executeReuseIdle(issueID string, existingIss *issue.Issue) {
+	idleTeam, ok := o.teams.AssignIdle(issueID, existingIss.Title)
+	if !ok {
+		// Race condition: idle team disappeared between DecideTeamAssignment and now.
+		// Log and return; the superintendent can retry.
+		log.Printf("[orchestrator] TEAM_CREATE %s: idle team disappeared, retrying is safe", issueID)
+		return
+	}
+	log.Printf("[orchestrator] TEAM_CREATE %s: reusing idle team %d", issueID, idleTeam.ID)
+
+	// Update the issue to reflect the new assignment.
+	existingIss.AssignedTeam = idleTeam.ID
+	existingIss.Status = issue.StatusInProgress
+	if updErr := o.store.Update(existingIss); updErr != nil {
+		log.Printf("[orchestrator] TEAM_CREATE: failed to update issue %s assignment: %v", issueID, updErr)
 	}
 
-	// Capacity is available — create a new team.
+	// Notify the idle team's engineer about the new assignment via chatlog.
+	engineerID := idleTeam.Engineer.ID.String()
+	o.appendOrLog(engineerID, "superintendent",
+		fmt.Sprintf("イシュー %s の実装をお願いします。あなたにアサインしました。", issueID))
+
+	// Notify superintendent that the assignment was completed.
+	o.appendOrLog("superintendent", "orchestrator",
+		fmt.Sprintf("TEAM_CREATE %s: アイドルチーム %d (%s) にアサインしました", issueID, idleTeam.ID, engineerID))
+}
+
+// executeCreateTeam creates a new team for the given issue asynchronously.
+// This is the effectful part of the Create decision.
+func (o *Orchestrator) executeCreateTeam(ctx context.Context, issueID string, existingIss *issue.Issue) {
+	issueTitle := existingIss.Title
+
 	// Mark issue as in_progress immediately to prevent the superintendent
 	// from sending duplicate TEAM_CREATE commands while the team is being created.
 	existingIss.Status = issue.StatusInProgress
@@ -786,13 +784,12 @@ func (o *Orchestrator) Wait() {
 
 // handleTeamDisband disbands the team for an issue and cleans up its worktrees.
 // Expected format: TEAM_DISBAND issue-id
-func (o *Orchestrator) handleTeamDisband(body string) {
-	parts := strings.Fields(body)
-	if len(parts) < 2 {
+func (o *Orchestrator) handleTeamDisband(cmd Command) {
+	if len(cmd.Args) == 0 {
 		log.Printf("[orchestrator] TEAM_DISBAND missing issue ID")
 		return
 	}
-	issueID := parts[1]
+	issueID := cmd.Args[0]
 
 	teamNum, err := o.teams.DisbandByIssue(issueID)
 	if err != nil {
@@ -806,7 +803,7 @@ func (o *Orchestrator) handleTeamDisband(body string) {
 
 // handleRelease triggers a develop -> main merge.
 // Expected format: RELEASE
-func (o *Orchestrator) handleRelease(_ string) {
+func (o *Orchestrator) handleRelease(_ Command) {
 	log.Println("[orchestrator] release requested")
 	for name, repo := range o.repos {
 		if err := repo.Checkout(o.cfg.Branches.Main); err != nil {

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -123,7 +123,7 @@ func TestHandleTeamCreateMissingID(t *testing.T) {
 	orc := New(cfg, dir, t.TempDir())
 
 	// TEAM_CREATE without issue ID should not panic
-	orc.handleTeamCreate(t.Context(), "TEAM_CREATE")
+	orc.handleTeamCreate(t.Context(), ParseCommand("TEAM_CREATE"))
 }
 
 func TestHandleTeamDisbandMissingID(t *testing.T) {
@@ -134,7 +134,7 @@ func TestHandleTeamDisbandMissingID(t *testing.T) {
 	orc := New(cfg, dir, t.TempDir())
 
 	// TEAM_DISBAND without issue ID should not panic
-	orc.handleTeamDisband("TEAM_DISBAND")
+	orc.handleTeamDisband(ParseCommand("TEAM_DISBAND"))
 }
 
 func TestChatLogPath(t *testing.T) {
@@ -473,7 +473,7 @@ func TestHandleTeamCreateRejectsClosedIssue(t *testing.T) {
 	defer cancel()
 
 	teamsBefore := orc.Teams().Count()
-	orc.handleTeamCreate(ctx, fmt.Sprintf("TEAM_CREATE %s", iss.ID))
+	orc.handleTeamCreate(ctx, ParseCommand(fmt.Sprintf("TEAM_CREATE %s", iss.ID)))
 
 	// No new team should be created.
 	if orc.Teams().Count() != teamsBefore {
@@ -515,7 +515,7 @@ func TestHandleTeamCreateRejectsAlreadyAssigned(t *testing.T) {
 	defer cancel()
 
 	teamsBefore := orc.Teams().Count()
-	orc.handleTeamCreate(ctx, fmt.Sprintf("TEAM_CREATE %s", iss.ID))
+	orc.handleTeamCreate(ctx, ParseCommand(fmt.Sprintf("TEAM_CREATE %s", iss.ID)))
 
 	// No new team should be created.
 	if orc.Teams().Count() != teamsBefore {
@@ -562,7 +562,7 @@ func TestHandleTeamCreateRejectsActiveTeam(t *testing.T) {
 	}
 
 	teamsBefore := orc.Teams().Count()
-	orc.handleTeamCreate(ctx, fmt.Sprintf("TEAM_CREATE %s", iss.ID))
+	orc.handleTeamCreate(ctx, ParseCommand(fmt.Sprintf("TEAM_CREATE %s", iss.ID)))
 
 	// No new team should be created.
 	if orc.Teams().Count() != teamsBefore {
@@ -936,7 +936,7 @@ func TestHandleTeamCreateUsesIdleTeam(t *testing.T) {
 	iss, _ := orc.Store().Create("New Issue for Idle Team", "body")
 
 	// Call TEAM_CREATE — should reuse an idle team instead of failing.
-	orc.handleTeamCreate(ctx, fmt.Sprintf("TEAM_CREATE %s", iss.ID))
+	orc.handleTeamCreate(ctx, ParseCommand(fmt.Sprintf("TEAM_CREATE %s", iss.ID)))
 
 	// Team count must not increase (no new team created).
 	if orc.Teams().Count() != 2 {
@@ -1004,7 +1004,7 @@ func TestHandleTeamCreateCreatesNewTeamWhenNoIdle(t *testing.T) {
 	iss, _ := orc.Store().Create("New Issue No Idle", "body")
 
 	// Call TEAM_CREATE — all existing teams are busy, so it must try to create a new one.
-	orc.handleTeamCreate(ctx, fmt.Sprintf("TEAM_CREATE %s", iss.ID))
+	orc.handleTeamCreate(ctx, ParseCommand(fmt.Sprintf("TEAM_CREATE %s", iss.ID)))
 
 	// Wait for the async goroutine to complete before inspecting state.
 	orc.Wait()
@@ -1356,7 +1356,7 @@ func TestHandleTeamCreateMalformedIssueID(t *testing.T) {
 	// Simulate the superintendent sending TEAM_CREATE with appended Japanese text,
 	// mimicking the exact pattern observed in the gh-121 incident.
 	malformed := "TEAM_CREATE gh-99（2回目の要求）。チームアサインをお願いします。"
-	orc.handleTeamCreate(ctx, malformed)
+	orc.handleTeamCreate(ctx, ParseCommand(malformed))
 
 	// The issue should have been transitioned to in_progress (assigned to a team),
 	// meaning the malformed ID was normalized and the lookup succeeded.
@@ -1416,7 +1416,7 @@ func TestHandleTeamCreateRejectsWhenAtMaxCapacityAllBusy(t *testing.T) {
 	iss, _ := orc.Store().Create("New Issue Cannot Assign", "body")
 
 	// Call TEAM_CREATE — all slots are full with busy teams; no idle team exists.
-	orc.handleTeamCreate(ctx, fmt.Sprintf("TEAM_CREATE %s", iss.ID))
+	orc.handleTeamCreate(ctx, ParseCommand(fmt.Sprintf("TEAM_CREATE %s", iss.ID)))
 
 	// Team count must NOT have increased.
 	if orc.Teams().Count() != 2 {

--- a/internal/team/team.go
+++ b/internal/team/team.go
@@ -288,6 +288,20 @@ func (m *Manager) Full() bool {
 	return len(m.teams)+m.pendingCount >= m.maxTeams
 }
 
+// HasIdle returns true if at least one idle standby team (IssueID == "") exists.
+// An idle team can be reused for a new issue via AssignIdle instead of creating
+// a fresh team. This method is safe to call concurrently.
+func (m *Manager) HasIdle() bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for _, t := range m.teams {
+		if t.IssueID == "" {
+			return true
+		}
+	}
+	return false
+}
+
 // Cap returns the configured maximum number of concurrent teams.
 func (m *Manager) Cap() int {
 	m.mu.Lock()


### PR DESCRIPTION
Issue: ytnobody-MADFLOW-252

## 概要

`internal/orchestrator` の純粋ロジックと副作用を分離し、テスト容易性・保守性を向上させた。

## 変更内容

### 新規ファイル
- `internal/orchestrator/command.go`: `CommandType` iota sum type と `ParseCommand` 純粋関数を実装
- `internal/orchestrator/command_test.go`: ParseCommand のテーブル駆動テスト
- `internal/orchestrator/decision.go`: `DecideTeamAssignment` 純粋判定関数を実装（チームアサイン判定ロジックをIOから分離）
- `internal/orchestrator/decision_test.go`: DecideTeamAssignment のテーブル駆動テスト
- `docs/specs/orchestrator-pure-effect-separation.md`: 設計仕様書

### 変更ファイル
- `internal/orchestrator/orchestrator.go`:
  - `handleCommand` を文字列 prefix 分岐から `ParseCommand` 経由の `CommandType` switch に置き換え
  - `handleTeamCreate` を `DecideTeamAssignment` 利用に切り替え、`executeReuseIdle`/`executeCreateTeam` へ分割
  - `handleTeamDisband`/`handleRelease` のシグネチャを `cmd Command` に統一
- `internal/team/team.go`: `HasIdle()` メソッドを追加（アイドルチーム存在確認の純粋クエリ）

## アーキテクチャ改善

- Pure: `ParseCommand(string) Command`, `DecideTeamAssignment(Issue, bool, bool, bool) TeamAssignResult`
- Effect: `executeReuseIdle`, `executeCreateTeam`（副作用を明示的に分離）

## テスト

全15パッケージのテストがパス。