### PR TITLE
local-030: orchestratorの重複TEAM_CREATE防止メカニズムの強化

### DIFF
--- a/docs/specs/duplicate-team-create-prevention.md
+++ b/docs/specs/duplicate-team-create-prevention.md
@@ -1,0 +1,134 @@
+# Spec: orchestratorの重複TEAM_CREATE防止メカニズムの強化
+
+## 概要
+
+orchestratorが同一イシューに対して複数回のTEAM_CREATEを実行してしまう問題を防ぐため、
+TEAM_CREATEの前に実施するチェックを強化する。
+
+## 背景・問題
+
+以下のような状況でTEAM_CREATEが重複して実行されていた：
+
+- PR提出済みにも関わらず再度TEAM_CREATE
+- PR OPEN中にも関わらず再度TEAM_CREATE
+- イシューがin_progressでチームが解散済みのときに再度TEAM_CREATE
+
+### 既存チェックの限界
+
+既存の `DecideTeamAssignment` 関数は以下をチェックしていた：
+
+1. ターミナル状態（resolved/closed）→ Reject
+2. AssignedTeam > 0（チームが割り当て済み）→ Reject
+3. hasActiveTeam（アクティブなチームが存在する）→ Reject
+
+しかし、以下のケースが抜け落ちていた：
+
+**ケース：in_progress + AssignedTeam=0 + アクティブチームなし**
+
+発生経路：
+1. エンジニアがPRを作成（status: in_progress, AssignedTeam=5）
+2. RC-1修正により、チームが manager に存在しない場合は AssignedTeam をリセット
+3. チームが解散している → hasActiveTeam=false
+4. AssignedTeam が 0 にリセットされた → AssignedTeam > 0 チェックをパス
+5. DecideTeamAssignment が Create を返してしまう → 重複チーム作成！
+
+## 変更仕様
+
+### 1. in_progress イシューの TEAM_CREATE 拒否（`decision.go`）
+
+`DecideTeamAssignment` 関数に、`StatusInProgress` の場合に拒否するチェックを追加する。
+
+**変更前の優先順位：**
+1. Terminal status → Reject
+2. AssignedTeam > 0 → Reject
+3. hasActiveTeam → Reject
+4. hasIdleTeam → ReuseIdle
+5. atCapacity → Defer
+6. Otherwise → Create
+
+**変更後の優先順位：**
+1. Terminal status (resolved/closed) → Reject
+2. **in_progress status → Reject** ← 新規追加
+3. AssignedTeam > 0 → Reject
+4. hasActiveTeam → Reject
+5. hasIdleTeam → ReuseIdle
+6. atCapacity → Defer
+7. Otherwise → Create
+
+**拒否メッセージ：**
+
+```
+TEAM_CREATE {issueID} は拒否されました: イシューのステータスが in_progress です。
+再アサインする場合はイシューのstatusをopenに変更してください
+```
+
+**再アサイン手順（通知に含める）：**
+- `status = "in_progress"` → `status = "open"` に変更してから再度 TEAM_CREATE
+
+### 2. 既存フィーチャーブランチ/ワークツリーの有無チェック（`orchestrator.go`）
+
+`handleTeamCreate` 関数に、フィーチャーブランチの存在確認チェックを追加する。
+
+`DecideTeamAssignment` を呼び出す前に、設定された全リポジトリに対して：
+
+- ローカルブランチ `{featurePrefix}{issueID}` の存在確認（`BranchExists`）
+- リモートトラッキングブランチ `origin/{featurePrefix}{issueID}` の存在確認
+
+いずれかが存在する場合は TEAM_CREATE を拒否し、superintendentに通知する。
+
+**拒否メッセージ：**
+```
+TEAM_CREATE {issueID} は拒否されました: フィーチャーブランチ {branchName} が
+リポジトリ {repoName} に既に存在します
+```
+
+また、設定された各リポジトリのワークツリーディレクトリ
+`.worktrees/{ghLogin}/issue-{issueID}` が存在する場合も拒否する。
+
+**拒否メッセージ：**
+```
+TEAM_CREATE {issueID} は拒否されました: ワークツリー {path} が既に存在します
+```
+
+## テスト仕様
+
+### decision_test.go の変更
+
+既存のテストケースを変更：
+- `"in_progress issue with idle team reuses idle"` → 期待値を `AssignDecisionReject` に変更
+- `"in_progress issue with no assignment creates new team"` → 期待値を `AssignDecisionReject` に変更
+
+新規テストケース追加：
+- `"in_progress issue is rejected regardless of active team"` - アクティブチームの有無に関わらず in_progress は拒否
+
+### orchestrator_test.go の追加テスト
+
+1. `TestHandleTeamCreateRejectsInProgressNoTeam`
+   - in_progress かつ AssignedTeam=0 かつアクティブチームなしのイシューへの TEAM_CREATE を拒否
+   - chatlog に拒否メッセージが記録される
+   - チーム数が変化しない
+
+2. `TestHandleTeamCreateRejectsExistingBranch`
+   - open のイシューだが、フィーチャーブランチが git リポジトリに既存
+   - chatlog に拒否メッセージが記録される
+   - チーム数が変化しない
+
+3. `TestHandleTeamCreateRejectsExistingWorktree`
+   - open のイシューだが、ワークツリーディレクトリが存在する
+   - chatlog に拒否メッセージが記録される
+   - チーム数が変化しない
+
+## 影響範囲
+
+- `internal/orchestrator/decision.go`：`DecideTeamAssignment` 関数
+- `internal/orchestrator/orchestrator.go`：`handleTeamCreate` 関数
+- `internal/orchestrator/decision_test.go`：既存テスト更新・新規テスト追加
+- `internal/orchestrator/orchestrator_test.go`：新規テスト追加
+
+## 注意事項
+
+- `startAllTeams` は `handleTeamCreate` を経由しないため、この変更の影響を受けない
+  - 起動時に in_progress イシューを正しくピックアップする動作は維持される
+- ブランチチェックは IO 操作であるため、純粋関数 `DecideTeamAssignment` では行わず
+  `handleTeamCreate` 内で実行する
+- ブランチチェックは `DecideTeamAssignment` 呼び出し前に実行し、早期リターンする

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -251,6 +251,18 @@ func (r *Repo) RemoveNamespacedWorktree(login, subDir string) error {
 	return nil
 }
 
+// WorktreeExistsForIssue checks if a namespaced engineer worktree for the given
+// issue exists under .worktrees/{ghLogin}/issue-{issueID}.
+// Returns false when ghLogin is empty or the directory does not exist.
+func (r *Repo) WorktreeExistsForIssue(ghLogin, issueID string) bool {
+	if ghLogin == "" {
+		return false
+	}
+	wtPath := filepath.Join(r.path, ".worktrees", ghLogin, "issue-"+issueID)
+	_, err := os.Stat(wtPath)
+	return err == nil
+}
+
 // ValidateSafeName validates that name is safe to use as a branch name component
 // or issue ID in file path operations. It rejects empty strings, strings
 // containing ".." (path traversal), path separators ("/" or "\"), and null bytes.

--- a/internal/orchestrator/decision.go
+++ b/internal/orchestrator/decision.go
@@ -56,16 +56,27 @@ type TeamAssignResult struct {
 //
 // Decision priority (highest to lowest):
 //  1. Terminal status or already-assigned → Reject
-//  2. Active/pending team exists → Reject
-//  3. Idle team available → ReuseIdle
-//  4. At capacity → Defer
-//  5. Otherwise → Create
+//  2. in_progress status → Reject
+//  3. Active/pending team exists → Reject
+//  4. Idle team available → ReuseIdle
+//  5. At capacity → Defer
+//  6. Otherwise → Create
 func DecideTeamAssignment(iss issue.Issue, hasActiveTeam bool, hasIdleTeam bool, atCapacity bool) TeamAssignResult {
 	// Reject terminal issues.
 	if iss.Status.IsTerminal() {
 		return TeamAssignResult{
 			Decision: AssignDecisionReject,
 			Reason:   fmt.Sprintf("issue status is %s", iss.Status),
+		}
+	}
+
+	// Reject in_progress issues to prevent duplicate team creation.
+	// in_progress means someone is already working on it. To re-assign,
+	// the status must first be reset to "open".
+	if iss.Status == issue.StatusInProgress {
+		return TeamAssignResult{
+			Decision: AssignDecisionReject,
+			Reason:   "イシューのステータスが in_progress です。再アサインする場合はステータスを open に変更してください",
 		}
 	}
 

--- a/internal/orchestrator/decision_test.go
+++ b/internal/orchestrator/decision_test.go
@@ -75,7 +75,7 @@ func TestDecideTeamAssignment(t *testing.T) {
 			name:         "in_progress issue with idle team reuses idle",
 			iss:          inProgressIssue,
 			hasIdleTeam:  true,
-			wantDecision: AssignDecisionReuseIdle,
+			wantDecision: AssignDecisionReject,
 		},
 		{
 			name:         "open issue at capacity is deferred",
@@ -91,7 +91,7 @@ func TestDecideTeamAssignment(t *testing.T) {
 		{
 			name:         "in_progress issue with no assignment creates new team",
 			iss:          inProgressIssue,
-			wantDecision: AssignDecisionCreate,
+			wantDecision: AssignDecisionReject,
 		},
 		{
 			name:          "active team check takes priority over idle team",
@@ -106,6 +106,13 @@ func TestDecideTeamAssignment(t *testing.T) {
 			hasIdleTeam:  true,
 			atCapacity:   true,
 			wantDecision: AssignDecisionReuseIdle,
+		},
+		{
+			name:          "in_progress issue is rejected regardless of active team",
+			iss:           inProgressIssue,
+			hasActiveTeam: true,
+			hasIdleTeam:   true,
+			wantDecision:  AssignDecisionReject,
 		},
 	}
 

--- a/internal/orchestrator/decision_test.go
+++ b/internal/orchestrator/decision_test.go
@@ -139,6 +139,7 @@ func TestTeamAssignDecisionTypeString(t *testing.T) {
 		{AssignDecisionReuseIdle, "ReuseIdle"},
 		{AssignDecisionCreate, "Create"},
 		{AssignDecisionDefer, "Defer"},
+		{TeamAssignDecisionType(99), "TeamAssignDecisionType(99)"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.want, func(t *testing.T) {
@@ -147,5 +148,21 @@ func TestTeamAssignDecisionTypeString(t *testing.T) {
 				t.Errorf("TeamAssignDecisionType(%d).String() = %q, want %q", tt.d, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestDecideTeamAssignment_OpenWithAssignedTeam(t *testing.T) {
+	// Open issue that still has AssignedTeam > 0 (e.g. stale field that RC-1 did not clear).
+	// This covers the AssignedTeam > 0 reject path that is skipped when the issue
+	// is already in_progress (in_progress check fires first in that case).
+	iss := issue.Issue{
+		ID:           "gh-200",
+		Title:        "open but still assigned",
+		Status:       issue.StatusOpen,
+		AssignedTeam: 7,
+	}
+	result := DecideTeamAssignment(iss, false, false, false)
+	if result.Decision != AssignDecisionReject {
+		t.Errorf("expected Reject for open issue with AssignedTeam > 0, got %s", result.Decision)
 	}
 }

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -658,6 +658,45 @@ func (o *Orchestrator) handleTeamCreate(ctx context.Context, cmd Command) {
 		return
 	}
 
+	// Check if a feature branch already exists for this issue (local or remote).
+	// This prevents duplicate teams when a previous engineer has already created a branch.
+	featurePrefix := o.cfg.Branches.FeaturePrefix
+	if featurePrefix == "" {
+		featurePrefix = "feature/issue-"
+	}
+	branchName := featurePrefix + issueID
+	for repoName, repo := range o.repos {
+		if repo.BranchExists(branchName) {
+			log.Printf("[orchestrator] TEAM_CREATE rejected: branch %s already exists in repo %s", branchName, repoName)
+			o.appendOrLog("superintendent", "orchestrator",
+				fmt.Sprintf("TEAM_CREATE %s は拒否されました: フィーチャーブランチ %s がリポジトリ %s に既に存在します",
+					issueID, branchName, repoName))
+			return
+		}
+		if repo.BranchExists("origin/" + branchName) {
+			log.Printf("[orchestrator] TEAM_CREATE rejected: remote branch origin/%s already exists in repo %s", branchName, repoName)
+			o.appendOrLog("superintendent", "orchestrator",
+				fmt.Sprintf("TEAM_CREATE %s は拒否されました: リモートブランチ origin/%s がリポジトリ %s に既に存在します",
+					issueID, branchName, repoName))
+			return
+		}
+	}
+
+	// Check if a worktree already exists for this issue.
+	ghLogin := o.cfg.GhLogin
+	if ghLogin != "" {
+		for repoName, repo := range o.repos {
+			if repo.WorktreeExistsForIssue(ghLogin, issueID) {
+				wtPath := filepath.Join(repo.Path(), ".worktrees", ghLogin, "issue-"+issueID)
+				log.Printf("[orchestrator] TEAM_CREATE rejected: worktree %s already exists in repo %s", wtPath, repoName)
+				o.appendOrLog("superintendent", "orchestrator",
+					fmt.Sprintf("TEAM_CREATE %s は拒否されました: ワークツリー %s が既に存在します",
+						issueID, wtPath))
+				return
+			}
+		}
+	}
+
 	// RC-1 fix: if the issue carries a stale AssignedTeam value (team no longer
 	// present in the manager — e.g. after a process restart or the previous
 	// engineer became unresponsive), clear it so DecideTeamAssignment does not

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -593,7 +593,9 @@ func TestHandleTeamCreateRejectsActiveTeam(t *testing.T) {
 	// team exists in the manager but the issue hasn't been updated yet.
 	iss.AssignedTeam = 0
 	iss.Status = issue.StatusOpen
-	orc.Store().Update(iss)
+	if err := orc.Store().Update(iss); err != nil {
+		t.Fatalf("Store.Update: %v", err)
+	}
 
 	teamsBefore := orc.Teams().Count()
 	orc.handleTeamCreate(ctx, ParseCommand(fmt.Sprintf("TEAM_CREATE %s", iss.ID)))
@@ -1522,9 +1524,13 @@ func initTestGitRepo(t *testing.T) string {
 func TestHandleTeamCreateRejectsInProgressNoTeam(t *testing.T) {
 	dir := t.TempDir()
 	cfg := testConfig(dir)
-	os.MkdirAll(filepath.Join(dir, "issues"), 0755)
+	if err := os.MkdirAll(filepath.Join(dir, "issues"), 0755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
 	chatlogPath := filepath.Join(dir, "chatlog.txt")
-	os.WriteFile(chatlogPath, nil, 0644)
+	if err := os.WriteFile(chatlogPath, nil, 0644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
 
 	orc := New(cfg, dir, t.TempDir())
 	orc.teams = team.NewManager(newMockTeamFactory(t), 3)
@@ -1533,10 +1539,11 @@ func TestHandleTeamCreateRejectsInProgressNoTeam(t *testing.T) {
 	iss, _ := orc.Store().Create("Orphaned In-Progress Issue", "body")
 	iss.Status = issue.StatusInProgress
 	iss.AssignedTeam = 0
-	orc.Store().Update(iss)
+	if err := orc.Store().Update(iss); err != nil {
+		t.Fatalf("Store.Update: %v", err)
+	}
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	teamsBefore := orc.Teams().Count()
 	orc.handleTeamCreate(ctx, Command{Type: CommandTeamCreate, Args: []string{iss.ID}})
@@ -1582,9 +1589,13 @@ func TestHandleTeamCreateRejectsExistingBranch(t *testing.T) {
 	cfg.Project.Repos = []config.RepoConfig{{Name: "main", Path: repoDir}}
 	cfg.Branches.FeaturePrefix = "feature/issue-"
 
-	os.MkdirAll(filepath.Join(dir, "issues"), 0755)
+	if err := os.MkdirAll(filepath.Join(dir, "issues"), 0755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
 	chatlogPath := filepath.Join(dir, "chatlog.txt")
-	os.WriteFile(chatlogPath, nil, 0644)
+	if err := os.WriteFile(chatlogPath, nil, 0644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
 
 	orc := New(cfg, dir, t.TempDir())
 	orc.teams = team.NewManager(newMockTeamFactory(t), 3)
@@ -1605,8 +1616,7 @@ func TestHandleTeamCreateRejectsExistingBranch(t *testing.T) {
 	}
 	runGitInDir(repoDir, "branch", branchName)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	teamsBefore := orc.Teams().Count()
 	orc.handleTeamCreate(ctx, Command{Type: CommandTeamCreate, Args: []string{iss.ID}})
@@ -1644,9 +1654,13 @@ func TestHandleTeamCreateRejectsExistingWorktree(t *testing.T) {
 	cfg.Branches.FeaturePrefix = "feature/issue-"
 	cfg.GhLogin = "testuser"
 
-	os.MkdirAll(filepath.Join(dir, "issues"), 0755)
+	if err := os.MkdirAll(filepath.Join(dir, "issues"), 0755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
 	chatlogPath := filepath.Join(dir, "chatlog.txt")
-	os.WriteFile(chatlogPath, nil, 0644)
+	if err := os.WriteFile(chatlogPath, nil, 0644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
 
 	orc := New(cfg, dir, t.TempDir())
 	orc.teams = team.NewManager(newMockTeamFactory(t), 3)
@@ -1660,8 +1674,7 @@ func TestHandleTeamCreateRejectsExistingWorktree(t *testing.T) {
 		t.Fatalf("MkdirAll worktree: %v", err)
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	teamsBefore := orc.Teams().Count()
 	orc.handleTeamCreate(ctx, Command{Type: CommandTeamCreate, Args: []string{iss.ID}})

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -504,22 +505,23 @@ func TestHandleTeamCreateRejectsClosedIssue(t *testing.T) {
 // TestHandleTeamCreateResetsStaleAssignment verifies RC-1 fix:
 // when an issue has AssignedTeam > 0 but the team is no longer present in the
 // manager (e.g. after a process restart or an unresponsive engineer), the stale
-// assignment is automatically cleared and a new team is created.
+// assignment is automatically cleared. After clearing, because the issue remains
+// in_progress status with no active team, TEAM_CREATE is rejected — the operator
+// must reset the issue to "open" before reassigning.
 func TestHandleTeamCreateResetsStaleAssignment(t *testing.T) {
 	dir := t.TempDir()
 	cfg := testConfig(dir)
 	if err := os.MkdirAll(filepath.Join(dir, "issues"), 0755); err != nil {
 		t.Fatalf("MkdirAll: %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(dir, "chatlog.txt"), nil, 0644); err != nil {
+	chatlogPath := filepath.Join(dir, "chatlog.txt")
+	if err := os.WriteFile(chatlogPath, nil, 0644); err != nil {
 		t.Fatalf("WriteFile: %v", err)
 	}
 
 	orc := New(cfg, dir, t.TempDir())
 	factory := newMockTeamFactory(t)
 	orc.teams = team.NewManager(factory, 3)
-	// Ensure all goroutines spawned by handleTeamCreate finish before TempDir cleanup.
-	t.Cleanup(orc.Wait)
 
 	// Create an issue with a stale assigned_team value (team not in manager).
 	iss, _ := orc.Store().Create("Stale Assignment Issue", "body")
@@ -532,9 +534,6 @@ func TestHandleTeamCreateResetsStaleAssignment(t *testing.T) {
 
 	orc.handleTeamCreate(ctx, ParseCommand(fmt.Sprintf("TEAM_CREATE %s", iss.ID)))
 
-	// A new team should have been created (async — wait up to 2s).
-	waitForTeamCount(t, orc, 1, 2*time.Second)
-
 	// The stale AssignedTeam should have been reset in the store.
 	updated, err := orc.Store().Get(iss.ID)
 	if err != nil {
@@ -542,6 +541,26 @@ func TestHandleTeamCreateResetsStaleAssignment(t *testing.T) {
 	}
 	if updated.AssignedTeam == 5 {
 		t.Errorf("AssignedTeam should have been reset from stale value 5, but is still 5")
+	}
+
+	// No new team should have been created — TEAM_CREATE is rejected because
+	// the issue is in_progress (operator must reset status to open first).
+	if orc.Teams().Count() != 0 {
+		t.Errorf("expected no team created for in_progress stale-assignment issue, got %d teams", orc.Teams().Count())
+	}
+
+	// Chatlog should contain a rejection message.
+	cl := chatlog.New(chatlogPath)
+	msgs, _ := cl.Poll("superintendent")
+	found := false
+	for _, m := range msgs {
+		if contains(m.Body, "拒否されました") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected rejection message in chatlog for in_progress stale-assignment TEAM_CREATE")
 	}
 }
 
@@ -555,10 +574,11 @@ func TestHandleTeamCreateRejectsActiveTeam(t *testing.T) {
 	orc := New(cfg, dir, t.TempDir())
 	orc.teams = team.NewManager(newMockTeamFactory(t), 3)
 
-	// Create an issue with AssignedTeam=0 but an active team already exists.
+	// Create an open issue. The active-team check must fire before status is changed
+	// to in_progress, so we start with an open issue, create a team for it, then
+	// manually set AssignedTeam=0 to simulate the race window where the team exists
+	// in the manager but the issue's AssignedTeam field hasn't been updated yet.
 	iss, _ := orc.Store().Create("Active Team Issue", "body")
-	iss.Status = issue.StatusInProgress
-	orc.Store().Update(iss)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -568,6 +588,12 @@ func TestHandleTeamCreateRejectsActiveTeam(t *testing.T) {
 	if err != nil {
 		t.Fatalf("create team: %v", err)
 	}
+
+	// Reset AssignedTeam to 0 in the store to simulate the race window where the
+	// team exists in the manager but the issue hasn't been updated yet.
+	iss.AssignedTeam = 0
+	iss.Status = issue.StatusOpen
+	orc.Store().Update(iss)
 
 	teamsBefore := orc.Teams().Count()
 	orc.handleTeamCreate(ctx, ParseCommand(fmt.Sprintf("TEAM_CREATE %s", iss.ID)))
@@ -1462,6 +1488,202 @@ func TestHandleTeamCreateRejectsWhenAtMaxCapacityAllBusy(t *testing.T) {
 	}
 	if !found {
 		t.Error("expected chatlog to contain capacity-limit message for superintendent")
+	}
+}
+
+// initTestGitRepo creates a temporary git repo with an initial commit on branch "main".
+// It configures user.email and user.name so commits work without global git config.
+func initTestGitRepo(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	runGit := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("git %v failed: %v\noutput: %s", args, err, out)
+		}
+	}
+	runGit("init", "-b", "main")
+	runGit("config", "user.email", "test@test.com")
+	runGit("config", "user.name", "Test User")
+	if err := os.WriteFile(filepath.Join(dir, "README.md"), []byte("# test\n"), 0644); err != nil {
+		t.Fatalf("write README: %v", err)
+	}
+	runGit("add", ".")
+	runGit("commit", "-m", "initial commit")
+	return dir
+}
+
+// TestHandleTeamCreateRejectsInProgressNoTeam verifies that a TEAM_CREATE for an
+// in_progress issue with AssignedTeam=0 and no active team is rejected. This covers
+// the scenario where a previous team was disbanded without resetting the issue status.
+func TestHandleTeamCreateRejectsInProgressNoTeam(t *testing.T) {
+	dir := t.TempDir()
+	cfg := testConfig(dir)
+	os.MkdirAll(filepath.Join(dir, "issues"), 0755)
+	chatlogPath := filepath.Join(dir, "chatlog.txt")
+	os.WriteFile(chatlogPath, nil, 0644)
+
+	orc := New(cfg, dir, t.TempDir())
+	orc.teams = team.NewManager(newMockTeamFactory(t), 3)
+
+	// Create an in_progress issue with no team assigned (simulates post-disband state).
+	iss, _ := orc.Store().Create("Orphaned In-Progress Issue", "body")
+	iss.Status = issue.StatusInProgress
+	iss.AssignedTeam = 0
+	orc.Store().Update(iss)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	teamsBefore := orc.Teams().Count()
+	orc.handleTeamCreate(ctx, Command{Type: CommandTeamCreate, Args: []string{iss.ID}})
+
+	// No new team should be created.
+	if orc.Teams().Count() != teamsBefore {
+		t.Errorf("expected no new team for in_progress issue without active team, but team count changed from %d to %d",
+			teamsBefore, orc.Teams().Count())
+	}
+
+	// Issue status must remain in_progress (not been modified).
+	got, err := orc.Store().Get(iss.ID)
+	if err != nil {
+		t.Fatalf("store.Get: %v", err)
+	}
+	if got.Status != issue.StatusInProgress {
+		t.Errorf("expected issue status to remain in_progress, got %s", got.Status)
+	}
+
+	// Chatlog should contain a rejection message.
+	cl := chatlog.New(chatlogPath)
+	msgs, _ := cl.Poll("superintendent")
+	found := false
+	for _, m := range msgs {
+		if contains(m.Body, "拒否されました") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected rejection message in chatlog for in_progress issue TEAM_CREATE")
+	}
+}
+
+// TestHandleTeamCreateRejectsExistingBranch verifies that TEAM_CREATE is rejected
+// when a feature branch for the issue already exists in the git repository.
+func TestHandleTeamCreateRejectsExistingBranch(t *testing.T) {
+	repoDir := initTestGitRepo(t)
+
+	dir := t.TempDir()
+	cfg := testConfig(dir)
+	// Point the orchestrator's repo at our test git repo.
+	cfg.Project.Repos = []config.RepoConfig{{Name: "main", Path: repoDir}}
+	cfg.Branches.FeaturePrefix = "feature/issue-"
+
+	os.MkdirAll(filepath.Join(dir, "issues"), 0755)
+	chatlogPath := filepath.Join(dir, "chatlog.txt")
+	os.WriteFile(chatlogPath, nil, 0644)
+
+	orc := New(cfg, dir, t.TempDir())
+	orc.teams = team.NewManager(newMockTeamFactory(t), 3)
+
+	// Create an open issue.
+	iss, _ := orc.Store().Create("Branch Exists Issue", "body")
+
+	// Create the feature branch in the git repo to simulate a previous engineer's work.
+	branchName := "feature/issue-" + iss.ID
+	runGitInDir := func(dir string, args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("git %v in %s failed: %v\noutput: %s", args, dir, err, out)
+		}
+	}
+	runGitInDir(repoDir, "branch", branchName)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	teamsBefore := orc.Teams().Count()
+	orc.handleTeamCreate(ctx, Command{Type: CommandTeamCreate, Args: []string{iss.ID}})
+
+	// No new team should be created.
+	if orc.Teams().Count() != teamsBefore {
+		t.Errorf("expected no new team when branch exists, but team count changed from %d to %d",
+			teamsBefore, orc.Teams().Count())
+	}
+
+	// Chatlog should contain a rejection message mentioning the branch.
+	cl := chatlog.New(chatlogPath)
+	msgs, _ := cl.Poll("superintendent")
+	found := false
+	for _, m := range msgs {
+		if contains(m.Body, "拒否されました") && contains(m.Body, "フィーチャーブランチ") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected rejection message in chatlog about existing feature branch")
+	}
+}
+
+// TestHandleTeamCreateRejectsExistingWorktree verifies that TEAM_CREATE is rejected
+// when a worktree directory for the issue already exists under .worktrees/{ghLogin}/.
+func TestHandleTeamCreateRejectsExistingWorktree(t *testing.T) {
+	repoDir := initTestGitRepo(t)
+
+	dir := t.TempDir()
+	cfg := testConfig(dir)
+	// Point the orchestrator's repo at our test git repo.
+	cfg.Project.Repos = []config.RepoConfig{{Name: "main", Path: repoDir}}
+	cfg.Branches.FeaturePrefix = "feature/issue-"
+	cfg.GhLogin = "testuser"
+
+	os.MkdirAll(filepath.Join(dir, "issues"), 0755)
+	chatlogPath := filepath.Join(dir, "chatlog.txt")
+	os.WriteFile(chatlogPath, nil, 0644)
+
+	orc := New(cfg, dir, t.TempDir())
+	orc.teams = team.NewManager(newMockTeamFactory(t), 3)
+
+	// Create an open issue.
+	iss, _ := orc.Store().Create("Worktree Exists Issue", "body")
+
+	// Create the worktree directory to simulate a previous engineer's work.
+	wtDir := filepath.Join(repoDir, ".worktrees", "testuser", "issue-"+iss.ID)
+	if err := os.MkdirAll(wtDir, 0755); err != nil {
+		t.Fatalf("MkdirAll worktree: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	teamsBefore := orc.Teams().Count()
+	orc.handleTeamCreate(ctx, Command{Type: CommandTeamCreate, Args: []string{iss.ID}})
+
+	// No new team should be created.
+	if orc.Teams().Count() != teamsBefore {
+		t.Errorf("expected no new team when worktree exists, but team count changed from %d to %d",
+			teamsBefore, orc.Teams().Count())
+	}
+
+	// Chatlog should contain a rejection message mentioning the worktree.
+	cl := chatlog.New(chatlogPath)
+	msgs, _ := cl.Poll("superintendent")
+	found := false
+	for _, m := range msgs {
+		if contains(m.Body, "拒否されました") && contains(m.Body, "ワークツリー") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected rejection message in chatlog about existing worktree")
 	}
 }
 

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -1094,6 +1094,12 @@ func TestWatchCommandsPicksUpEarlyTeamCreate(t *testing.T) {
 
 	cfg := testConfig(dir)
 	orc := New(cfg, dir, t.TempDir())
+	// Use mock factory so no real claude processes write to TempDir.
+	// Without this, executeCreateTeam spawns a real agent that creates
+	// files in WorkDir (the TempDir), causing t.Cleanup RemoveAll to fail.
+	orc.teams = team.NewManager(newMockTeamFactory(t), 3)
+	// Wait for all handleTeamCreate goroutines to finish before TempDir cleanup.
+	t.Cleanup(orc.Wait)
 
 	// Create an open issue that the superintendent would want to assign.
 	store := orc.Store()
@@ -1789,5 +1795,240 @@ feature_prefix = "feature/issue-"
 
 	if orc.teams.Cap() != 5 {
 		t.Errorf("expected Cap()=5 after config hot-reload, got %d", orc.teams.Cap())
+	}
+}
+
+// TestHandleTeamCreateRejectsRemoteOriginBranch verifies that TEAM_CREATE is rejected
+// when a remote-tracking branch (origin/feature/issue-XXX) already exists in the repo.
+func TestHandleTeamCreateRejectsRemoteOriginBranch(t *testing.T) {
+	repoDir := initTestGitRepo(t)
+
+	dir := t.TempDir()
+	cfg := testConfig(dir)
+	cfg.Project.Repos = []config.RepoConfig{{Name: "main", Path: repoDir}}
+	cfg.Branches.FeaturePrefix = "feature/issue-"
+
+	if err := os.MkdirAll(filepath.Join(dir, "issues"), 0755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	chatlogPath := filepath.Join(dir, "chatlog.txt")
+	if err := os.WriteFile(chatlogPath, nil, 0644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	orc := New(cfg, dir, t.TempDir())
+	orc.teams = team.NewManager(newMockTeamFactory(t), 3)
+
+	iss, _ := orc.Store().Create("Remote Branch Exists Issue", "body")
+
+	// Create a remote-tracking ref to simulate a previously pushed branch.
+	remoteRef := "refs/remotes/origin/feature/issue-" + iss.ID
+	runGit := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = repoDir
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("git %v failed: %v\noutput: %s", args, err, out)
+		}
+	}
+	// Get current HEAD sha to point the remote tracking ref at.
+	headCmd := exec.Command("git", "rev-parse", "HEAD")
+	headCmd.Dir = repoDir
+	headOut, err := headCmd.Output()
+	if err != nil {
+		t.Fatalf("git rev-parse HEAD: %v", err)
+	}
+	runGit("update-ref", remoteRef, strings.TrimSpace(string(headOut)))
+
+	ctx := t.Context()
+	teamsBefore := orc.Teams().Count()
+	orc.handleTeamCreate(ctx, Command{Type: CommandTeamCreate, Args: []string{iss.ID}})
+
+	if orc.Teams().Count() != teamsBefore {
+		t.Errorf("expected no new team when remote branch exists, team count changed from %d to %d",
+			teamsBefore, orc.Teams().Count())
+	}
+
+	cl := chatlog.New(chatlogPath)
+	msgs, _ := cl.Poll("superintendent")
+	found := false
+	for _, m := range msgs {
+		if contains(m.Body, "拒否されました") && contains(m.Body, "リモートブランチ") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected rejection message about existing remote branch in chatlog")
+	}
+}
+
+// TestHandleTeamCreateEmptyFeaturePrefix verifies that TEAM_CREATE falls back to
+// "feature/issue-" when cfg.Branches.FeaturePrefix is empty.
+func TestHandleTeamCreateEmptyFeaturePrefix(t *testing.T) {
+	repoDir := initTestGitRepo(t)
+
+	dir := t.TempDir()
+	cfg := testConfig(dir)
+	cfg.Project.Repos = []config.RepoConfig{{Name: "main", Path: repoDir}}
+	cfg.Branches.FeaturePrefix = "" // intentionally empty — should fall back to "feature/issue-"
+
+	if err := os.MkdirAll(filepath.Join(dir, "issues"), 0755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	chatlogPath := filepath.Join(dir, "chatlog.txt")
+	if err := os.WriteFile(chatlogPath, nil, 0644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	orc := New(cfg, dir, t.TempDir())
+	orc.teams = team.NewManager(newMockTeamFactory(t), 3)
+	t.Cleanup(orc.Wait)
+
+	iss, _ := orc.Store().Create("Empty Prefix Issue", "body")
+
+	// Create the default-prefix branch to trigger the rejection path.
+	runGit := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = repoDir
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("git %v failed: %v\noutput: %s", args, err, out)
+		}
+	}
+	runGit("branch", "feature/issue-"+iss.ID)
+
+	ctx := t.Context()
+	teamsBefore := orc.Teams().Count()
+	orc.handleTeamCreate(ctx, Command{Type: CommandTeamCreate, Args: []string{iss.ID}})
+
+	// Should be rejected because the branch exists (validates the fallback prefix is used).
+	if orc.Teams().Count() != teamsBefore {
+		t.Errorf("expected no new team when branch exists with fallback prefix, count changed %d->%d",
+			teamsBefore, orc.Teams().Count())
+	}
+
+	cl := chatlog.New(chatlogPath)
+	msgs, _ := cl.Poll("superintendent")
+	found := false
+	for _, m := range msgs {
+		if contains(m.Body, "拒否されました") && contains(m.Body, "フィーチャーブランチ") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected rejection message about existing feature branch when using fallback prefix")
+	}
+}
+
+// TestHandleWakeGitHubWithDetector verifies that WAKE_GITHUB wakes the idle detector
+// when one is configured.
+func TestHandleWakeGitHubWithDetector(t *testing.T) {
+	dir := t.TempDir()
+	cfg := testConfig(dir)
+	orc := New(cfg, dir, t.TempDir())
+
+	// Verify that handleWakeGitHub with no idleDetector doesn't panic.
+	orc.idleDetector = nil
+	orc.handleWakeGitHub() // should just log and return
+
+	// Now set a real idle detector and verify Wake() is called.
+	orc.idleDetector = githubPkg.NewIdleDetector()
+	orc.handleWakeGitHub() // should call Wake() on the detector without panic
+}
+
+// TestConfig verifies that the Config() getter returns the active configuration.
+func TestConfig(t *testing.T) {
+	dir := t.TempDir()
+	cfg := testConfig(dir)
+	orc := New(cfg, dir, t.TempDir())
+
+	got := orc.Config()
+	if got == nil {
+		t.Fatal("Config() returned nil")
+	}
+	if got.Project.Name != cfg.Project.Name {
+		t.Errorf("Config().Project.Name = %q, want %q", got.Project.Name, cfg.Project.Name)
+	}
+}
+
+// TestHandleCommandWakeGitHub verifies that WAKE_GITHUB dispatched via HandleCommandForTest
+// reaches handleWakeGitHub without error.
+func TestHandleCommandWakeGitHub(t *testing.T) {
+	dir := t.TempDir()
+	cfg := testConfig(dir)
+	orc := New(cfg, dir, t.TempDir())
+	orc.idleDetector = githubPkg.NewIdleDetector()
+
+	ctx := t.Context()
+	msg := chatlog.Message{Sender: "superintendent", Recipient: "orchestrator", Body: "WAKE_GITHUB"}
+	// Should not panic and should call Wake() on the detector.
+	orc.HandleCommandForTest(ctx, msg)
+}
+
+// TestHandleCommandRelease verifies that RELEASE dispatched via HandleCommandForTest
+// reaches handleRelease without panic (even if the underlying git operations fail
+// because the test dir is not a git repo).
+func TestHandleCommandRelease(t *testing.T) {
+	dir := t.TempDir()
+	cfg := testConfig(dir)
+	orc := New(cfg, dir, t.TempDir())
+
+	ctx := t.Context()
+	msg := chatlog.Message{Sender: "superintendent", Recipient: "orchestrator", Body: "RELEASE"}
+	// handleRelease will attempt git operations on a non-git dir, which will fail gracefully.
+	orc.HandleCommandForTest(ctx, msg)
+}
+
+// TestHandleTeamDisbandNoTeam verifies that TEAM_DISBAND for an issue with no
+// active team logs a warning and does not panic.
+func TestHandleTeamDisbandNoTeam(t *testing.T) {
+	dir := t.TempDir()
+	cfg := testConfig(dir)
+	if err := os.MkdirAll(filepath.Join(dir, "issues"), 0755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	orc := New(cfg, dir, t.TempDir())
+	orc.teams = team.NewManager(newMockTeamFactory(t), 3)
+
+	iss, _ := orc.Store().Create("No Team Issue", "body")
+	// Call TEAM_DISBAND for an issue with no active team — should log and not panic.
+	orc.handleTeamDisband(ParseCommand("TEAM_DISBAND " + iss.ID))
+}
+
+// TestHandleTeamDisbandSuccess verifies that TEAM_DISBAND for an issue with an
+// active team disbands the team and cleans up worktrees.
+func TestHandleTeamDisbandSuccess(t *testing.T) {
+	dir := t.TempDir()
+	cfg := testConfig(dir)
+	if err := os.MkdirAll(filepath.Join(dir, "issues"), 0755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "chatlog.txt"), nil, 0644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	orc := New(cfg, dir, t.TempDir())
+	orc.teams = team.NewManager(newMockTeamFactory(t), 3)
+	t.Cleanup(orc.Wait)
+
+	iss, _ := orc.Store().Create("Disband Success Issue", "body")
+
+	// Create a team for the issue so DisbandByIssue can find it.
+	ctx := t.Context()
+	if _, err := orc.Teams().Create(ctx, iss.ID, iss.Title); err != nil {
+		t.Fatalf("Teams().Create: %v", err)
+	}
+
+	if orc.Teams().Count() != 1 {
+		t.Fatalf("expected 1 team before disband, got %d", orc.Teams().Count())
+	}
+
+	orc.handleTeamDisband(ParseCommand("TEAM_DISBAND " + iss.ID))
+
+	if orc.Teams().Count() != 0 {
+		t.Errorf("expected 0 teams after disband, got %d", orc.Teams().Count())
 	}
 }


### PR DESCRIPTION
## Issue
local-030: [改善] orchestratorの重複TEAM_CREATE防止メカニズムの強化

## 変更概要

orchestratorが同一イシューに対して複数回TEAM_CREATEを発行する問題を解消するため、
TEAM_CREATE前のチェックを以下の3点強化した。

### 1. `in_progress` イシューの TEAM_CREATE 拒否

`decision.go` の `DecideTeamAssignment` 関数に `StatusInProgress` チェックを追加。
- `in_progress` のイシューには TEAM_CREATE を拒否し、`open` に戻してから再アサインするよう通知

### 2. 既存フィーチャーブランチの検出

`handleTeamCreate` でローカルブランチ/リモートトラッキングブランチ (`origin/{featurePrefix}{issueID}`) の存在を確認し、
既存ブランチがある場合は TEAM_CREATE を拒否。

### 3. 既存ワークツリーの検出

`.worktrees/{ghLogin}/issue-{issueID}` が存在する場合も TEAM_CREATE を拒否。

## 変更ファイル

- `docs/specs/duplicate-team-create-prevention.md` — 仕様ドキュメント追加
- `internal/orchestrator/decision.go` — `in_progress` 拒否チェック追加
- `internal/orchestrator/decision_test.go` — テスト更新・追加
- `internal/orchestrator/orchestrator.go` — ブランチ/ワークツリーチェック追加
- `internal/orchestrator/orchestrator_test.go` — 新規テスト追加 (3件)
- `internal/git/git.go` — `WorktreeExistsForIssue` メソッド追加

## テスト結果

全テスト合格 (`go test -count=1 ./...`)