### PR TITLE
254: refactor: Agent バックエンド選択の sum type 化 (internal/agent)

### DIFF
--- a/docs/specs/agent-backend-sum-type.md
+++ b/docs/specs/agent-backend-sum-type.md
@@ -1,0 +1,108 @@
+# Agent Backend Sum Type
+
+## Overview
+
+The `internal/agent` package is refactored to replace scattered string-prefix matching for backend selection with a `Backend` sum type and a single `ParseModel` function that converts model strings to typed backends.
+
+## Problem (Before)
+
+`NewAgent` in `agent.go` selects the backend using string prefix matching in a switch statement:
+
+```go
+switch {
+case cfg.Model == "test":
+    proc = &noopProcess{}
+case strings.HasPrefix(cfg.Model, "gemini-"):
+    proc = NewGeminiAPIProcess(...)
+case strings.HasPrefix(cfg.Model, "anthropic/"):
+    proc = NewAnthropicAPIProcess(...)
+case strings.HasPrefix(cfg.Model, "copilot/"):
+    proc = NewCopilotCLIProcess(...)
+default:
+    proc = NewClaudeStreamProcess(...)
+}
+```
+
+Issues:
+- String prefix logic is duplicated whenever a new backend needs to be detected
+- New backends require changes across multiple call sites
+- The relationship between model string and backend is implicit
+
+## Solution (After)
+
+### Types
+
+```go
+// Backend represents which AI backend an agent uses.
+type Backend int
+
+const (
+    BackendClaudeCLI    Backend = iota // Default: Claude CLI (claude command)
+    BackendAnthropicAPI                 // anthropic/ prefix → Anthropic API
+    BackendGeminiAPI                    // gemini- prefix → Gemini API
+    BackendCopilotCLI                   // copilot/ prefix → GitHub Copilot CLI
+    BackendTest                         // "test" → no-op process for testing
+)
+
+// ModelID is the model identifier string used when calling the backend.
+type ModelID string
+```
+
+### ParseModel Function
+
+```go
+// ParseModel parses a model string into a Backend and ModelID.
+// This is the single point where model strings are converted to typed backends.
+// Returns an error if the model string is invalid or empty.
+func ParseModel(model string) (Backend, ModelID, error)
+```
+
+Parsing rules:
+- `"test"` → `(BackendTest, "test", nil)`
+- `strings.HasPrefix(model, "gemini-")` → `(BackendGeminiAPI, ModelID(model), nil)`
+- `strings.HasPrefix(model, "anthropic/")` → `(BackendAnthropicAPI, ModelID(model), nil)`
+- `strings.HasPrefix(model, "copilot/")` → `(BackendCopilotCLI, ModelID(model), nil)`
+- `model == ""` → error: model string is required
+- anything else → `(BackendClaudeCLI, ModelID(model), nil)`
+
+### NewAgent Simplified
+
+`NewAgent` calls `ParseModel` to select the backend, then delegates process creation to an internal `newProcessForBackend` helper:
+
+```go
+func NewAgent(cfg AgentConfig) *Agent {
+    var proc Process
+    if cfg.Process != nil {
+        proc = cfg.Process
+    } else {
+        backend, modelID, err := ParseModel(cfg.Model)
+        if err != nil {
+            log.Printf("[agent] model parse error: %v, defaulting to ClaudeCLI", err)
+            backend, modelID = BackendClaudeCLI, ModelID(cfg.Model)
+        }
+        proc = newProcessForBackend(backend, modelID, cfg)
+    }
+    ...
+}
+```
+
+## File Organization
+
+- New file: `internal/agent/backend.go` — `Backend` type, constants, `ParseModel`, `newProcessForBackend`
+- Modified: `internal/agent/agent.go` — `NewAgent` simplified to use `ParseModel`
+- New test file: `internal/agent/backend_test.go` — tests for `ParseModel`
+
+## Test Strategy
+
+`TestParseModel` with table-driven tests covering:
+- Known prefixes: `gemini-2.5-pro`, `anthropic/claude-opus-4-7`, `copilot/gpt-4o`
+- Claude CLI default: `claude-sonnet-4-6`, `claude-haiku-4-5`
+- Test special case: `"test"`
+- Empty string error case
+
+## Backward Compatibility
+
+- `NewAgent(cfg AgentConfig) *Agent` signature is unchanged
+- `AgentConfig.Model` field is unchanged (still a string)
+- `Backend` and `ParseModel` are new additions to the public API
+- All existing tests pass without modification

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -53,37 +53,12 @@ func NewAgent(cfg AgentConfig) *Agent {
 	if cfg.Process != nil {
 		proc = cfg.Process
 	} else {
-		switch {
-		case cfg.Model == "test":
-			proc = &noopProcess{}
-		case strings.HasPrefix(cfg.Model, "gemini-"):
-			proc = NewGeminiAPIProcess(GeminiAPIOptions{
-				SystemPrompt: cfg.SystemPrompt,
-				Model:        cfg.Model,
-				WorkDir:      cfg.WorkDir,
-				BashTimeout:  cfg.BashTimeout,
-			})
-		case strings.HasPrefix(cfg.Model, "anthropic/"):
-			proc = NewAnthropicAPIProcess(AnthropicAPIOptions{
-				SystemPrompt: cfg.SystemPrompt,
-				Model:        cfg.Model,
-				WorkDir:      cfg.WorkDir,
-				BashTimeout:  cfg.BashTimeout,
-			})
-		case strings.HasPrefix(cfg.Model, "copilot/"):
-			proc = NewCopilotCLIProcess(CopilotCLIOptions{
-				SystemPrompt: cfg.SystemPrompt,
-				Model:        cfg.Model,
-				WorkDir:      cfg.WorkDir,
-				BashTimeout:  cfg.BashTimeout,
-			})
-		default:
-			proc = NewClaudeStreamProcess(ClaudeOptions{
-				SystemPrompt: cfg.SystemPrompt,
-				Model:        cfg.Model,
-				WorkDir:      cfg.WorkDir,
-			})
+		backend, modelID, err := ParseModel(cfg.Model)
+		if err != nil {
+			log.Printf("[agent] model parse error (%q): %v, defaulting to ClaudeCLI", cfg.Model, err)
+			backend, modelID = BackendClaudeCLI, cfg.Model
 		}
+		proc = newProcessForBackend(backend, modelID, cfg)
 	}
 
 	lang := cfg.Language

--- a/internal/agent/backend.go
+++ b/internal/agent/backend.go
@@ -1,0 +1,99 @@
+package agent
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Backend represents which AI backend an agent uses.
+// It is a closed sum type: new backends must be added here and handled in ParseModel.
+type Backend int
+
+const (
+	// BackendClaudeCLI is the default backend using the local `claude` CLI.
+	BackendClaudeCLI Backend = iota
+	// BackendAnthropicAPI uses the Anthropic API directly (model prefix: "anthropic/").
+	BackendAnthropicAPI
+	// BackendGeminiAPI uses the Google Gemini API (model prefix: "gemini-").
+	BackendGeminiAPI
+	// BackendCopilotCLI uses the GitHub Copilot CLI (model prefix: "copilot/").
+	BackendCopilotCLI
+	// BackendTest is a no-op backend used in tests (model value: "test").
+	BackendTest
+)
+
+// String returns a human-readable name for the Backend.
+func (b Backend) String() string {
+	switch b {
+	case BackendClaudeCLI:
+		return "ClaudeCLI"
+	case BackendAnthropicAPI:
+		return "AnthropicAPI"
+	case BackendGeminiAPI:
+		return "GeminiAPI"
+	case BackendCopilotCLI:
+		return "CopilotCLI"
+	case BackendTest:
+		return "Test"
+	default:
+		return fmt.Sprintf("Backend(%d)", int(b))
+	}
+}
+
+// ModelID is the model identifier string passed to the backend.
+type ModelID = string
+
+// ParseModel converts a model string into a Backend and ModelID.
+// This is the single point of conversion from model strings to typed backends.
+// Returns an error if model is empty.
+func ParseModel(model string) (Backend, ModelID, error) {
+	switch {
+	case model == "":
+		return BackendClaudeCLI, "", fmt.Errorf("model string is required")
+	case model == "test":
+		return BackendTest, model, nil
+	case strings.HasPrefix(model, "gemini-"):
+		return BackendGeminiAPI, model, nil
+	case strings.HasPrefix(model, "anthropic/"):
+		return BackendAnthropicAPI, model, nil
+	case strings.HasPrefix(model, "copilot/"):
+		return BackendCopilotCLI, model, nil
+	default:
+		return BackendClaudeCLI, model, nil
+	}
+}
+
+// newProcessForBackend creates the appropriate Process for the given Backend and model.
+func newProcessForBackend(backend Backend, modelID ModelID, cfg AgentConfig) Process {
+	switch backend {
+	case BackendTest:
+		return &noopProcess{}
+	case BackendGeminiAPI:
+		return NewGeminiAPIProcess(GeminiAPIOptions{
+			SystemPrompt: cfg.SystemPrompt,
+			Model:        modelID,
+			WorkDir:      cfg.WorkDir,
+			BashTimeout:  cfg.BashTimeout,
+		})
+	case BackendAnthropicAPI:
+		return NewAnthropicAPIProcess(AnthropicAPIOptions{
+			SystemPrompt: cfg.SystemPrompt,
+			Model:        modelID,
+			WorkDir:      cfg.WorkDir,
+			BashTimeout:  cfg.BashTimeout,
+		})
+	case BackendCopilotCLI:
+		return NewCopilotCLIProcess(CopilotCLIOptions{
+			SystemPrompt: cfg.SystemPrompt,
+			Model:        modelID,
+			WorkDir:      cfg.WorkDir,
+			BashTimeout:  cfg.BashTimeout,
+		})
+	default: // BackendClaudeCLI
+		return NewClaudeStreamProcess(ClaudeOptions{
+			SystemPrompt: cfg.SystemPrompt,
+			Model:        modelID,
+			WorkDir:      cfg.WorkDir,
+		})
+	}
+}

--- a/internal/agent/backend_test.go
+++ b/internal/agent/backend_test.go
@@ -1,0 +1,175 @@
+package agent
+
+import (
+	"testing"
+)
+
+func TestParseModel(t *testing.T) {
+	tests := []struct {
+		name        string
+		model       string
+		wantBackend Backend
+		wantModelID ModelID
+		wantErr     bool
+	}{
+		{
+			name:        "test special value",
+			model:       "test",
+			wantBackend: BackendTest,
+			wantModelID: "test",
+		},
+		{
+			name:        "gemini prefix",
+			model:       "gemini-2.5-pro",
+			wantBackend: BackendGeminiAPI,
+			wantModelID: "gemini-2.5-pro",
+		},
+		{
+			name:        "gemini flash",
+			model:       "gemini-2.5-flash",
+			wantBackend: BackendGeminiAPI,
+			wantModelID: "gemini-2.5-flash",
+		},
+		{
+			name:        "anthropic prefix",
+			model:       "anthropic/claude-opus-4-7",
+			wantBackend: BackendAnthropicAPI,
+			wantModelID: "anthropic/claude-opus-4-7",
+		},
+		{
+			name:        "anthropic haiku",
+			model:       "anthropic/claude-haiku-4-5",
+			wantBackend: BackendAnthropicAPI,
+			wantModelID: "anthropic/claude-haiku-4-5",
+		},
+		{
+			name:        "copilot prefix",
+			model:       "copilot/gpt-4o",
+			wantBackend: BackendCopilotCLI,
+			wantModelID: "copilot/gpt-4o",
+		},
+		{
+			name:        "claude cli default - sonnet",
+			model:       "claude-sonnet-4-6",
+			wantBackend: BackendClaudeCLI,
+			wantModelID: "claude-sonnet-4-6",
+		},
+		{
+			name:        "claude cli default - haiku",
+			model:       "claude-haiku-4-5",
+			wantBackend: BackendClaudeCLI,
+			wantModelID: "claude-haiku-4-5",
+		},
+		{
+			name:        "claude cli default - opus",
+			model:       "claude-opus-4-7",
+			wantBackend: BackendClaudeCLI,
+			wantModelID: "claude-opus-4-7",
+		},
+		{
+			name:    "empty string returns error",
+			model:   "",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			backend, modelID, err := ParseModel(tt.model)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("ParseModel(%q): expected error, got nil", tt.model)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ParseModel(%q): unexpected error: %v", tt.model, err)
+			}
+			if backend != tt.wantBackend {
+				t.Errorf("ParseModel(%q): backend = %v, want %v", tt.model, backend, tt.wantBackend)
+			}
+			if modelID != tt.wantModelID {
+				t.Errorf("ParseModel(%q): modelID = %q, want %q", tt.model, modelID, tt.wantModelID)
+			}
+		})
+	}
+}
+
+func TestBackendString(t *testing.T) {
+	tests := []struct {
+		backend Backend
+		want    string
+	}{
+		{BackendClaudeCLI, "ClaudeCLI"},
+		{BackendAnthropicAPI, "AnthropicAPI"},
+		{BackendGeminiAPI, "GeminiAPI"},
+		{BackendCopilotCLI, "CopilotCLI"},
+		{BackendTest, "Test"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.want, func(t *testing.T) {
+			got := tt.backend.String()
+			if got != tt.want {
+				t.Errorf("Backend(%d).String() = %q, want %q", tt.backend, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNewAgentUsesParseModel_Gemini(t *testing.T) {
+	cfg := AgentConfig{
+		ID:    AgentID{Role: RoleEngineer, TeamNum: 1},
+		Model: "gemini-2.5-flash",
+	}
+	a := NewAgent(cfg)
+	if a == nil {
+		t.Fatal("NewAgent returned nil")
+	}
+	// Process should be a GeminiAPIProcess
+	if _, ok := a.Process.(*GeminiAPIProcess); !ok {
+		t.Errorf("expected GeminiAPIProcess, got %T", a.Process)
+	}
+}
+
+func TestNewAgentUsesParseModel_Anthropic(t *testing.T) {
+	cfg := AgentConfig{
+		ID:    AgentID{Role: RoleEngineer, TeamNum: 1},
+		Model: "anthropic/claude-haiku-4-5",
+	}
+	a := NewAgent(cfg)
+	if a == nil {
+		t.Fatal("NewAgent returned nil")
+	}
+	if _, ok := a.Process.(*AnthropicAPIProcess); !ok {
+		t.Errorf("expected AnthropicAPIProcess, got %T", a.Process)
+	}
+}
+
+func TestNewAgentUsesParseModel_Test(t *testing.T) {
+	cfg := AgentConfig{
+		ID:    AgentID{Role: RoleEngineer, TeamNum: 1},
+		Model: "test",
+	}
+	a := NewAgent(cfg)
+	if a == nil {
+		t.Fatal("NewAgent returned nil")
+	}
+	if _, ok := a.Process.(*noopProcess); !ok {
+		t.Errorf("expected noopProcess, got %T", a.Process)
+	}
+}
+
+func TestNewAgentUsesParseModel_ClaudeCLIDefault(t *testing.T) {
+	cfg := AgentConfig{
+		ID:    AgentID{Role: RoleEngineer, TeamNum: 1},
+		Model: "claude-sonnet-4-6",
+	}
+	a := NewAgent(cfg)
+	if a == nil {
+		t.Fatal("NewAgent returned nil")
+	}
+	if _, ok := a.Process.(*ClaudeStreamProcess); !ok {
+		t.Errorf("expected ClaudeStreamProcess, got %T", a.Process)
+	}
+}


### PR DESCRIPTION
Issue: ytnobody-MADFLOW-254

## 変更内容

- `backend.go` を新規追加:
  - `Backend` iota sum type（ClaudeCLI / AnthropicAPI / GeminiAPI / CopilotCLI / Test）
  - `Backend.String()` メソッド
  - `ModelID` 型エイリアス
  - `ParseModel(string) (Backend, ModelID, error)` — モデル文字列を型に変換する唯一の関数
  - `newProcessForBackend` ヘルパー — Backend switch で Process を生成
- `agent.go` の `NewAgent` を簡素化: 散在していた文字列 prefix マッチを `ParseModel` + `newProcessForBackend` の2行に集約

## 完了条件の確認

- [x] `type Backend` sum type が実装されている
- [x] `ParseModel` が一点で文字列をパースしている
- [x] 文字列 prefix マッチによる分岐が解消されている（NewAgent から除去）
- [x] 既存テストが green（全15パッケージ）